### PR TITLE
fix for searchd http content-length header (the space character missed)

### DIFF
--- a/src/searchdhttp.cpp
+++ b/src/searchdhttp.cpp
@@ -35,7 +35,7 @@ static void HttpBuildReply ( CSphVector<BYTE> & dData, ESphHttpStatus eCode, con
 
 	const char * sContent = ( bHtml ? "text/html" : "application/json" );
 	CSphString sHttp;
-	sHttp.SetSprintf ( "HTTP/1.1 %s\r\nServer: %s\r\nContent-Type: %s; charset=UTF-8\r\nContent-Length:%d\r\n\r\n", g_dHttpStatus[eCode], g_sStatusVersion.cstr(), sContent, iBodyLen );
+	sHttp.SetSprintf ( "HTTP/1.1 %s\r\nServer: %s\r\nContent-Type: %s; charset=UTF-8\r\nContent-Length: %d\r\n\r\n", g_dHttpStatus[eCode], g_sStatusVersion.cstr(), sContent, iBodyLen );
 
 	int iHeaderLen = sHttp.Length();
 	dData.Resize ( iHeaderLen + iBodyLen );


### PR DESCRIPTION
<!--
Make sure you have read the Contributing guide (see file CONTRIBUTING.md in the root) before you submit a pull request.
-->

**Type of change:**

- [x] Bug fix 
- [ ] New feature
- [ ] Documentation update


**Description of the change:**
our monitoring tool fails to read response header Content-Length:45, it should be Content-Length: 45

**Related PRs:**
n/a

**Steps to test or reproduce:**
GET -E http://127.0.0.1:9312/sql?query="select count(*) from jobs_dynamic"
and see the answer via "tcpflow -C -i lo port 9312"

**Possible drawbacks:**
Nothing should be
