### PR TITLE
max_children when workers=thread_pool

### DIFF
--- a/docs/conf_options_reference/searchd_program_configuration_options.rst
+++ b/docs/conf_options_reference/searchd_program_configuration_options.rst
@@ -591,6 +591,12 @@ raise max_children much higher than the amount of CPU cores. Usually
 that will only hurt CPU contention and *decrease* the general
 throughput.
 
+For workers **thread_pool** searchd daemon *always creates* N threads for the thread pool:
+| max_children is defined | max_children is undefined |
+| ------ | ------ |
+| value of max_children  | max ( 3 * sphCpuThreadsCount() / 2, 2 ) |
+High value for max_children and *thread_pool* may lead to N=max_children amount of threads created immediattely on daemon startup.
+
 Example:
 
 

--- a/docs/conf_options_reference/searchd_program_configuration_options.rst
+++ b/docs/conf_options_reference/searchd_program_configuration_options.rst
@@ -595,7 +595,7 @@ For workers **thread_pool** searchd daemon *always creates* N threads for the th
 | max_children is defined | max_children is undefined |
 | ------ | ------ |
 | value of max_children  | max ( 3 * sphCpuThreadsCount() / 2, 2 ) |
-High value for max_children and *thread_pool* may lead to N=max_children amount of threads created immediattely on daemon startup.
+High value for max_children and *thread_pool* may lead to N=max_children amount of threads created immediately on daemon startup.
 
 Example:
 


### PR DESCRIPTION
When migrating from threads to thread_pool its important to reduce max_children as all of the threads got created on startup

Requirements:

* make sure you have read the Contributing guide
* filling the below template is required
* the new code pass all existing tests
* the new code should be  accompanied by new tests


We recommend opening an [issue][issues] to discuss first.

Type of change:

- [ ] Bug fix 
- [ ] New feature
- [x] Documentation update


Description of the change:
Documentation update about max_children

Related PRs:
none

Steps to test or reproduce:
#126 

Possible drawbacks:
Long description for max_children