### PR TITLE
PY3 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,13 @@
 import os
 import sys
-import collections
+
 try:
- if THEME_PATH:
-	sys.path.append(THEME_PATH)
+    if THEME_PATH:
+        sys.path.append(THEME_PATH)
 except NameError:
-	pass
+    pass
 import sphinx_rtd_theme
+
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.append(os.path.dirname(__file__))
 sys.path.append(os.path.abspath('_ext'))


### PR DESCRIPTION
Removed mixed indentation for PY3 support

Type of change:
- [x] Bug fix 

Description of the change:
Python 2.x support mixed indentation but Python 3.x wont support it. As we know python 2.x is deprecating, We have to give support fpython 3  
Related PRs:



