### PR TITLE
Matrix for Template was wrong way round

### DIFF
--- a/manual/Creating_an_index/Local_indexes.md
+++ b/manual/Creating_an_index/Local_indexes.md
@@ -29,4 +29,4 @@ All index types are supported in this mode.
 | Plain       | no       | yes         |
 | Percolate   | yes      | yes         |
 | Distributed | yes      | yes         |
-| Template    | yes      | no          |
+| Template    | no       | yes         |


### PR DESCRIPTION
Template indexes work in plain mode. In fact don't think they make sense in RT mode, as there is no 'inheritance' as such. 

Also plain mode does say: All index types are supported in this mode.

Think it was just a typo