### PR TITLE
Fix enabled check

### DIFF
--- a/manual/Starting_the_server/Linux.md
+++ b/manual/Starting_the_server/Linux.md
@@ -26,7 +26,7 @@ sudo systemctl stop manticore
 The Manticore service is set to run at boot. You can check it by running:
 
 ```shell
-sudo systemctl is-active manticore
+sudo systemctl is-enabled manticore
 ```
 
 If you want to disable Manticore starting at boot time run:


### PR DESCRIPTION
<!--
Make sure you have read the Contributing guide (see file CONTRIBUTING.md in the root) before you submit a pull request.
-->

**Type of change:**

- [ ] Bug fix 
- [ ] New feature
- [x] Documentation update


**Description of the change:**

`is-active` will check if the service is currently running, no matter if it's enabled to start on boot or not, s. https://www.freedesktop.org/software/systemd/man/systemctl.html#is-active%20PATTERN%E2%80%A6

To determine if a service will be started on boot, `is-enabled` should be used: https://www.freedesktop.org/software/systemd/man/systemctl.html#is-enabled%20UNIT%E2%80%A6
