### PR TITLE
Add support for indexing packaged (by zlib) fields for pgsql source

### DIFF
--- a/src/indexing_sources/source_pgsql.cpp
+++ b/src/indexing_sources/source_pgsql.cpp
@@ -115,8 +115,8 @@ protected:
 	DWORD			SqlColumnLength ( int iIndex ) final;
 	const char *	SqlColumn ( int iIndex ) final;
 	const char *	SqlFieldName ( int iIndex ) final;
-	const char *	SqlColumnStream ( int iIndex, DWORD &iStreamLength ) final;
-	void			SqlColumnFreeStream (char *stream ) final;
+	const char *	SqlColumnStream ( int iIndex, DWORD &uStreamLength ) final;
+	void			SqlColumnReleaseStream (char *szStream ) final;
 };
 
 CSphSourceParams_PgSQL::CSphSourceParams_PgSQL ()
@@ -312,25 +312,25 @@ DWORD CSphSource_PgSQL::SqlColumnLength ( int iIndex )
 }
 
 
-const char * CSphSource_PgSQL::SqlColumnStream( int iIndex, DWORD &iStreamLength )
+const char * CSphSource_PgSQL::SqlColumnStream(int iIndex, DWORD &uStreamLength )
 {
-	const char * value = SqlColumn( iIndex );
+	const char * szValue = SqlColumn( iIndex );
 	size_t iUnpackedLength;
-	iStreamLength = 0;
+	uStreamLength = 0;
 
-	if ( !value )
+	if ( szValue == nullptr )
 		return NULL;
 
-	const char * sStream = (const char *) sph_PQunescapeBytea ( (const unsigned char *) value, &iUnpackedLength);
-	iStreamLength = (DWORD) iUnpackedLength;
-	return sStream;
+	auto szStream = (const char *) sph_PQunescapeBytea ( (const unsigned char *) szValue, &iUnpackedLength);
+	uStreamLength = (DWORD) iUnpackedLength;
+	return szStream;
 }
 
 
-void CSphSource_PgSQL::SqlColumnFreeStream( char *sStream )
+void CSphSource_PgSQL::SqlColumnReleaseStream( char *szStream )
 {
-	if ( sStream )
-		sph_PQfreemem( sStream );
+	if ( szStream )
+		sph_PQfreemem( szStream );
 }
 
 // the fabrics

--- a/src/indexing_sources/source_sql.cpp
+++ b/src/indexing_sources/source_sql.cpp
@@ -1227,13 +1227,15 @@ const char * CSphSource_SQL::SqlUnpackColumn ( int iFieldIndex, DWORD & uUnpacke
 			char * sResult = 0;
 			int iBufferOffset = 0;
 			int iResult;
+			DWORD iStreamLen = iPackedLen;
+			char *sStream = (char *) SqlColumnStream( iIndex, iStreamLen );
 
 			z_stream tStream;
 			tStream.zalloc = Z_NULL;
 			tStream.zfree = Z_NULL;
 			tStream.opaque = Z_NULL;
-			tStream.avail_in = iPackedLen;
-			tStream.next_in = (Bytef *)SqlColumn(iIndex);
+			tStream.avail_in = iStreamLen;
+			tStream.next_in = (Bytef *)sStream;
 
 			iResult = inflateInit ( &tStream );
 			if ( iResult!=Z_OK )
@@ -1264,6 +1266,7 @@ const char * CSphSource_SQL::SqlUnpackColumn ( int iFieldIndex, DWORD & uUnpacke
 				}
 			}
 
+			SqlColumnFreeStream( sStream );
 			inflateEnd ( &tStream );
 			return sResult;
 		}

--- a/src/indexing_sources/source_sql.cpp
+++ b/src/indexing_sources/source_sql.cpp
@@ -1266,7 +1266,7 @@ const char * CSphSource_SQL::SqlUnpackColumn ( int iFieldIndex, DWORD & uUnpacke
 				}
 			}
 
-			SqlColumnFreeStream( sStream );
+			SqlColumnReleaseStream( sStream );
 			inflateEnd ( &tStream );
 			return sResult;
 		}

--- a/src/indexing_sources/source_sql.h
+++ b/src/indexing_sources/source_sql.h
@@ -149,6 +149,8 @@ protected:
 	virtual DWORD			SqlColumnLength ( int iIndex ) = 0;
 	virtual const char *	SqlColumn ( int iIndex ) = 0;
 	virtual const char *	SqlFieldName ( int iIndex ) = 0;
+	virtual const char *	SqlColumnStream ( int iIndex, DWORD &iStreamLength ) { iStreamLength = SqlColumnLength( iIndex ); return SqlColumn( iIndex ); }
+	virtual void			SqlColumnFreeStream ( char */*sStream*/ ) { }
 
 	const char *	SqlUnpackColumn ( int iIndex, DWORD & uUnpackedLen, ESphUnpackFormat eFormat );
 	void			ReportUnpackError ( int iIndex, int iError );

--- a/src/indexing_sources/source_sql.h
+++ b/src/indexing_sources/source_sql.h
@@ -150,7 +150,7 @@ protected:
 	virtual const char *	SqlColumn ( int iIndex ) = 0;
 	virtual const char *	SqlFieldName ( int iIndex ) = 0;
 	virtual const char *	SqlColumnStream ( int iIndex, DWORD &iStreamLength ) { iStreamLength = SqlColumnLength( iIndex ); return SqlColumn( iIndex ); }
-	virtual void			SqlColumnFreeStream ( char */*sStream*/ ) { }
+	virtual void			SqlColumnReleaseStream ( char *szStream ) { }
 
 	const char *	SqlUnpackColumn ( int iIndex, DWORD & uUnpackedLen, ESphUnpackFormat eFormat );
 	void			ReportUnpackError ( int iIndex, int iError );


### PR DESCRIPTION
<!--
Make sure you have read the Contributing guide (see file CONTRIBUTING.md in the root) before you submit a pull request.
-->

**Type of change:**

Those patch adds support for indexing documents from zlib-compressed streams for PostgreSQL source.

**Description of the change:**

See #628 for details. Because zlib streams can be returned from PostgreSQL query only by bytea. The client need unescape those field via `PQunescapeBytea`. After that zlib's stream can be unpacked via zlib's code in Manticore. 

**Related PRs:**

**Steps to test or reproduce:**

**Possible drawbacks:**

