### PR TITLE
Use branch to run nightly tests of release installation

### DIFF
--- a/.github/workflows/clt_nightly.yml
+++ b/.github/workflows/clt_nightly.yml
@@ -19,8 +19,9 @@ jobs:
         image: [ "centos:7", "almalinux:8", "almalinux:9", "oraclelinux:9", "amazonlinux:latest" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.1.11
+      - uses: manticoresoftware/clt@0.1.13
         with:
+          ref: manticore-6.2.12
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/rhel-release-
   clt_deb_release_installation:
@@ -31,7 +32,8 @@ jobs:
         image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:buster", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.1.11
+      - uses: manticoresoftware/clt@0.1.13
         with:
+          ref: manticore-6.2.12
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/deb-release-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -425,7 +425,7 @@ jobs:
     needs: build_test_kit_docker
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.1.11
+      - uses: manticoresoftware/clt@0.1.13
         with:
           artifact: manticore_test_kit.img
           image: test-kit:img
@@ -436,7 +436,7 @@ jobs:
     needs: build_test_kit_docker
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.1.11
+      - uses: manticoresoftware/clt@0.1.13
         with:
           artifact: manticore_test_kit.img
           image: test-kit:img
@@ -447,7 +447,7 @@ jobs:
     needs: build_test_kit_docker
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.1.11
+      - uses: manticoresoftware/clt@0.1.13
         with:
           artifact: manticore_test_kit.img
           image: test-kit:img
@@ -458,7 +458,7 @@ jobs:
     needs: build_test_kit_docker
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.1.11
+      - uses: manticoresoftware/clt@0.1.13
         with:
           artifact: manticore_test_kit.img
           image: test-kit:img


### PR DESCRIPTION
This update resolves the problem of running development tests on the release branch. Now, it's feasible to execute them from the associated branch. Specifically for releases, we run the appropriate tests in the release branch, rather than testing only the files that have been modified.