### PR TITLE
--date=format-local instead of --date=format to unify date/time in builds

### DIFF
--- a/sphinxrev.cmake
+++ b/sphinxrev.cmake
@@ -27,7 +27,7 @@ function ( guess_from_git )
 	set ( SPH_GIT_COMMIT_ID "${SPH_GIT_COMMIT_ID}" PARENT_SCOPE )
 
 	# extract timestamp and make number YYMMDDHH from it
-	execute_process ( COMMAND "${GIT_EXECUTABLE}" log -1 --date=format:"%y%m%d%H" --format=%cd
+	execute_process ( COMMAND "${GIT_EXECUTABLE}" log -1 --date=format-local:"%y%m%d%H" --format=%cd
 			WORKING_DIRECTORY "${MANTICORE_SOURCE_DIR}"
 			RESULT_VARIABLE res
 			OUTPUT_VARIABLE GIT_TIMESTAMP_ID


### PR DESCRIPTION
https://github.com/manticoresoftware/manticoresearch/blob/e35e5b563f5c45ce9781c7f1b1959c6189a29da7/sphinxrev.cmake#L30 led to:
```
git log -10 --date=format:"%y%m%d%H" --format=%cd
24043017
24043021
24043021
24043021
24043021
...
```

then when we pubished packages of `24043017` after `24043021` it broke the installation. This PR fixes it by unifying the tz.