### PR TITLE
Fix message in init.d script for force-stop action

### DIFF
--- a/dist/deb/manticore.init.in
+++ b/dist/deb/manticore.init.in
@@ -87,7 +87,7 @@ do_force_stop() {
             kill -9 $pid
             [ -n "$DODTIME" ] && sleep "$DODTIME"s
             if running ; then
-                echo "Cannot kill $LABEL (pid=$pid)!"
+                echo "Cannot kill $NAME (pid=$pid)!"
                 exit 1
             fi
         fi


### PR DESCRIPTION
This fixes a very minor bug in system V init.d script on the "force-stop" action.

In case of failure, the current message displays `Cannot kill  (pid=123)` instead of `Cannot kill manticore (pid=123)` (`$LABEL` is not initialized)