### PR TITLE
[DOC] Add an indication link to update the Manticore documentation file.

### DIFF
--- a/manual/Connecting_to_the_server.md
+++ b/manual/Connecting_to_the_server.md
@@ -87,4 +87,7 @@ Run Manticore container and use built-in MySQL client to connect to the node.
 docker run -e EXTRA=1 --name manticore -d manticoresearch/manticore && docker exec -it manticore mysql
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Connecting_to_the_server.md)
+
 <!-- proofread -->

--- a/manual/Connecting_to_the_server/HTTP.md
+++ b/manual/Connecting_to_the_server/HTTP.md
@@ -249,4 +249,7 @@ POST /cli -d "select id,1+2 as a, packedfactors() from test where match('tes*') 
 ### Keep-alive
 
 HTTP keep-alive is also supported, which makes working via the HTTP JSON interface stateful as long as the client supports keep-alive too. For example, using the new [/cli](../Connecting_to_the_server/HTTP.md#/cli) endpoint you can call `SHOW META` after `SELECT` and it will work the same way it works via mysql.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Connecting_to_the_server/HTTP.md)
+
 <!-- proofread -->

--- a/manual/Connecting_to_the_server/MySQL_protocol.md
+++ b/manual/Connecting_to_the_server/MySQL_protocol.md
@@ -92,4 +92,7 @@ Manticore SQL over MySQL supports C-style comment syntax. Everything from an ope
 ```sql
 SELECT /*! SQL_CALC_FOUND_ROWS */ col1 FROM table1 WHERE ...
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Connecting_to_the_server/MySQL_protocol.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Adding_a_new_node.md
+++ b/manual/Creating_a_cluster/Adding_a_new_node.md
@@ -2,4 +2,6 @@
 
 To add a new node to a cluster, simply start another instance of Manticore and ensure that it is accessible by the other nodes in the cluster. Connect the new node to the rest of the cluster using a [distributed table](../Creating_a_table/Creating_a_distributed_table/Creating_a_distributed_table.md) and ensure data safety with [replication](../Creating_a_cluster/Setting_up_replication/Setting_up_replication.md).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Adding_a_new_node.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Creating_a_cluster.md
+++ b/manual/Creating_a_cluster/Creating_a_cluster.md
@@ -8,4 +8,6 @@ Manticore Search is a highly distributed system that provides all the necessary 
 
 Manticore Search offers great flexibility in terms of how you set up your cluster. There are no limitations, so it's up to you to design your cluster according to your needs. Simply learn about the tools mentioned above and use them to achieve your desired goal.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Creating_a_cluster.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Remote_nodes.md
+++ b/manual/Creating_a_cluster/Remote_nodes.md
@@ -43,4 +43,6 @@ table mydist {
 ```
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Remote_nodes.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Remote_nodes/Load_balancing.md
+++ b/manual/Creating_a_cluster/Remote_nodes/Load_balancing.md
@@ -118,4 +118,6 @@ For a distributed table with agent mirrors, the server sends all mirrors a ping 
 
 If you want to disable pings, set ha_ping_interval to 0.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Remote_nodes/Load_balancing.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Remote_nodes/Mirroring.md
+++ b/manual/Creating_a_cluster/Remote_nodes/Mirroring.md
@@ -38,4 +38,7 @@ agent = node3:9312|node4:9312:shard2
 # config on node3, node4
 agent = node1:9312|node2:9312:shard1
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Remote_nodes/Mirroring.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Adding_and_removing_a_table_from_a_replication_cluster.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Adding_and_removing_a_table_from_a_replication_cluster.md
@@ -149,4 +149,7 @@ utilsApi.sql("ALTER CLUSTER posts DROP weekly_index");
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Adding_and_removing_a_table_from_a_replication_cluster.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Cluster_recovery.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Cluster_recovery.md
@@ -95,4 +95,7 @@ SET CLUSTER posts GLOBAL 'pc.bootstrap' = 1
 <!-- end -->
 
 However, it's important to note that if the statement is issued at both groups, it will result in the formation of two separate clusters, and the subsequent network recovery will not result in the groups rejoining.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Cluster_recovery.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Creating_a_replication_cluster.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Creating_a_replication_cluster.md
@@ -94,4 +94,6 @@ utilsApi.sql("CREATE CLUSTER click_query '/var/data/click_query/' as path, 'clic
 
 If the [nodes](../../Creating_a_cluster/Setting_up_replication/Setting_up_replication.md#nodes) option is not specified when creating a cluster, the first node that joins the cluster will be saved as the [nodes](../../Creating_a_cluster/Setting_up_replication/Setting_up_replication.md#nodes) option.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Creating_a_replication_cluster.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Deleting_a_replication_cluster.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Deleting_a_replication_cluster.md
@@ -65,4 +65,7 @@ res = await utilsApi.sql('DELETE CLUSTER click_query');
 utilsApi.sql("DELETE CLUSTER click_query");
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Deleting_a_replication_cluster.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Joining_a_replication_cluster.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Joining_a_replication_cluster.md
@@ -157,4 +157,7 @@ utilsApi.sql("JOIN CLUSTER click_query 'clicks_mirror1:9312;clicks_mirror2:9312;
 <!-- end -->
 
 The `JOIN CLUSTER` command works synchronously and completes as soon as the node receives all data from the other nodes in the cluster and is in sync with them.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Joining_a_replication_cluster.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Managing_replication_nodes.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Managing_replication_nodes.md
@@ -85,4 +85,7 @@ To remove a node from the replication cluster, follow these steps:
 3. Run `ALTER CLUSTER cluster_name UPDATE nodes` on any other node.
 
 After these steps, the other nodes will forget about the detached node and the detached node will forget about the cluster. This action will not impact the tables in the cluster or on the detached node.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Managing_replication_nodes.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Replication_cluster_status.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Replication_cluster_status.md
@@ -190,4 +190,7 @@ utilsApi.sql("SHOW STATUS");
   warning= }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Replication_cluster_status.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Restarting_a_cluster.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Restarting_a_cluster.md
@@ -6,4 +6,6 @@ In case of a full cluster shutdown, the server that was stopped last should be s
 
 In the event of a hard crash or an unclean shutdown of all servers in the cluster, the most advanced node with the largest `seqno` in the `grastate.dat` file located at the cluster [path](../../Creating_a_cluster/Setting_up_replication/Setting_up_replication.md#Replication-cluster) must be identified and started with the `--new-cluster-force` command line key.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Restarting_a_cluster.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_cluster/Setting_up_replication/Setting_up_replication.md
+++ b/manual/Creating_a_cluster/Setting_up_replication/Setting_up_replication.md
@@ -509,4 +509,7 @@ sqlresult = indexApi.insert(newdoc);
 <!-- end -->
 
 All queries that modify tables in the cluster are now replicated to all nodes in the cluster.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_cluster/Setting_up_replication/Setting_up_replication.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Creating_a_distributed_table/Creating_a_distributed_table.md
+++ b/manual/Creating_a_table/Creating_a_distributed_table/Creating_a_distributed_table.md
@@ -48,4 +48,6 @@ Each agent can have multiple external locations and options for how it should wo
 
 It is important to note that the server does not have any information about the type of table it is working with. This may lead to errors if, for example, you issue a `CALL PQ` to a remote table 'foo' that is not a percolate table.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Creating_a_distributed_table/Creating_a_distributed_table.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Creating_a_distributed_table/Creating_a_local_distributed_table.md
+++ b/manual/Creating_a_table/Creating_a_distributed_table/Creating_a_local_distributed_table.md
@@ -66,4 +66,7 @@ utilsApi.sql("CREATE TABLE local_dist type='distributed' local='index1' local='i
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Creating_a_distributed_table/Creating_a_local_distributed_table.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Creating_a_distributed_table/Remote_tables.md
+++ b/manual/Creating_a_table/Creating_a_distributed_table/Remote_tables.md
@@ -210,4 +210,7 @@ For DPQ, the operations of listing stored queries and searching through them (us
 If you include a non-percolate table in the list of agents, the behavior will be undefined. If the incorrect agent has the same schema as the outer schema of the PQ table (id, query, tags, filters), it will not trigger an error when listing stored PQ rules, and may pollute the list of actual PQ rules stored in PQ tables with its own non-PQ strings. As a result, be cautious and aware of the confusion that this may cause. A`CALL PQ` to such an incorrect agent will trigger an error.
 
 For more information on making queries to a distributed percolate table, see [making queries to a distribute percolate table](../../Searching/Percolate_query.md#Performing-a-percolate-query-with-CALL-PQ).
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Creating_a_distributed_table/Remote_tables.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Data_types.md
+++ b/manual/Creating_a_table/Data_types.md
@@ -2260,4 +2260,7 @@ table tbl {
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Data_types.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Local_tables.md
+++ b/manual/Creating_a_table/Local_tables.md
@@ -31,4 +31,6 @@ All table types are supported in this mode.
 | Distributed | supported      | supported   |
 | Template    | not supported  | supported   |
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Local_tables.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Local_tables/Percolate_table.md
+++ b/manual/Creating_a_table/Local_tables/Percolate_table.md
@@ -115,4 +115,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Local_tables/Percolate_table.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md
+++ b/manual/Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md
@@ -743,4 +743,7 @@ The following settings are supported. They are all described in section [NLP and
 * [stored_fields](../../Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md#stored_fields)
 * [stored_only_fields](../../Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md)
 * [wordforms](../../Creating_a_table/NLP_and_tokenization/Wordforms.md#wordforms)
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Local_tables/Plain_table.md
+++ b/manual/Creating_a_table/Local_tables/Plain_table.md
@@ -95,4 +95,6 @@ The following table outlines the various file extensions used in a plain table a
 |`.new.sp*` | new version of a plain table before rotation |
 |`.old.sp*` | old version of a plain table after rotation |
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Local_tables/Plain_table.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Local_tables/Real-time_table.md
+++ b/manual/Creating_a_table/Local_tables/Real-time_table.md
@@ -117,4 +117,7 @@ The following table outlines the different file extensions and their respective 
 | `.*.sp*` | Disk chunks that are stored on disk with the same format as plain tables. They are created when the RAM chunk size exceeds the  rt_mem_limit.|
 
  For more information on the structure of disk chunks, refer to the [plain table format](../../Creating_a_table/Local_tables/Plain_table.md#Plain-table-files-structure))
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Creating_a_table/Local_tables/Real-time_table.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/Local_tables/Template_table.md
+++ b/manual/Creating_a_table/Local_tables/Template_table.md
@@ -24,4 +24,7 @@ table template {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/Local_tables/Template_table.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Advanced_HTML_tokenization.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Advanced_HTML_tokenization.md
@@ -428,4 +428,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/Advanced_HTML_tokenization.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/CJK.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/CJK.md
@@ -230,4 +230,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/CJK.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Data_tokenization.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Data_tokenization.md
@@ -15,4 +15,7 @@ Very common words can have some unwanted effects on searching, mostly because of
 A more advanced blacklisting is [bigrams](../../Creating_a_table/NLP_and_tokenization/Low-level_tokenization.md#bigram_index), which allows creating a special token between a "bigram" (common) word and an uncommon word. This can speed up several times when common words are used in phrase searches.
 
 In case of indexing HTML content, it's important not to index the HTML tags, as they can introduce a lot of "noise" in the index. [HTML stripping](../../Creating_a_table/NLP_and_tokenization/Advanced_HTML_tokenization.md#Stripping-HTML-tags) can be used and can be configured to strip, but index certain tag attributes or completely ignore the content of certain HTML elements.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/Data_tokenization.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Exceptions.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Exceptions.md
@@ -127,4 +127,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/Exceptions.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Ignoring_stop-words.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Ignoring_stop-words.md
@@ -435,4 +435,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Creating_a_table/NLP_and_tokenization/Ignoring_stop-words.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Low-level_tokenization.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Low-level_tokenization.md
@@ -1816,4 +1816,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Creating_a_table/NLP_and_tokenization/Low-level_tokenization.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Morphology.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Morphology.md
@@ -345,4 +345,7 @@ table products {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/Morphology.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Supported_languages.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Supported_languages.md
@@ -85,4 +85,7 @@ The table below lists all supported languages and indicates how to enable:
 | Ukrainian | charset_table=non_cjk,U+0406->U+0456,U+0456,U+0407->U+0457,U+0457,U+0490->U+0491,U+0491   | - | morphology=lemmatize_uk_all | Requires [installation](../../../Installation/Debian_and_Ubuntu.md#Ukrainian-lemmatizer) of UK lemmatizer |
 | Yoruba | charset_table=non_cjk | yo | - | |
 | Zulu | charset_table=non_cjk | zu | - |  |
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/Supported_languages.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Wildcard_searching_settings.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Wildcard_searching_settings.md
@@ -455,4 +455,6 @@ expansion_limit = number
 
 Maximum number of expanded keywords for a single wildcard. Details are [here](../../Server_settings/Searchd.md#expansion_limit).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Creating_a_table/NLP_and_tokenization/Wildcard_searching_settings.md)
+
 <!-- proofread -->

--- a/manual/Creating_a_table/NLP_and_tokenization/Wordforms.md
+++ b/manual/Creating_a_table/NLP_and_tokenization/Wordforms.md
@@ -122,4 +122,6 @@ table products {
 ```
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Creating_a_table/NLP_and_tokenization/Wordforms.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Attaching_a_plain_table_to_RT_table.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Attaching_a_plain_table_to_RT_table.md
@@ -108,4 +108,7 @@ mysql> SELECT * FROM plain WHERE MATCH('test');
 ERROR 1064 (42000): no enabled local indexes to search
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Attaching_a_plain_table_to_RT_table.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Importing_table.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Importing_table.md
@@ -52,4 +52,7 @@ mysql -P 9306 -h0 < /tmp/dump_regular.sql
 rm /tmp/dump_regular.sql
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Importing_table.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Killlist_in_plain_tables.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Killlist_in_plain_tables.md
@@ -84,4 +84,7 @@ POST /cli -d "
 ALTER TABLE delta KILLLIST_TARGET='new_main_table:kl'"
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Killlist_in_plain_tables.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Merging_tables.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Merging_tables.md
@@ -21,4 +21,7 @@ sudo -u manticore indexer --merge main delta --merge-dst-range deleted 0 0
 This switch allows you to apply filters to the destination table along with merging. There can be several filters; all of their conditions must be met in order to include the document in the resulting merged table. In the example above, the filter passes only those records where 'deleted' is 0, eliminating all records that were flagged as deleted.
 
 `--drop-src` enables dropping SRCINDEX after the merge and before rotating the tables, which is important if you specify DSTINDEX in `killlist_target` of DSTINDEX. Otherwise, when rotating the tables, the documents that have been merged into DSTINDEX may be suppressed by SRCINDEX.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Merging_tables.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_CSV,TSV.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_CSV,TSV.md
@@ -85,4 +85,7 @@ source csv_test
 2,"Deep Purple","35,92"
 3,"Frank Zappa","35,23,16,92,33,24"
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_CSV,TSV.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_XML_streams.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_XML_streams.md
@@ -120,4 +120,7 @@ source xml_test_2
     xmlpipe_attr_uint = author_id:16
 }
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_XML_streams.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Database_connection.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Database_connection.md
@@ -104,4 +104,7 @@ odbc_dsn = Driver={Oracle ODBC Driver};Dbq=myDBName;Uid=myUsername;Pwd=myPasswor
 ```
 
 Please note that the format depends on the specific ODBC driver used.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Database_connection.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Execution_of_fetch_queries.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Execution_of_fetch_queries.md
@@ -84,4 +84,6 @@ sql_query_post_index = REPLACE INTO counters ( id, val ) \
 
 The difference between `sql_query_post` and `sql_query_post_index` is that `sql_query_post` is run immediately when Manticore receives all the documents, but further indexing may still fail for some other reason. On the contrary, by the time the `sql_query_post_index` query gets executed, it is guaranteed that the table was created successfully. Database connection is dropped and re-established because sorting phase can be very lengthy and would just time out otherwise.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Execution_of_fetch_queries.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Introduction.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Introduction.md
@@ -8,4 +8,7 @@ Manticore Search allows fetching data from databases using specialized drivers o
 * `odbc` - for any database that accepts connections using ODBC
 
 To fetch data from the database, a source must be configured with type as one of the above. The source requires information about how to connect to the database and the query that will be used to fetch the data. Additional pre- and post-queries can also be set - either to configure session settings or to perform pre/post fetch tasks. The source also must contain definitions of data types for the columns that are fetched.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Introduction.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Processing_fetched_data.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Processing_fetched_data.md
@@ -248,4 +248,6 @@ Example:
 sql_query = SELECT id, mytitle, mycontent FROM documents
 sql_column_buffers = mytitle=64K, mycontent=10M
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Processing_fetched_data.md)
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Ranged_queries.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Ranged_queries.md
@@ -36,4 +36,7 @@ Throttling can be useful when the indexer imposes too much load on the database 
 ```ini
 sql_ranged_throttle = 1000 # sleep for 1 sec before each query step
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Fetching_from_databases/Ranged_queries.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Main_delta.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Main_delta.md
@@ -53,5 +53,6 @@ table delta {
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Main_delta.md)
 
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Plain_tables_creation.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Plain_tables_creation.md
@@ -240,4 +240,7 @@ ignore_non_plain = 1
 ```
 
 `ignore_non_plain` allows you to completely ignore warnings about skipping non-plain tables. The default is 0 (not ignoring).
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Plain_tables_creation.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_data_from_external_storages/Rotating_a_table.md
+++ b/manual/Data_creation_and_modification/Adding_data_from_external_storages/Rotating_a_table.md
@@ -75,4 +75,7 @@ Example:
 ```ini
 seamless_rotate = 1
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_data_from_external_storages/Rotating_a_table.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md
+++ b/manual/Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md
@@ -865,4 +865,6 @@ sqlresult = indexApi.insert(newdoc);
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Adding_documents_to_a_table/Adding_rules_to_a_percolate_table.md
+++ b/manual/Data_creation_and_modification/Adding_documents_to_a_table/Adding_rules_to_a_percolate_table.md
@@ -386,4 +386,7 @@ GET /pq/pq/doc/2810823411335430149
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Adding_documents_to_a_table/Adding_rules_to_a_percolate_table.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Data_creation_and_modification.md
+++ b/manual/Data_creation_and_modification/Data_creation_and_modification.md
@@ -3,4 +3,7 @@
 You can add, update, replace, and delete your indexed data using different ways provided by Manticore. Manticore supports working with external storages such as databases, XML, CSV, and TSV documents. For insert and delete operations, a [transaction mechanism](../Data_creation_and_modification/Transactions.md) is supported.
  
 Also, for insert and replace queries, Manticore supports Elasticsearch-like query format along with its own format. For details, see the corresponding examples in the [Adding documents to a real-time table](../Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md) and [REPLACE](../Data_creation_and_modification/Updating_documents/REPLACE.md) sections.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Data_creation_and_modification.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Deleting_documents.md
+++ b/manual/Data_creation_and_modification/Deleting_documents.md
@@ -436,4 +436,8 @@ class DeleteResponse {
 }
 ```
 <!-- end -->
+
+
+[deleting_documents](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Deleting_documents.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Transactions.md
+++ b/manual/Data_creation_and_modification/Transactions.md
@@ -136,5 +136,6 @@ select * from indexrt where id=2;
 1 row in set (0.01 sec)
 ```
 
+[transactions](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Transactions.md)
 
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Updating_documents/REPLACE.md
+++ b/manual/Data_creation_and_modification/Updating_documents/REPLACE.md
@@ -360,4 +360,6 @@ class BulkResponse {
 ```
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Updating_documents/REPLACE.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Updating_documents/REPLACE_vs_UPDATE.md
+++ b/manual/Data_creation_and_modification/Updating_documents/REPLACE_vs_UPDATE.md
@@ -6,4 +6,6 @@ You can modify existing data in an RT or PQ table by either updating or replacin
 
 [REPLACE](../../Data_creation_and_modification/Updating_documents/REPLACE.md) works similarly to [INSERT](../../Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md) except that if an old document has the same ID as the new document, the old document is marked as deleted before the new document is inserted. Note that the old document does not get physically deleted from the table. The deletion can only happen when chunks are merged in a table, e.g., as a result of an [OPTIMIZE](../../Securing_and_compacting_a_table/Compacting_a_table.md).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Updating_documents/REPLACE_vs_UPDATE.md)
+
 <!-- proofread -->

--- a/manual/Data_creation_and_modification/Updating_documents/UPDATE.md
+++ b/manual/Data_creation_and_modification/Updating_documents/UPDATE.md
@@ -1238,4 +1238,6 @@ attr_flush_period = 900 # persist updates to disk every 15 minutes
 
 When updating attributes the changes are first written to in-memory copy of attributes. This setting allows to set the interval between flushing the updates to disk. It defaults to 0, which disables the periodic flushing, but flushing will still occur at normal shut-down.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Data_creation_and_modification/Updating_documents/UPDATE.md)
+
 <!-- proofread -->

--- a/manual/Deleting_a_table.md
+++ b/manual/Deleting_a_table.md
@@ -185,4 +185,7 @@ sqlresult = utilsApi.sql("DROP TABLE IF EXISTS products");
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Deleting_a_table.md)
+
 <!-- proofread -->

--- a/manual/Emptying_a_table.md
+++ b/manual/Emptying_a_table.md
@@ -204,4 +204,7 @@ utilsApi.sql("TRUNCATE TABLE products WITH RECONFIGURE");
 {total=0, error=, warning=}
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Emptying_a_table.md)
+
 <!-- proofread -->

--- a/manual/Extensions/FEDERATED.md
+++ b/manual/Extensions/FEDERATED.md
@@ -107,4 +107,7 @@ SELECT t1.id, t1.year, comments.comment FROM t1 JOIN comments ON t1.id=comments.
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/FEDERATED.md)
+
 <!-- proofread -->

--- a/manual/Extensions/SphinxSE.md
+++ b/manual/Extensions/SphinxSE.md
@@ -388,4 +388,7 @@ SELECT title, sphinx_snippets(text, 'index', 'mysql php') AS text
     FROM sphinx, documents
     WHERE query='mysql php' AND sphinx.id=documents.id;
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/SphinxSE.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/Listing_plugins.md
+++ b/manual/Extensions/UDFs_and_Plugins/Listing_plugins.md
@@ -74,4 +74,7 @@ SHOW BUDDY PLUGINS;
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/Listing_plugins.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/Plugins/Creating_a_plugin.md
+++ b/manual/Extensions/UDFs_and_Plugins/Plugins/Creating_a_plugin.md
@@ -49,4 +49,7 @@ CREATE BUDDY PLUGIN manticoresoftware/buddy-plugin-show-hostname VERSION 'dev-ma
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/Plugins/Creating_a_plugin.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/Plugins/Deleting_a_plugin.md
+++ b/manual/Extensions/UDFs_and_Plugins/Plugins/Deleting_a_plugin.md
@@ -30,4 +30,7 @@ DELETE BUDDY PLUGIN manticoresoftware/buddy-plugin-show-hostname
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/Plugins/Deleting_a_plugin.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/Plugins/Ranker_plugins.md
+++ b/manual/Extensions/UDFs_and_Plugins/Plugins/Ranker_plugins.md
@@ -12,5 +12,6 @@ The call workflow proceeds as follows:
 3. `XXX_finalize()` is called once for each matched document when there are no more keyword occurrences. It must return the `WEIGHT()` value. This function is the only mandatory one.
 4. `XXX_deinit()` is invoked once per query, at the very end.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/Plugins/Ranker_plugins.md)
 
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/Plugins/Reloading_plugins.md
+++ b/manual/Extensions/UDFs_and_Plugins/Plugins/Reloading_plugins.md
@@ -20,4 +20,7 @@ On Windows, overwriting or deleting a DLL library currently in use can be proble
 mysql> RELOAD PLUGINS FROM SONAME 'udfexample.dll';
 Query OK, 0 rows affected (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/Plugins/Reloading_plugins.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/Plugins/Token_filter_plugins.md
+++ b/manual/Extensions/UDFs_and_Plugins/Plugins/Token_filter_plugins.md
@@ -52,4 +52,6 @@ The call workflow for query-time token filter is as follows:
 
 Absence of the functions is tolerated.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/Plugins/Token_filter_plugins.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/UDF.md
+++ b/manual/Extensions/UDFs_and_Plugins/UDF.md
@@ -115,4 +115,6 @@ The calling sequence of the other functions is fixed, though. Namely,
 * `testfunc()` is called for every eligible row (see above), whenever Manticore needs to compute the UDF value. It can also indicate an (internal) failure error by writing a non-zero byte value to `error_flag`. In that case, it is guaranteed that it will not be called for subsequent rows, and a default return value of 0 will be substituted. Manticore might or might not choose to terminate such queries early; neither behavior is currently guaranteed.
 * `testfunc_deinit()` is called once when the query processing (in a given table shard) ends.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/UDF.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/UDF/Creating_a_function.md
+++ b/manual/Extensions/UDFs_and_Plugins/UDF/Creating_a_function.md
@@ -22,4 +22,7 @@ mysql> SELECT *, AVGMVA(tag) AS q from test1;
 |    4 |      1 | 7,40    | 23.500000 |
 +------+--------+---------+-----------+
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/UDF/Creating_a_function.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/UDF/Deleting_a_function.md
+++ b/manual/Extensions/UDFs_and_Plugins/UDF/Deleting_a_function.md
@@ -10,4 +10,7 @@ DROP FUNCTION udf_name
 mysql> DROP FUNCTION avgmva;
 Query OK, 0 rows affected (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/UDF/Deleting_a_function.md)
+
 <!-- proofread -->

--- a/manual/Extensions/UDFs_and_Plugins/UDFs_and_Plugins.md
+++ b/manual/Extensions/UDFs_and_Plugins/UDFs_and_Plugins.md
@@ -76,5 +76,8 @@ mysql> SELECT id, weight() FROM test1 WHERE MATCH('test') OPTION ranker=myrank('
 +------+----------+
 2 rows in set (0.01 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Extensions/UDFs_and_Plugins/UDFs_and_Plugins.md)
+
 <!-- proofread -->
 

--- a/manual/Functions/Arrays_and_conditions_functions.md
+++ b/manual/Functions/Arrays_and_conditions_functions.md
@@ -347,4 +347,7 @@ More examples:
 SELECT REMAP(userid, karmapoints, (1, 67), (999, 0)) FROM users;
 SELECT REMAP(id%10, salary, (0), (0.0)) FROM employes;
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Arrays_and_conditions_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/Date_and_time_functions.md
+++ b/manual/Functions/Date_and_time_functions.md
@@ -185,4 +185,6 @@ mysql> SELECT DATE_FORMAT(NOW(), 'year %Y and time %T');
 
 This example formats the current date and time, displaying the four-digit year and the time in 24-hour format.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Date_and_time_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/Geo_spatial_functions.md
+++ b/manual/Functions/Geo_spatial_functions.md
@@ -27,4 +27,6 @@ The default method is "adaptive". It is a well-optimized implementation that is 
 ### POLY2D()
 `POLY2D(x1,y1,x2,y2,x3,y3...)` creates a polygon to be used with the [CONTAINS()](../Functions/Arrays_and_conditions_functions.md#CONTAINS%28%29) function. This polygon assumes a flat Earth, so it should not be too large; for large areas, the [GEOPOLY2D()](../Functions/Geo_spatial_functions.md#GEOPOLY2D%28%29) function, which takes Earth's curvature into consideration, should be used.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Geo_spatial_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/Mathematical_functions.md
+++ b/manual/Functions/Mathematical_functions.md
@@ -64,4 +64,6 @@ Returns the sine of the argument.
 ### SQRT()
 Returns the square root of the argument.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Mathematical_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/Other_functions.md
+++ b/manual/Functions/Other_functions.md
@@ -36,4 +36,7 @@ mysql> select CONNECTION_ID();
 +-----------------+
 1 row in set (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Other_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/Searching_and_ranking_functions.md
+++ b/manual/Functions/Searching_and_ranking_functions.md
@@ -184,4 +184,6 @@ The `ZONESPANLIST()` function returns pairs of matched zone spans. Each pair con
 
 Table functions are a mechanism for post-query result set processing. Table functions take an arbitrary result set as input and return a new, processed set as output. The first argument should be the input result set, but a table function can optionally take and handle more arguments. Table functions can completely change the result set, including the schema. Currently, only built-in table functions are supported. Table functions work for both outer `SELECT` and [nested SELECT](../Searching/Sub-selects.md).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Searching_and_ranking_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/String_functions.md
+++ b/manual/Functions/String_functions.md
@@ -67,4 +67,7 @@ It is important to note that `SNIPPET()` does not support field-based limitation
 SELECT SUBSTRING_INDEX('www.w3schools.com', '.', 2) FROM test;
 SELECT SUBSTRING_INDEX(j.coord, ' ', 1) FROM test;
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/String_functions.md)
+
 <!-- proofread -->

--- a/manual/Functions/Type_casting_functions.md
+++ b/manual/Functions/Type_casting_functions.md
@@ -20,4 +20,7 @@ Converts the given argument to a 64-bit unsigned integer type.
 
 ### SINT()
 Forcefully reinterprets its 32-bit unsigned integer argument as signed and expands it to a 64-bit type (because the 32-bit type is unsigned). This is easily illustrated by the following example: 1-2 normally evaluates to 4294967295, but `SINT(1-2)` evaluates to -1.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Functions/Type_casting_functions.md)
+
 <!-- proofread -->

--- a/manual/Installation/Compiling_from_sources.md
+++ b/manual/Installation/Compiling_from_sources.md
@@ -302,4 +302,7 @@ Configured with these definitions: -DDISTR_BUILD=rhel8 -DUSE_SYSLOG=1 -DWITH_GAL
 -DMYSQL_LIB=libmariadb.so.3 -DWITH_POSTGRESQL=1 -DDL_POSTGRESQL=1 -DPOSTGRESQL_LIB=libpq.so.5 -DLOCALDATADIR=/var/lib/manticore/data
 -DFULL_SHARE_DIR=/usr/share/manticore
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/Compiling_from_sources.md)
+
 <!-- proofread -->

--- a/manual/Installation/Debian_and_Ubuntu.md
+++ b/manual/Installation/Debian_and_Ubuntu.md
@@ -140,4 +140,7 @@ sudo ldconfig
 sudo pip3.9 install pymorphy2[fast]
 sudo pip3.9 install pymorphy2-dicts-uk
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/Debian_and_Ubuntu.md)
+
 <!-- proofread -->

--- a/manual/Installation/Docker.md
+++ b/manual/Installation/Docker.md
@@ -10,4 +10,6 @@ docker pull manticoresearch/manticore
 
 For more information about using Manticore in Docker, see the [Using Manticore in Docker](../Starting_the_server/Docker.md) section.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/Docker.md)
+
 <!-- proofread -->

--- a/manual/Installation/MacOS.md
+++ b/manual/Installation/MacOS.md
@@ -45,4 +45,6 @@ Manticore configuration file is `./etc/manticoresearch/manticore.conf` after you
 
 -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/MacOS.md)
+
 <!-- proofread -->

--- a/manual/Installation/Migration_from_Sphinx.md
+++ b/manual/Installation/Migration_from_Sphinx.md
@@ -126,4 +126,6 @@ Here's the complete list of `index_converter` options:
 * `--all` - converts all tables from the config
 * `--killlist-target <targets>` sets the target tables for which kill-lists will be applied. This option should be used only in conjunction with the `--index` option
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/Migration_from_Sphinx.md)
+
 <!-- proofread -->

--- a/manual/Installation/Old_linuxes.md
+++ b/manual/Installation/Old_linuxes.md
@@ -16,4 +16,7 @@ and then start it:
 ```bash
 brew services start manticoresearch
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/Old_linuxes.md)
+
 <!-- proofread -->

--- a/manual/Installation/RHEL_and_Centos.md
+++ b/manual/Installation/RHEL_and_Centos.md
@@ -85,4 +85,6 @@ ldconfig
 pip3.9 install pymorphy2[fast]
 pip3.9 install pymorphy2-dicts-uk
 ```
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/RHEL_and_Centos.md)
+
 <!-- proofread -->

--- a/manual/Installation/Windows.md
+++ b/manual/Installation/Windows.md
@@ -25,4 +25,6 @@ mysql -P9306 -h127.0.0.1
 
 Note that in most examples in this manual, we use `-h0` to connect to the local host, but in Windows, you must use `localhost` or `127.0.0.1` explicitly.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Installation/Windows.md)
+
 <!-- proofread -->

--- a/manual/Introduction.md
+++ b/manual/Introduction.md
@@ -89,4 +89,5 @@ Manticore has a variety of use cases, including:
 * [Manticore Columnar Library](https://github.com/manticoresoftware/columnar), which provides [columnar storage](Creating_a_table/Data_types.md#Row-wise-and-columnar-attribute-storages) and [secondary indexes](Introduction.md#Automatic-secondary-indexes), requires a CPU with SSE >= 4.2.
 * No specific disk space or RAM requirements are needed. An empty Manticore Search instance only uses around 40MB of RSS RAM.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Introduction.md)
 <!-- proofread -->

--- a/manual/Listing_tables.md
+++ b/manual/Listing_tables.md
@@ -328,4 +328,7 @@ mysql> desc pq table like '%title%';
 +-------+------+----------------+
 1 row in set (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Listing_tables.md)
+
 <!-- proofread -->

--- a/manual/Logging/Binary_logging.md
+++ b/manual/Logging/Binary_logging.md
@@ -75,4 +75,6 @@ The default RT flush period is set to 10 hours.
 
 It's important to note that `rt_flush_period` only controls the frequency at which *checks* occur. There are no *guarantees* that a specific RAM chunk will be saved. For example, it doesn't make sense to regularly re-save a large RAM chunk that only receives a few rows worth of updates. Manticore automatically determines whether to perform the flush using a few heuristics.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Logging/Binary_logging.md)
+
 <!-- proofread -->

--- a/manual/Logging/Docker_logging.md
+++ b/manual/Logging/Docker_logging.md
@@ -8,4 +8,7 @@ docker logs manticore
 The query log can be diverted to the Docker log by passing the variable `QUERY_LOG_TO_STDOUT=true`.
 
 The log folder is the same as in the case of the Linux package, set to `/var/log/manticore`. If desired, it can be mounted to a local path to view or process the logs.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Logging/Docker_logging.md)
+
 <!-- proofread -->

--- a/manual/Logging/Query_logging.md
+++ b/manual/Logging/Query_logging.md
@@ -150,4 +150,7 @@ searchd {
 ...
 }
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Logging/Query_logging.md)
+
 <!-- proofread -->

--- a/manual/Logging/Rotating_query_and_server_logs.md
+++ b/manual/Logging/Rotating_query_and_server_logs.md
@@ -26,4 +26,7 @@ Query OK, 0 rows affected (0.01 sec)
 ```
 
 Additionally, the `FLUSH LOGS` SQL command is available, which works the same way as the USR1 system signal. It initiates the reopening of searchd log and query log files, allowing you to implement log file rotation. The command is non-blocking (i.e., it returns immediately).
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Logging/Rotating_query_and_server_logs.md)
+
 <!-- proofread -->

--- a/manual/Logging/Server_logging.md
+++ b/manual/Logging/Server_logging.md
@@ -15,5 +15,6 @@ searchd {
 * You can also use `syslog` as the file name. In this case, events will be sent to your server's syslog daemon.
 * In some cases, you might want to use `/dev/stdout` as the file name. In this case, on Linux, Manticore will simply output the events. This can be useful in Docker/Kubernetes environments.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Logging/Server_logging.md)
 
 <!-- proofread -->

--- a/manual/Miscellaneous_tools.md
+++ b/manual/Miscellaneous_tools.md
@@ -92,4 +92,6 @@ indexer --buildstops dict.txt 100000 --buildfreqs myindex -c /path/to/sphinx.con
 
 which will write the 100,000 most frequent words along with their counts from myindex into dict.txt. The output file is a text file, so it can be edited by hand if necessary to add or remove words.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Miscellaneous_tools.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/KILL.md
+++ b/manual/Node_info_and_management/KILL.md
@@ -14,4 +14,7 @@ Query OK, 1 row affected (0.00 sec)
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/KILL.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/Node_status.md
+++ b/manual/Node_info_and_management/Node_status.md
@@ -980,4 +980,6 @@ utilsApi.sql("SHOW AGENT \"192.168.0.202:6714\" STATUS LIKE \"%15periods%\"");
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/Node_status.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/Profiling/Query_plan.md
+++ b/manual/Node_info_and_management/Profiling/Query_plan.md
@@ -342,4 +342,7 @@ Variable: transformed_tree
 ```
 
 ![SHOW PLAN graphviz example](graphviz.png)
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/Profiling/Query_plan.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/Profiling/Query_profile.md
+++ b/manual/Node_info_and_management/Profiling/Query_profile.md
@@ -173,4 +173,6 @@ This feature is somewhat similar to the [SHOW PLAN](../../Node_info_and_manageme
 * `field_end`: keyword must occur at the very end of the field. Keyword nodes only
 * `boost`: keyword IDF will be multiplied by this. Keyword nodes only
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/Profiling/Query_profile.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/SHOW_META.md
+++ b/manual/Node_info_and_management/SHOW_META.md
@@ -427,4 +427,7 @@ CALL PQ ('pq', ('{"title":"angry", "gid":3 }'), 1 as verbose); SHOW META;
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/SHOW_META.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/SHOW_QUERIES.md
+++ b/manual/Node_info_and_management/SHOW_QUERIES.md
@@ -33,4 +33,6 @@ mysql> SHOW QUERIES;
 
 Refer to [SHOW THREADS](../Node_info_and_management/SHOW_THREADS.md) if you'd like to gain insight from the perspective of the threads themselves.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/SHOW_QUERIES.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/SHOW_THREADS.md
+++ b/manual/Node_info_and_management/SHOW_THREADS.md
@@ -1086,4 +1086,7 @@ utilsApi.sql("SHOW THREADS OPTION columns=30");
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/SHOW_THREADS.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/SHOW_VARIABLES.md
+++ b/manual/Node_info_and_management/SHOW_VARIABLES.md
@@ -44,4 +44,7 @@ mysql> show session variables like 'autocommit';
 +---------------+-------+
 1 row in set (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/SHOW_VARIABLES.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/SHOW_WARNINGS.md
+++ b/manual/Node_info_and_management/SHOW_WARNINGS.md
@@ -26,4 +26,7 @@ Message: quorum threshold too high (words=2, thresh=3); replacing quorum operato
          with AND operator
 1 row in set (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/SHOW_WARNINGS.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/Table_settings_and_status/SHOW_TABLE_SETTINGS.md
+++ b/manual/Node_info_and_management/Table_settings_and_status/SHOW_TABLE_SETTINGS.md
@@ -57,4 +57,7 @@ charset_table = 0..9, A..Z->a..z, _, -, a..z, U+410..U+42F->U+430..U+44F, U+430.
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/Table_settings_and_status/SHOW_TABLE_SETTINGS.md)
+
 <!-- proofread -->

--- a/manual/Node_info_and_management/Table_settings_and_status/SHOW_TABLE_STATUS.md
+++ b/manual/Node_info_and_management/Table_settings_and_status/SHOW_TABLE_STATUS.md
@@ -221,4 +221,7 @@ utilsApi.sql("SHOW TABLE statistic STATUS");
   warning= }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Node_info_and_management/Table_settings_and_status/SHOW_TABLE_STATUS.md)
+
 <!-- proofread -->

--- a/manual/Openapi.md
+++ b/manual/Openapi.md
@@ -3,4 +3,7 @@
 The Manticore Search API is documented using the OpenAPI specification, which can be used to generate client SDKs. The machine-readable YAML file is available at https://raw.githubusercontent.com/manticoresoftware/openapi/master/manticore.yml
 
 You can also view the specification visualized with the online Swagger Editor [here](https://editor.swagger.io).
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Openapi.md)
+
 <!-- proofread -->

--- a/manual/Quick_start_guide.md
+++ b/manual/Quick_start_guide.md
@@ -770,4 +770,7 @@ indexApi.delete(deleteRequest);
 
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Quick_start_guide.md)
+
 <!-- proofread -->

--- a/manual/Read_this_first.md
+++ b/manual/Read_this_first.md
@@ -55,4 +55,5 @@ Manticore provides multiple ways and interfaces to manage your schemas and data,
   * design your queries as SQL is much closer to natural language than the JSON DSL which is important when you design something new. You can use Manticore SQL via any MySQL client or [/sql](Connecting_to_the_server/MySQL_protocol.md).
 * **JSON**. Most functionality is also available via JSON domain specific language. This is especially useful when you integrate Manticore with your application as with JSON you can do it more programmatically than with SQL. The best practice is to **first explore how to do something via SQL and then use JSON to integrate it into your application.**
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Read_this_first.md)
 <!-- proofread -->

--- a/manual/Reporting_bugs.md
+++ b/manual/Reporting_bugs.md
@@ -239,4 +239,6 @@ The subcommand `crash` literally causes a crash. It may be used for testing purp
 
 If some commands are found to be useful in a more general context, they may be moved from the debug subcommands to a more stable and generic location (as exemplified by the `debug tasks` and `debug sched` in the table).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Reporting_bugs.md)
+
 <!-- proofread -->

--- a/manual/Searching/Autocomplete.md
+++ b/manual/Searching/Autocomplete.md
@@ -165,4 +165,7 @@ MySQL [(none)]> CALL KEYWORDS('cat*', 't', 1 as stats, 'hits' as sort_mode);
 <!-- end -->
 
 `CALL KEYWORDS` supports distributed tables so no matter how big your data set you can benefit from using it.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Autocomplete.md)
+
 <!-- proofread -->

--- a/manual/Searching/Collations.md
+++ b/manual/Searching/Collations.md
@@ -53,4 +53,6 @@ Collation can be overridden via SQL on a per-session basis using the `SET collat
 
 Collations affect all string attribute comparisons, including those within `ORDER BY` and `GROUP BY`, so differently ordered or grouped results can be returned depending on the collation chosen. Note that collations don't affect full-text searching; for that, use the [charset_table](../Creating_a_table/NLP_and_tokenization/Low-level_tokenization.md#charset_table).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Collations.md)
+
 <!-- proofread -->

--- a/manual/Searching/Cost_based_optimizer.md
+++ b/manual/Searching/Cost_based_optimizer.md
@@ -32,4 +32,6 @@ Queries using secondary indexes and docid indexes always run in a single thread,
 
 At present, the optimizer only uses CPU costs and does not take memory or disk usage into account.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Cost_based_optimizer.md)
+
 <!-- proofread -->

--- a/manual/Searching/Distributed_searching.md
+++ b/manual/Searching/Distributed_searching.md
@@ -26,4 +26,6 @@ From the application's perspective, there are no differences between searching t
 
 Learn more about [remote nodes](../Creating_a_cluster/Remote_nodes.md).
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Distributed_searching.md)
+
 <!-- proofread -->

--- a/manual/Searching/Expressions.md
+++ b/manual/Searching/Expressions.md
@@ -216,4 +216,6 @@ By default, expression values are included in the `_source` array of the result 
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Expressions.md)
+
 <!-- proofread -->

--- a/manual/Searching/Faceted_search.md
+++ b/manual/Searching/Faceted_search.md
@@ -1345,4 +1345,7 @@ SHOW META LIKE 'multiplier';
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Faceted_search.md)
+
 <!-- proofread -->

--- a/manual/Searching/Filters.md
+++ b/manual/Searching/Filters.md
@@ -465,4 +465,7 @@ POST /search
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Filters.md)
+
 <!-- proofread -->

--- a/manual/Searching/Full_text_matching/Basic_usage.md
+++ b/manual/Searching/Full_text_matching/Basic_usage.md
@@ -345,4 +345,7 @@ class SearchResponse {
 }
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Full_text_matching/Basic_usage.md)
+
 <!-- proofread -->

--- a/manual/Searching/Full_text_matching/Boolean_optimization.md
+++ b/manual/Searching/Full_text_matching/Boolean_optimization.md
@@ -13,5 +13,7 @@ Queries can be automatically optimized if `OPTION boolean_simplify=1` is specifi
 Note that optimizing queries consumes CPU time, so for simple queries or hand-optimized queries, you'll achieve better results with the default `boolean_simplify=0` value. Simplifications often benefit complex queries or algorithmically generated queries.
 
 Queries like "-dog," which implicitly include all documents from the collection, cannot be evaluated. This is due to both technical and performance reasons. Technically, Manticore does not always maintain a list of all IDs. Performance-wise, evaluating such queries could take a long time when the collection is massive (e.g., 10-100M documents).
- 
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Full_text_matching/Boolean_optimization.md)
+
 <!-- proofread -->

--- a/manual/Searching/Full_text_matching/Escaping.md
+++ b/manual/Searching/Full_text_matching/Escaping.md
@@ -90,4 +90,7 @@ MySQL [(none)]> select * from t where json.`a:b`=123;
 | 8215557549554925577 | {"a:b":123} |      |
 +---------------------+-------------+------+
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Full_text_matching/Escaping.md)
+
 <!-- proofread -->

--- a/manual/Searching/Full_text_matching/Operators.md
+++ b/manual/Searching/Full_text_matching/Operators.md
@@ -236,4 +236,6 @@ only in a (single) title
 
 The `ZONESPAN` limit operator resembles the `ZONE` operator but mandates that the match occurs within a single continuous span. In the example provided earlier, `ZONESPAN:th hello world` would not match the document, as "hello" and "world" do not appear within the same span.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Full_text_matching/Operators.md)
+
 <!-- proofread -->

--- a/manual/Searching/Full_text_matching/Profiling.md
+++ b/manual/Searching/Full_text_matching/Profiling.md
@@ -868,4 +868,7 @@ packedfactors(): bm25=569, bm25a=0.617197, field_mask=2, doc_word_count=2,
 1 row in set (0.00 sec)
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Full_text_matching/Profiling.md)
+
 <!-- proofread -->

--- a/manual/Searching/Geo_search.md
+++ b/manual/Searching/Geo_search.md
@@ -54,4 +54,7 @@ There are two functions available for creating the polygon:
 ```sql
 SELECT *,CONTAINS(GEOPOLY2D(40.76439, -73.9997, 42.21211, -73.999,  42.21211, -76.123, 40.76439, -76.123), 41.5445, -74.973) AS inside FROM myindex WHERE MATCH('...') AND inside=1;
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Geo_search.md)
+
 <!-- proofread -->

--- a/manual/Searching/Grouping.md
+++ b/manual/Searching/Grouping.md
@@ -1065,4 +1065,7 @@ MySQL [(none)]> SELECT release_year year, count(*) FROM films GROUP BY year limi
 +------+----------+
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Grouping.md)
+
 <!-- proofread -->

--- a/manual/Searching/Highlighting.md
+++ b/manual/Searching/Highlighting.md
@@ -1954,4 +1954,7 @@ CALL SNIPPETS(('data/doc1.txt','data/doc2.txt'), 'forum', 'is text', 1 AS load_f
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Highlighting.md)
+
 <!-- proofread -->

--- a/manual/Searching/Intro.md
+++ b/manual/Searching/Intro.md
@@ -27,4 +27,7 @@ POST /search
     }
 }
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Intro.md)
+
 <!-- proofread -->

--- a/manual/Searching/Multi-queries.md
+++ b/manual/Searching/Multi-queries.md
@@ -78,4 +78,6 @@ For reference, this is how the regular log would look like if the queries were n
 
 Notice how the per-query time in the multi-query case improved by a factor of 1.5x to 2.3x, depending on the specific sorting mode.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Searching/Multi-queries.md)
+
 <!-- proofread -->

--- a/manual/Searching/Options.md
+++ b/manual/Searching/Options.md
@@ -280,4 +280,6 @@ SELECT * FROM students where age > 21 /*+ SecondaryIndex(age) */
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Options.md)
+
 <!-- proofread -->

--- a/manual/Searching/Pagination.md
+++ b/manual/Searching/Pagination.md
@@ -79,4 +79,7 @@ SELECT  ... FROM ...   OPTION max_matches=<value>
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Pagination.md)
+
 <!-- proofread -->

--- a/manual/Searching/Percolate_query.md
+++ b/manual/Searching/Percolate_query.md
@@ -1995,4 +1995,7 @@ CALL PQ('products', ('{"title": "nice pair of shoes", "color": "blue"}', '{"titl
 +-----------------------+-----------+
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Percolate_query.md)
+
 <!-- proofread -->

--- a/manual/Searching/Query_cache.md
+++ b/manual/Searching/Query_cache.md
@@ -42,4 +42,7 @@ mysql> SHOW STATUS LIKE 'qcache%';
 +-----------------------+----------+
 6 rows in set (0.00 sec)
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Query_cache.md)
+
 <!-- proofread -->

--- a/manual/Searching/Search_results.md
+++ b/manual/Searching/Search_results.md
@@ -189,6 +189,8 @@ You can also explicitly specify which attributes you want to include and which t
 
 An empty list of includes is interpreted as "include all attributes," while an empty list of excludes does not match anything. If an attribute matches both the includes and excludes, then the excludes win.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Search_results.md)
+
 <!-- proofread -->
 
 

--- a/manual/Searching/Sorting_and_ranking.md
+++ b/manual/Searching/Sorting_and_ranking.md
@@ -245,4 +245,6 @@ Second, `idf=tfidf_normalized` causes IDF drift over queries. Historically, we a
 
 IDF flags can be mixed; `plain` and `normalized` are mutually exclusive;`tfidf_unnormalized` and `tfidf_normalized` are mutually exclusive; and unspecified flags in such a mutually exclusive group take their defaults. That means that `OPTION idf=plain` is equivalent to a complete `OPTION idf='plain,tfidf_normalized'` specification.    
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Sorting_and_ranking.md)
+
 <!-- proofread -->

--- a/manual/Searching/Spell_correction.md
+++ b/manual/Searching/Spell_correction.md
@@ -182,4 +182,7 @@ CALL QSUGGEST('bagg with tasel', 'products', 1 as result_line);
 [This interactive course](https://play.manticoresearch.com/didyoumean/) demonstrates online how the spell correction feature works on a web page and experiment with different examples.
 
 ![Typical flow with Manticore and a database](didyoumean.png){.scale-0.5}
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Searching/Spell_correction.md)
+
 <!-- proofread -->

--- a/manual/Searching/Sub-selects.md
+++ b/manual/Searching/Sub-selects.md
@@ -45,4 +45,7 @@ The outer select allows only `ORDER BY` and `LIMIT` clauses. Sub-select queries 
     ```
 
     In this case, the nodes receive only the inner query and execute it. This means the master will receive only 20x10K=200K records. The master will take all the records received, reorder them by the OUTER clause, and return the best 50K records. The sub-select helps reduce the traffic between the master and the nodes, as well as reduce the master's computation time (since it processes only 200K instead of 1M records).
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Searching/Sub-selects.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Backup_and_restore.md
+++ b/manual/Securing_and_compacting_a_table/Backup_and_restore.md
@@ -223,4 +223,6 @@ Manticore config
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Backup_and_restore.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Compacting_a_table.md
+++ b/manual/Securing_and_compacting_a_table/Compacting_a_table.md
@@ -106,4 +106,6 @@ Once the table is added back to the cluster, you must resume write operations on
 
 Search operations are available as usual during the process on any of the nodes.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Compacting_a_table.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Flushing_RAM_chunk_to_a_new_disk_chunk.md
+++ b/manual/Securing_and_compacting_a_table/Flushing_RAM_chunk_to_a_new_disk_chunk.md
@@ -25,4 +25,7 @@ FLUSH RAMCHUNK rt;
 Query OK, 0 rows affected (0.05 sec)
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Flushing_RAM_chunk_to_a_new_disk_chunk.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Flushing_RAM_chunk_to_disk.md
+++ b/manual/Securing_and_compacting_a_table/Flushing_RAM_chunk_to_disk.md
@@ -28,4 +28,6 @@ Query OK, 0 rows affected (0.05 sec)
 ```
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Flushing_RAM_chunk_to_disk.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Flushing_attributes.md
+++ b/manual/Securing_and_compacting_a_table/Flushing_attributes.md
@@ -19,4 +19,6 @@ mysql> FLUSH ATTRIBUTES;
 1 row in set (0.19 sec)
 ```
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Flushing_attributes.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Flushing_hostnames.md
+++ b/manual/Securing_and_compacting_a_table/Flushing_hostnames.md
@@ -11,4 +11,6 @@ mysql> FLUSH HOSTNAMES;
 Query OK, 5 rows affected (0.01 sec)
 ```
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Flushing_hostnames.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Freezing_a_table.md
+++ b/manual/Securing_and_compacting_a_table/Freezing_a_table.md
@@ -81,4 +81,6 @@ UNFREEZE tbl;
 
 <!-- end -->
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Freezing_a_table.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/Isolation_during_flushing_and_merging.md
+++ b/manual/Securing_and_compacting_a_table/Isolation_during_flushing_and_merging.md
@@ -7,4 +7,7 @@ For example, during table compaction, a pair of disk chunks are merged and a new
 The same applies to flushing a RAM chunk, where suitable RAM segments are merged into a new disk chunk and the participated RAM chunk segments are abandoned. During this operation, Manticore provides isolation for queries that started before the operation began.
 
 Furthermore, these operations are transparent for replaces and updates. If you update an attribute in a document that belongs to a disk chunk being merged with another one, the update will be applied to both that chunk and the resulting merged chunk. If you delete a document during a merge, it will be deleted in the original chunk and also in the resulting merged chunk, which will either have the document marked as deleted or have no such document at all if the deletion happened early in the merging process.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/Isolation_during_flushing_and_merging.md)
+
 <!-- proofread -->

--- a/manual/Securing_and_compacting_a_table/RT_table_structure.md
+++ b/manual/Securing_and_compacting_a_table/RT_table_structure.md
@@ -43,4 +43,7 @@ As a summary: the deletion works in two phases:
 **Fifth, if an RT table contains plain disk tables in its collection, can I just add my ready old disk table to it?** No. It's not possible to avoid unneeded complexity and prevent accidental corruption. However, if your RT table has just been created and contains no data, then you can [ATTACH TABLE](../Data_creation_and_modification/Adding_data_from_external_storages/Adding_data_to_tables/Attaching_a_plain_table_to_RT_table.md) your disk table to it. Your old table will be moved inside the RT table and will become its part.
 
 As a summary about the RT table structure: it is a cleverly organized collection of plain disk tables with a fast in-memory table, intended for real-time insertions and semi-real-time deletions of documents. The RT table has a common schema, common settings, and can be easily maintained without deep digging into details. 
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Securing_and_compacting_a_table/RT_table_structure.md)
+
 <!-- proofread -->

--- a/manual/Security/Read_only.md
+++ b/manual/Security/Read_only.md
@@ -16,4 +16,6 @@ If you're connected to a [VIP](../Server_settings/Searchd.md#listen) socket, you
 
 For standard (non-VIP) connections, escaping read-only mode is only possible by reconnecting if it was set interactively, or by updating the configuration file and restarting the daemon.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Security/Read_only.md)
+
 <!-- proofread -->

--- a/manual/Security/SSL.md
+++ b/manual/Security/SSL.md
@@ -90,4 +90,7 @@ If your SSL configuration is not valid for any reason (which the daemon detects 
 * Binary API connections (such as connections from old clients or inter-daemons master-agent communication) are not secured.
 * SSL for replication needs to be set up separately. However, since the SST stage of the replication is done through the binary API connection, it is not secured either.
 * You can still use any external proxies (e.g., SSH tunneling) to secure your connections.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Security/SSL.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Comments.md
+++ b/manual/Server_settings/Comments.md
@@ -6,4 +6,6 @@ When using comments, be cautious when incorporating the `#` character in charact
 
 If you need to use the `#` character within your configuration file, such as within database credentials in source declarations, you can escape it using a backslash `\`. This allows you to include the `#` character in your settings without it being interpreted as the start of a comment.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Comments.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Common.md
+++ b/manual/Server_settings/Common.md
@@ -69,4 +69,7 @@ Example:
 ```ini
 plugin_dir = /usr/local/lib/manticore/
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Common.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Inheritance_of_index_and_source_declarations.md
+++ b/manual/Server_settings/Inheritance_of_index_and_source_declarations.md
@@ -23,4 +23,7 @@ The child will inherit the entire configuration of the parent. Any settings decl
 Note that existing values of a multi-value setting will not be copied if the child declares one value for that setting.
 
 The inheritance behavior applies to fields and attributes, not just table options. For example, if the parent has two integer attributes and the child needs a new integer attribute, the integer attribute declarations from the parent must be copied into the child configuration.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Inheritance_of_index_and_source_declarations.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Scripted_configuration.md
+++ b/manual/Server_settings/Scripted_configuration.md
@@ -36,4 +36,7 @@ table test_<?=$i?> {
  }
  ?>
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Scripted_configuration.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Searchd.md
+++ b/manual/Server_settings/Searchd.md
@@ -1406,4 +1406,7 @@ When a Manticore query crashes, it can take down the entire server. With the wat
 watchdog = 0 # disable watchdog
 ```
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Searchd.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Setting_variables_online.md
+++ b/manual/Server_settings/Setting_variables_online.md
@@ -86,4 +86,7 @@ Query OK, 0 rows affected (0.01 sec)
 ```
 
 To make user variables persistent, make sure [sphinxql_state](../Server_settings/Searchd.md#sphinxql_state) is enabled.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Setting_variables_online.md)
+
 <!-- proofread -->

--- a/manual/Server_settings/Special_suffixes.md
+++ b/manual/Server_settings/Special_suffixes.md
@@ -17,4 +17,6 @@ Manticore Search supports the use of special suffixes to simplify numeric values
   - `d` for days
   - `w` for weeks
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Server_settings/Special_suffixes.md)
+
 <!-- proofread -->

--- a/manual/Starting_the_server.md
+++ b/manual/Starting_the_server.md
@@ -2,4 +2,6 @@
 
 Manticore Search server can be started using different methods, depending on the installation type.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Starting_the_server.md)
+
 <!-- proofread -->

--- a/manual/Starting_the_server/Docker.md
+++ b/manual/Starting_the_server/Docker.md
@@ -282,4 +282,7 @@ prereading 0 indexes
 prereaded 0 indexes in 0.000 sec
 accepting connections
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Starting_the_server/Docker.md)
+
 <!-- proofread -->

--- a/manual/Starting_the_server/Linux.md
+++ b/manual/Starting_the_server/Linux.md
@@ -91,4 +91,6 @@ update-rc.d manticore defaults
 
 Please note that `searchd` is started by the init system under the `manticore` user and all files created by the server will be owned by this user. If `searchd` is started under, for example, the root user, the file permissions will be changed, which may result in issues when running `searchd` as a service again.
 
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Starting_the_server/Linux.md)
+
 <!-- proofread -->

--- a/manual/Starting_the_server/MacOS.md
+++ b/manual/Starting_the_server/MacOS.md
@@ -14,4 +14,7 @@ To stop Manticore, run the following command:
 ```bash
 brew services stop manticoresearch
 ```
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Starting_the_server/MacOS.md)
+
 <!-- proofread -->

--- a/manual/Starting_the_server/Manually.md
+++ b/manual/Starting_the_server/Manually.md
@@ -126,4 +126,7 @@ Manticore utilizes the [plugin_dir](../Server_settings/Common.md#plugin_dir) for
 ## Environment variables
 
 * `MANTICORE_TRACK_DAEMON_SHUTDOWN=1` enables detailed logging while searchd is shutting down. It's useful in case of some shutdown problems, such as when Manticore takes too long to shut down or freezes during the shutdown process.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Starting_the_server/Manually.md)
+
 <!-- proofread -->

--- a/manual/Starting_the_server/Windows.md
+++ b/manual/Starting_the_server/Windows.md
@@ -17,4 +17,7 @@ Alternatively, if you don't install Manticore as a Windows service, you can star
 .\bin\searchd -c manticore.conf
 ```
 This command assumes that you have the Manticore's binary and the configuration file in the current directory.
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Starting_the_server/Windows.md)
+
 <!-- proofread -->

--- a/manual/Telemetry.md
+++ b/manual/Telemetry.md
@@ -65,4 +65,7 @@ The following is a list of all collected metrics:
 | config_unreachable | Specified configuration file does not exist |
 | config_data_dir_missing | Failed to parse `data_dir` from specified configuration file |
 | config_data_dir_is_relative | `data_dir` path in Manticore instance's configuration file is relative |
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Telemetry.md)
+
 <!-- proofread -->

--- a/manual/Updating_table_schema_and_settings.md
+++ b/manual/Updating_table_schema_and_settings.md
@@ -273,4 +273,7 @@ Query OK, 0 rows affected (0.00 sec)
 ```
 
 <!-- end -->
+
+[Edit this page on GitHub](https://github.com/manticoresoftware/manticoresearch/tree/master/manual/Updating_table_schema_and_settings.md)
+
 <!-- proofread -->


### PR DESCRIPTION
While reading the documentation and we want to add some modification you need to check on: https://github.com/manticoresoftware/manticoresearch/tree/master/manual, 
But it's not indicated in the docs: https://manual.manticoresearch.com/ 
And you need also the find the right file to edit.
So we add an indication link that would allow anyone who needs to make any modification to the documentation, he could not strugle to find the file to edit. A link on each page that will redirect to the right file to edit and allow modification easier.

issue : #1119