### PR TITLE
Handshake send problem

### DIFF
--- a/src/netreceive_ql.cpp
+++ b/src/netreceive_ql.cpp
@@ -646,6 +646,7 @@ public:
 		}
 		if ( i < AUTH_DATA_LEN )
 			memcpy ( m_sAuthData + i, &uRand, AUTH_DATA_LEN - i );
+		memset ( m_sAuthData + AUTH_DATA_LEN - 1, 0, 1);
 
 		// version string (plus 0-terminator)
 		m_sVersionString = FromStr ( g_sMySQLVersion );


### PR DESCRIPTION
When sending a handshake, m_sAuthData must ends with 0x0, otherwise cant connect to server with "authentication plugin undefined" error.

**Type of change:**

- [x] Bug fix 
- [ ] New feature
- [ ] Documentation update


**Description of the change:**
Fixed HandshakeV10_c constructor

**Related PRs:**

**Steps to test or reproduce:**
Connect to server, get handshake, byte before mysql_native_password must be 0x0. Currently it's random value.

**Possible drawbacks:**

