### PR TITLE
Slightly incorrect example in using DESCRIBE on percolate

### DIFF
--- a/docs/searching/percolate_query.rst
+++ b/docs/searching/percolate_query.rst
@@ -260,7 +260,7 @@ and repopulating the index with queries back.
 .. code-block:: sql
 
 
-    mysql> DESC pq1;
+    mysql> DESC pq1 TABLE;
     +-------+--------+
     | Field | Type   |
     +-------+--------+
@@ -286,7 +286,7 @@ Add `JSON` attribute to the index config ``rt_attr_json = json_data``, then issu
 
     mysql> ALTER RTINDEX pq1 RECONFIGURE;
 
-    mysql> DESC pq1;
+    mysql> DESC pq1 TABLE;
     +-----------+--------+
     | Field     | Type   |
     +-----------+--------+


### PR DESCRIPTION
**Type of change:**

- Documentation update

**Description of the change:**

A 'DESCRIBE' on a percolate index needs "TABLE" postfix to work correctly to see the defined columns. Without 'TABLE' just get the fixed percolate indexes definition

As defined here: https://manticoresearch.gitlab.io/dev/sphinxql_reference/describe_syntax.html#percolate-index-schemas

**Related PRs:**

Background: https://forum.manticoresearch.com/t/how-should-a-describe-on-a-percolate-index-show/531


