### PR TITLE
Fix application of docid killlists from other indexes.

### DIFF
--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -17650,7 +17650,7 @@ bool ApplyKillListsTo ( CSphIndex* pKillListTarget, CSphString & sError )
 
 				// kill all the docids present in this index
 				if ( tIndex.m_uFlags & KillListTarget_t::USE_DOCIDS )
-					pKillListTarget->KillExistingDocids ( pIndexWithKillList );
+					pIndexWithKillList->KillExistingDocids ( pKillListTarget );
 			}
 	}
 


### PR DESCRIPTION

<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change (select one):**
- Bug fix 

**Description of the Change:**

The direction of indexes in ApplyKillListsTo is swapped in case of docid killists - they are accidentally applied from target to source, not from source to target. So it has never worked properly, the docid killlists completely messed up other indexes. This fix corrects that.

**Related Issue (provide the link):**
None.