### PR TITLE
Make clear statement about transactions is not supported for distributed tables

### DIFF
--- a/manual/Data_creation_and_modification/Transactions.md
+++ b/manual/Data_creation_and_modification/Transactions.md
@@ -1,6 +1,6 @@
 # Transactions
 
-Manticore supports basic transactions for deleting and inserting data into real-time and percolate tables. Each change to a table is first saved in an internal changeset and then actually committed to the table. By default, each command is wrapped in an individual automatic transaction, making it transparent: you simply 'insert' something and can see the inserted result after it completes, without worrying about transactions. However, this behavior can be explicitly managed by starting and committing transactions manually.
+Manticore supports basic transactions for deleting and inserting data into real-time and percolate tables, but not for tables in distributed configuration (in both RT and percolate modes). Each change to a table is first saved in an internal changeset and then actually committed to the table. By default, each command is wrapped in an individual automatic transaction, making it transparent: you simply 'insert' something and can see the inserted result after it completes, without worrying about transactions. However, this behavior can be explicitly managed by starting and committing transactions manually.
 
 Transactions are supported for the following commands:
 * [INSERT](../Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md)

--- a/manual/Data_creation_and_modification/Transactions.md
+++ b/manual/Data_creation_and_modification/Transactions.md
@@ -1,6 +1,6 @@
 # Transactions
 
-Manticore supports basic transactions for deleting and inserting data into real-time and percolate tables, but not for tables in distributed configuration (in both RT and percolate modes). Each change to a table is first saved in an internal changeset and then actually committed to the table. By default, each command is wrapped in an individual automatic transaction, making it transparent: you simply 'insert' something and can see the inserted result after it completes, without worrying about transactions. However, this behavior can be explicitly managed by starting and committing transactions manually.
+Manticore supports basic transactions for deleting and inserting data into real-time and percolate tables, except when attempting to write to a distributed table which includes a real-time or percolate table. Each change to a table is first saved in an internal changeset and then actually committed to the table. By default, each command is wrapped in an individual automatic transaction, making it transparent: you simply 'insert' something and can see the inserted result after it completes, without worrying about transactions. However, this behavior can be explicitly managed by starting and committing transactions manually.
 
 Transactions are supported for the following commands:
 * [INSERT](../Data_creation_and_modification/Adding_documents_to_a_table/Adding_documents_to_a_real-time_table.md)


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change (select one):**
- Documentation update

**Description of the Change:**
Added clear statement about transactions not supported for distributed tables.

**Related Issue (provide the link):**
Related to the [message](https://t.me/manticore_chat/7196/9280) in Telegram Manticore chat