### PR TITLE
Handshake send problem

### DIFF
--- a/src/netreceive_ql.cpp
+++ b/src/netreceive_ql.cpp
@@ -638,15 +638,15 @@ public:
 
 		// fill scramble auth data (random)
 		int i = 0;
-		DWORD uRand = sphRand();
+		DWORD uRand = sphRand() | 0x01010101;
 		for ( ; i < AUTH_DATA_LEN - sizeof ( DWORD ); i += sizeof ( DWORD ) )
 		{
 			memcpy ( m_sAuthData + i, &uRand, sizeof ( DWORD ) );
-			uRand = sphRand();
+			uRand = sphRand() | 0x01010101;
 		}
 		if ( i < AUTH_DATA_LEN )
 			memcpy ( m_sAuthData + i, &uRand, AUTH_DATA_LEN - i );
-
+		memset ( m_sAuthData + AUTH_DATA_LEN - 1, 0, 1);
 		// version string (plus 0-terminator)
 		m_sVersionString = FromStr ( g_sMySQLVersion );
 		++m_sVersionString.second; // encount also z-terminator


### PR DESCRIPTION
When sending a handshake, m_sAuthData must contains not 0x0 bytes and ends with 0x0, otherwise cant connect to server with authentication plugin undefined error.

**Type of change:**

- [x] Bug fix 
- [ ] New feature
- [ ] Documentation update


**Description of the change:**
Fixed HandshakeV10_c constructor, fixed generation of  m_sAuthData, made it so that the random numbers generated to fill in ms_AuthData did not contain byte 0x0 and ended with 0x0.
**Related PRs:**

**Steps to test or reproduce:**
Connect to host with manticore, look at the end on handshake, 13 bytes before authentication method string "mysql_native_password" must be a 12 bytes non-zero data with zero byte at the end.

I create a simple .net core 7 console application, [download](https://drive.google.com/file/d/1MN2_-YvGDty3WDDFW8VVZyVtPNEihhXZ/view?usp=sharing), there are binaries for windows x86 in the archive 'binary.zip' and source code inside. Application is quite simple, it's only try to connect to server, whose settings set in appsettings.json in section ConnectionStrings:ManticoreConnection.

At the moment, the application is exiting with the error "Authentication method '' not supported by any of the available plugins" after try to connect to manticore 5.0.3 . And it connects to the mariadb server 10.3.16 without problems and at the end writes Successfully Connected to console.

The problem can be observed simply in the telnet connection, before the "mysql_native_password" line in the server prompt when connecting, there must be a 0x0 character. It is not there in manticore 5.0.3.

**Possible drawbacks:**
I'm developing in .net, so the code can be a bit buggy, but I tried to get the idea across.
