### PR TITLE
Update URL for Snowball library (fixes #265)

### DIFF
--- a/cmake/GetStemmer.cmake
+++ b/cmake/GetStemmer.cmake
@@ -13,9 +13,9 @@
 # Then (if it is not found) it try to look into ${LIBS_BUNDLE} for file named 'libstemmer_c.tgz'
 # It is supposed, that file (if any) contains archive from snowball with stemmer's sources.
 # If no file found, it will try to fetch it from
-# http://snowball.tartarus.org/dist/libstemmer_c.tgz
+# https://snowballstem.org/dist/libstemmer_c.tgz
 
-set ( STEMMER_URL "http://snowball.tartarus.org/dist/libstemmer_c.tgz" )
+set ( STEMMER_URL "https://snowballstem.org/dist/libstemmer_c.tgz" )
 mark_as_advanced( STEMMER_URL)
 
 find_package ( stemmer )
@@ -71,7 +71,7 @@ if ( NEED_STEMMER_FROMSOURCES )
 	if ( NOT EXISTS "${STEMMER_BASEDIR}/CMakeLists.txt" )
 		message ( SEND_ERROR "missing libstemmer sources from libstemmer_c.
 Please download the C version of libstemmer library from
-http://snowball.tartarus.org/ and extract its sources over libstemmer_c/
+https://snowballstem.org/ and extract its sources over libstemmer_c/
 subdirectory in order to build Manticore with libstemmer support. Or
 install the package named like 'libstemmer-dev' using your favorite
 package manager." )

--- a/docs/conf_options_reference/index_configuration_options.rst
+++ b/docs/conf_options_reference/index_configuration_options.rst
@@ -2069,8 +2069,8 @@ See also
 :ref:`icu_data_dir`
 
 Additional stemmers provided by
-`Snowball <http://snowball.tartarus.org/>`__ project
-`libstemmer <http://snowball.tartarus.org/dist/libstemmer_c.tgz>`__
+`Snowball <https://snowballstem.org/>`__ project
+`libstemmer <https://snowballstem.org/dist/libstemmer_c.tgz>`__
 library can be enabled at compile time using ``--with-libstemmer``
 ``configure`` option. Built-in English and Russian stemmers should be
 faster than their libstemmer counterparts, but can produce slightly

--- a/libstemmer_c/README
+++ b/libstemmer_c/README
@@ -1,3 +1,3 @@
 Dummy file for automake.
 Should be overwritten after libstemmer_c.tgz is properly extracted.
-The latest should be available at http://snowball.tartarus.org/dist/libstemmer_c.tgz
+The latest should be available at https://snowballstem.org/dist/libstemmer_c.tgz


### PR DESCRIPTION
As announced at http://snowball.tartarus.org/, Snowball is now available
from https://snowballstem.org/. The directory structure is the same and
there don't appear to have been any incompatible changes to the library,
so simply changing the domain is enough. The library compiles and links
fine and all tests still pass.

I didn't change test/bench/sphinx.html although it contains the URL,
since that file appears to be test data.

Type of change:

- [X] Dependency update