### PR TITLE
Experiment: back to Clang 15

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
     timeout-minutes: 30
     container:
-      image: manticoresearch/external_toolchain:clang16_cmake3263
+      image: manticoresearch/external_toolchain:clang15_cmake3263
       env:
         CACHEB: "../cache"
         DIAGNOSTIC: 1


### PR DESCRIPTION
It's turned out Manticore Search can crash under high pressure when compiled with Clang 16. This PR is to double check that it's indeed a compiler issue. The expectation is that the latest master commit won't crash with Clang 15 (if it can be built at all).