### PR TITLE
use RE2::Options.set_encoding() instead of set_utf8()

### DIFF
--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -21626,7 +21626,7 @@ bool CSphFieldRegExps::AddRegExp ( const char * sRegExp, CSphString & sError )
 	tRegExp.m_sTo.Trim();
 
 	RE2::Options tOptions;
-	tOptions.set_utf8 ( true );
+	tOptions.set_encoding ( RE2::Options::Encoding::EncodingUTF8 );
 	tRegExp.m_pRE2 = new RE2 ( tRegExp.m_sFrom.cstr(), tOptions );
 
 	std::string sRE2Error;

--- a/src/sphinxexpr.cpp
+++ b/src/sphinxexpr.cpp
@@ -8157,7 +8157,7 @@ public:
 #if USE_RE2
 		re2::StringPiece tBuf ( (const char *)sVal, iLen );
 		RE2::Options tOpts;
-		tOpts.set_utf8 ( true );
+		tOpts.set_encoding ( RE2::Options::Encoding::EncodingUTF8 );
 		m_pRE2 = new RE2 ( tBuf, tOpts );
 #endif
 	}


### PR DESCRIPTION
Options::set_utf8() is removed from libre2 since Apr 9, 2020
Use set_encoding(Encoding::EncodingUTF8) instead of it.