### PR TITLE
Fix race condition in tokenizer causing crash on SNIPPETS('','','') call

### DIFF
--- a/src/tokenizer/tokenizer.cpp
+++ b/src/tokenizer/tokenizer.cpp
@@ -100,7 +100,10 @@ CSphLowercaser& ISphTokenizer::StagingLowercaser()
 LowercaserRefcountedConstPtr ISphTokenizer::GetLC() const
 {
 	assert ( m_pLC );
-	m_pStagingLC = nullptr;
+	{
+		ScopedMutex_t _ { m_tStagingLock };
+		m_pStagingLC = nullptr;
+	}
 	return m_pLC;
 }
 

--- a/src/tokenizer/tokenizer.h
+++ b/src/tokenizer/tokenizer.h
@@ -209,6 +209,7 @@ protected:
 private:
 	LowercaserRefcountedConstPtr			m_pLC;						///< my lowercaser
 	mutable LowercaserRefcountedPtr			m_pStagingLC;				///< preparing my lowercaser.
+	mutable CSphMutex				m_tStagingLock;				///< lock to prevent race condition when destructing staging lowercaser
 
 protected:
 	CSphLowercaser &				StagingLowercaser();


### PR DESCRIPTION
Hi!

I've decided to upgrade a legacy installation of Sphinx 2.2.11 to Manticore but run into a problem, any version newer than 3.5 crashed on me after running a few dozens of queries.

I've narrowed the crash down to:
1. Config. As simple as it can be.
`manticore.conf`
```
source testsrc
{
	type = csvpipe
	csvpipe_command = echo "1,The quick brown fox jumps over the lazy dog"
	csvpipe_field = teststring
}

index testidx
{
	source = testsrc
	path = data/testidx
}

searchd
{
	listen = 0.0.0.0:3309:mysql41
}
```
2. Request. Crash only (reliably?) happens when at least three strings are passed to the SNIPPETS().
`test.php`
```
<?php
$c = mysqli_connect('127.0.0.1', '', '', '', 3309);
for ($i = 0; $i < 300; ++$i)
	echo $i.' '.(mysqli_query($c, "CALL SNIPPETS(('test content', 'test content', 'test content', 'test content', 'test content', 'test content', 'test content', 'test content', 'test content', 'test content', 'test content', 'test content'), 'testidx', 'test query', 'retain' AS html_strip_mode, 0 AS limit)") ? "ok\n" : "fail\n");
```

3. Parallel execution. Crash only happens when Manticore can run multiple threads truly simultaneously (box has multiple cores, "threads" option for searchd is not set to 1, searchd not run with valgrind).

The production box has FreeBSD on it so Manticore is built manually but the official Ubuntu build crashes the same, the only difference is the message:
`Ubuntu 22.10`
```
malloc(): unsorted double linked list corrupted
Crash!!! Handling signal 6
```
`FreeBSD 13.1`
```
FATAL: pthread_mutex_destroy() failed Resource temporarily unavailable
Crash!!! Handling signal 11
Segmentation fault (core dumped)
```

Here's the backtrace:
```
(gdb) bt
#0  0x0000000801340a6a in ?? () from /lib/libthr.so.3
#1  0x00000000011079b6 in RwLock_t::ReadLock (this=0x1191710 <(anonymous namespace)::g_dDetachedGuard()::dDetachedGuard>) at /home/manticore6/manticoresearch-6.0.2/src/std/rwlock.cpp:203
#2  0x0000000000de503a in CSphScopedRLock_T<RwLock_t>::CSphScopedRLock_T (tLock=..., this=<optimized out>) at /home/manticore6/manticoresearch-6.0.2/src/std/rwlock_impl.h:30
#3  Iterate(std::__1::function<void (Threads::LowThreadDesc_t*)>&) (fnHandler=...) at /home/manticore6/manticoresearch-6.0.2/src/threads_detached.cpp:36
#4  0x0000000000dbd999 in Threads::details::SchedulerOperation_t::Complete (this=0x801a4e3b0, pOwner=0x7fffdff36ce0) at /home/manticore6/manticoresearch-6.0.2/src/threadutils_impl.h:191
#5  (anonymous namespace)::IteratorsQueue_t::IterateActive(std::__1::function<void (Threads::LowThreadDesc_t*)>) (this=<optimized out>, fnHandler=...)
    at /home/manticore6/manticoresearch-6.0.2/src/threadutils.cpp:1287
#6  Threads::IterateActive(std::__1::function<void (Threads::LowThreadDesc_t*)>) (fnHandler=...) at /home/manticore6/manticoresearch-6.0.2/src/threadutils.cpp:1312
...
(gdb) frame 1
#1  0x00000000011079b6 in RwLock_t::ReadLock (this=0x1191710 <(anonymous namespace)::g_dDetachedGuard()::dDetachedGuard>) at /home/manticore6/manticoresearch-6.0.2/src/std/rwlock.cpp:203
203			return pthread_rwlock_rdlock ( m_pLock ) == 0;
(gdb) print m_pLock
$1 = (pthread_rwlock_t *) 0x0
```

It looks like the pointer is `SafeDelete`d and the lock itself is destructed. I've made Manticore to crash when `RwLock_t::Done` for this particular lock (`g_dDetachedGuard` in `threads_detached.cpp`) is called:
```
(gdb) bt
#0  0x000000080148d33a in thr_kill () from /lib/libc.so.7
#1  0x0000000801405c74 in raise () from /lib/libc.so.7
#2  0x00000008014b7109 in abort () from /lib/libc.so.7
#3  0x0000000001107a5b in RwLock_t::Done (this=0x1191810 <(anonymous namespace)::g_dDetachedGuard()::dDetachedGuard>) at /home/manticore6/manticoresearch-6.0.2/src/std/rwlock.cpp:192
#4  0x000000000086351f in RwLock_t::~RwLock_t (this=0x1191810 <(anonymous namespace)::g_dDetachedGuard()::dDetachedGuard>) at /home/manticore6/manticoresearch-6.0.2/src/std/rwlock_impl.h:18
#5  0x00000008014b755a in __cxa_finalize () from /lib/libc.so.7
#6  0x00000008014b7ae1 in exit () from /lib/libc.so.7
#7  0x000000000110708c in sphDie (sFmt=<optimized out>) at /home/manticore6/manticoresearch-6.0.2/src/std/fatal.cpp:70
#8  0x000000000110758a in CSphMutex::~CSphMutex (this=<optimized out>) at /home/manticore6/manticoresearch-6.0.2/src/std/mutex.cpp:72
#9  0x000000000110b44c in CSphLowercaser::~CSphLowercaser (this=0x80505fc00) at /home/manticore6/manticoresearch-6.0.2/src/tokenizer/lowercaser.h:51
#10 0x000000000110b47e in CSphLowercaser::~CSphLowercaser (this=0x80505fc00) at /home/manticore6/manticoresearch-6.0.2/src/tokenizer/lowercaser.h:51
#11 0x000000000110f9fe in CSphTokenizer_UTF8<true>::~CSphTokenizer_UTF8 (this=0x80505cc00) at /home/manticore6/manticoresearch-6.0.2/src/tokenizer/tokenizer_utf8.cpp:76
#12 0x00000000009e5052 in ISphRefcountedMT::Release (this=0xc6fad) at /home/manticore6/manticoresearch-6.0.2/src/std/refcounted_mt_impl.h:26
#13 CSphRefcountedPtr<ISphTokenizer>::~CSphRefcountedPtr (this=0x8048044e8) at /home/manticore6/manticoresearch-6.0.2/src/std/refptr.h:87
#14 SnippetBuilder_c::Impl_c::~Impl_c (this=0x8048044e0) at /home/manticore6/manticoresearch-6.0.2/src/sphinxexcerpt.cpp:373
#15 SnippetBuilder_c::~SnippetBuilder_c (this=0x804803840) at /home/manticore6/manticoresearch-6.0.2/src/sphinxexcerpt.cpp:1585
#16 0x000000000081a4a0 in SnippedBuilderCtxClone_t::~SnippedBuilderCtxClone_t (this=0x805093548) at /home/manticore6/manticoresearch-6.0.2/src/searchd.cpp:7945
#17 std::__1::__optional_destruct_base<SnippedBuilderCtxClone_t, false>::~__optional_destruct_base (this=0x805093548) at /usr/include/c++/v1/optional:227
#18 sph::DefaultStorage_T<std::__1::optional<SnippedBuilderCtxClone_t> >::Deallocate (pData=0x805093548) at /home/manticore6/manticoresearch-6.0.2/src/std/storage.h:38
#19 CSphFixedVector<std::__1::optional<SnippedBuilderCtxClone_t>, sph::DefaultCopy_T<std::__1::optional<SnippedBuilderCtxClone_t> >, sph::DefaultStorage_T<std::__1::optional<SnippedBuilderCtxClone_t> > >::~CSphFixedVector (this=0x805e59798) at /home/manticore6/manticoresearch-6.0.2/src/std/fixedvector_impl.h:27
#20 Threads::ClonableCtx_T<SnippedBuilderCtxRef_t, SnippedBuilderCtxClone_t, (Threads::ECONTEXT)0>::~ClonableCtx_T (this=0x805e59790) at /home/manticore6/manticoresearch-6.0.2/src/coroutine.h:150
#21 MakeSnippetsCoro (dTasks=..., dQueries=..., q=..., pBuilder=<optimized out>) at /home/manticore6/manticoresearch-6.0.2/src/searchd.cpp:7997
#22 0x0000000000819b9d in MakeSnippets (sIndex=..., dQueries=..., q=..., sError=...) at /home/manticore6/manticoresearch-6.0.2/src/searchd.cpp:8234
```

So `~CSphMutex()` in frame 8 calls `sphDie()` because of an error returned by `pthread_mutex_destroy()`.
I've added debug prints to `CSphMutex` ctr and dtr to check for a double destruction and indeed:
```
CSphMutex::CSphMutex(): this=0x80404f830, m_tMutex_top64bit=0x802000e88
CSphMutex::~CSphMutex(): this=0x80404f830, m_tMutex_top64bit=0x802000e88
CSphMutex::~CSphMutex(): this=0x80404f830, m_tMutex_top64bit=0x2
FATAL: pthread_mutex_destroy() failed No error: 0
```

It looks like `CSphLowercaser` reference counting is broken and sometimes `AddRef` and subsequent `Release` are called for a destructed object.
I've added debug prints with stacktraces to `ISphRefcountedMT::AddRef()` and `ISphRefcountedMT::Release()` to test this assumption. Log is huge so I'm only pasting one `CSphLowercaser` instance excerpt here:
```
A. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801c15100
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::StagingLowercaser() in /home/manticore6/searchd
 2# ISphTokenizer::AddSpecials(char const*) in /home/manticore6/searchd
 3# SnippetBuilder_c::Impl_c::Setup(CSphIndex const*, SnippetQuerySettings_t const&) in /home/manticore6/searchd
 4# MakeSnippets(CSphString, sph::Vector_T<ExcerptQuery_t, sph::DefaultCopy_T<ExcerptQuery_t>, sph::DefaultRelimit, sph::DefaultStorage_T<ExcerptQuery_t> >&, SnippetQuerySettings_t const&, CSphString&) in /home/manticore6/searchd
 5# HandleMysqlCallSnippets(RowBuffer_i&, SqlStmt_t&) in /home/manticore6/searchd
 6# long complex in /home/manticore6/searchd
 7# short in /home/manticore6/searchd
 8# unsigned __int128 restrict* in /home/manticore6/searchd
 9# SqlServe(std::__1::unique_ptr<AsyncNetBuffer_c, std::__1::default_delete<AsyncNetBuffer_c> >) in /home/manticore6/searchd
10# MultiServe(std::__1::unique_ptr<AsyncNetBuffer_c, std::__1::default_delete<AsyncNetBuffer_c> >, std::__1::pair<int, unsigned char>, Proto_e) in /home/manticore6/searchd
11# NetActionAccept_c::NetLoopDestroying() in /home/manticore6/searchd
12# _ZZN7Threads11CoRoutine_c13CreateContextENSt3__18functionIFvvEEE11VecTraits_TIhEENUlN5boost7context6detail10transfer_tEE_8__invokeESA_ in /home/manticore6/searchd
 
B. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801c17400
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
 2#  complex in /home/manticore6/searchd
 3#  complex in /home/manticore6/searchd
 4# SnippetBuilder_c::Impl_c::Impl_c(SnippetBuilder_c::Impl_c const&) in /home/manticore6/searchd
 5# SnippetBuilder_c::MakeClone() const in /home/manticore6/searchd
 6# unsigned long in /home/manticore6/searchd
 7# PublishSystemInfo(char const*) in /home/manticore6/searchd
 8# _ZZN7Threads11CoRoutine_c13CreateContextENSt3__18functionIFvvEEE11VecTraits_TIhEENUlN5boost7context6detail10transfer_tEE_8__invokeESA_ in /home/manticore6/searchd

C. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801db3e00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

D. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801c14a00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...
 
E. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801db4500
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

F. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

G. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801c15f00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

H. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x804c43700
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

I. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801db3e00
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
 2#  complex in /home/manticore6/searchd
 3#  complex in /home/manticore6/searchd
 4# SnippetBuilder_c::Impl_c::Impl_c(SnippetBuilder_c::Impl_c const&) in /home/manticore6/searchd
 5# SnippetBuilder_c::MakeClone() const in /home/manticore6/searchd
 6# unsigned long in /home/manticore6/searchd
 7# PublishSystemInfo(char const*) in /home/manticore6/searchd
 8# _ZZN7Threads11CoRoutine_c13CreateContextENSt3__18functionIFvvEEE11VecTraits_TIhEENUlN5boost7context6detail10transfer_tEE_8__invokeESA_ in /home/manticore6/searchd

J. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801c17400
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...
 
K. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

L. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x804c43700
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

M. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801c15f00
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

N. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801db4500
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

O. ISphRefcountedMT::AddRef() new_refcount=2, this=0x803c58000, thread=0x801c14a00
 0# ISphRefcountedMT::AddRef() const in /home/manticore6/searchd
 1# ISphTokenizer::GetLC() const in /home/manticore6/searchd
...

P. ISphRefcountedMT::Release() new_refcount=1, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 1#  complex in /home/manticore6/searchd
 2# ISphRefcountedMT::Release() const in /home/manticore6/searchd
 3# SnippetBuilder_c::~SnippetBuilder_c() in /home/manticore6/searchd
 4# MakeSnippets(CSphString, sph::Vector_T<ExcerptQuery_t, sph::DefaultCopy_T<ExcerptQuery_t>, sph::DefaultRelimit, sph::DefaultStorage_T<ExcerptQuery_t> >&, SnippetQuerySettings_t const&, CSphString&) in /home/manticore6/searchd
 5# MakeSnippets(CSphString, sph::Vector_T<ExcerptQuery_t, sph::DefaultCopy_T<ExcerptQuery_t>, sph::DefaultRelimit, sph::DefaultStorage_T<ExcerptQuery_t> >&, SnippetQuerySettings_t const&, CSphString&) in /home/manticore6/searchd
 6# HandleMysqlCallSnippets(RowBuffer_i&, SqlStmt_t&) in /home/manticore6/searchd
 7# long complex in /home/manticore6/searchd
 8# short in /home/manticore6/searchd
 9# unsigned __int128 restrict* in /home/manticore6/searchd
10# SqlServe(std::__1::unique_ptr<AsyncNetBuffer_c, std::__1::default_delete<AsyncNetBuffer_c> >) in /home/manticore6/searchd
11# MultiServe(std::__1::unique_ptr<AsyncNetBuffer_c, std::__1::default_delete<AsyncNetBuffer_c> >, std::__1::pair<int, unsigned char>, Proto_e) in /home/manticore6/searchd
12# NetActionAccept_c::NetLoopDestroying() in /home/manticore6/searchd
13# _ZZN7Threads11CoRoutine_c13CreateContextENSt3__18functionIFvvEEE11VecTraits_TIhEENUlN5boost7context6detail10transfer_tEE_8__invokeESA_ in /home/manticore6/searchd

Q. ISphRefcountedMT::Release() new_refcount=0, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...

R. ISphRefcountedMT::Release() new_refcount=-1, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...

S. ISphRefcountedMT::Release() new_refcount=-2, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...

T. ISphRefcountedMT::Release() new_refcount=-3, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...

U. ISphRefcountedMT::Release() new_refcount=-4, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...

V. ISphRefcountedMT::Release() new_refcount=-5, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...

W. ISphRefcountedMT::Release() new_refcount=-6, this=0x803c58000, thread=0x801c16d00
 0# ISphRefcountedMT::Release() const in /home/manticore6/searchd
...
```
Traces B to H and I to O are performed simultaneously on different threads so refcount stays the same, but after that refcount goes to -6 when cloned pointers get actually destructed.
Problem here are traces B to H, they're all generated by the line `m_pStagingLC = nullptr;` in `ISphTokenizer::GetLC()`.
It should only destruct `LowercaserRefcountedPtr m_pStagingLC` once but it does so 7 times instead because of the race condition.

So as a PoC I've serialized this line with a mutex a week ago and have no crashes since then.
Proper fix should maybe do something more elegant/atomic, but I don't think I have enough expertise with the Manticore code, so it's up to you.

Thanks! 
