### PR TITLE
fix: quick start index name

### DIFF
--- a/manual/Quick_start_guide.md
+++ b/manual/Quick_start_guide.md
@@ -341,9 +341,9 @@ $index->addDocuments([
 <!-- request Python -->
 
 ``` python
-indexApi.insert({"index" : "test", "doc" : {"title" : "Crossbody Bag with Tassel", "price" : 19.85}})
-indexApi.insert({"index" : "test", "doc" : {"title" : "microfiber sheet set", "price" : 19.99}})
-indexApi.insert({"index" : "test", "doc" : {"title" : "Pet Hair Remover Glove", "price" : 7.99}})
+indexApi.insert({"index" : "products", "doc" : {"title" : "Crossbody Bag with Tassel", "price" : 19.85}})
+indexApi.insert({"index" : "products", "doc" : {"title" : "microfiber sheet set", "price" : 19.99}})
+indexApi.insert({"index" : "products", "doc" : {"title" : "Pet Hair Remover Glove", "price" : 7.99}})
 ```
 <!-- intro -->
 ##### Javascript:
@@ -351,9 +351,9 @@ indexApi.insert({"index" : "test", "doc" : {"title" : "Pet Hair Remover Glove", 
 <!-- request Javascript -->
 
 ``` javascript
-res = await indexApi.insert({"index" : "test", "doc" : {"title" : "Crossbody Bag with Tassel", "price" : 19.85}});
-res = await indexApi.insert({"index" : "test", "doc" : {"title" : "microfiber sheet set", "price" : 19.99}});
-res = await indexApi.insert({"index" : "test", doc" : {"title" : "Pet Hair Remover Glove", "price" : 7.99}});
+res = await indexApi.insert({"index" : "products", "doc" : {"title" : "Crossbody Bag with Tassel", "price" : 19.85}});
+res = await indexApi.insert({"index" : "products", "doc" : {"title" : "microfiber sheet set", "price" : 19.99}});
+res = await indexApi.insert({"index" : "products", "doc" : {"title" : "Pet Hair Remover Glove", "price" : 7.99}});
 ```
 
 <!-- intro -->
@@ -501,7 +501,7 @@ Python
 <!-- request Python -->
 
 ```python
-searchApi.search({"index":"myindex","query":{"query_string":"@title remove hair"},"highlight":{"fields":["title"]}})
+searchApi.search({"index":"products","query":{"query_string":"@title remove hair"},"highlight":{"fields":["title"]}})
 ```
 <!-- response Python -->
 ``` python
@@ -520,7 +520,7 @@ javascript
 <!-- request javascript -->
 
 ```javascript
-res = await searchApi.search({"index":"myindex","query":{"query_string":"@title remove hair"}"highlight":{"fields":["title"]}});
+res = await searchApi.search({"index":"products","query":{"query_string":"@title remove hair"}"highlight":{"fields":["title"]}});
 ```
 <!-- response javascript -->
 ```javascript


### PR DESCRIPTION
Fixed wrong index name in quick start guide for Python and JS

<!--
Make sure you have read the Contributing guide (see file CONTRIBUTING.md in the root) before you submit a pull request.
-->

**Type of change:**

- [ ] Bug fix 
- [ ] New feature
- [x] Documentation update


**Description of the change:**
In quick start guide we are specifically creating `products` index ([here](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Quick_start_guide.md?plain=1#L219) and [here](https://github.com/manticoresoftware/manticoresearch/blob/master/manual/Quick_start_guide.md?plain=1#L236)), not `test` nor `myindex`


