### PR TITLE
Test/exceptions stopwords wordforms validation release to dev

### DIFF
--- a/test/clt-tests/installation/check-version/ex-sw-wf.recb
+++ b/test/clt-tests/installation/check-version/ex-sw-wf.recb
@@ -1,40 +1,31 @@
 ––– input –––
-yum install -y --skip-broken mariadb mariadb105 which > /dev/null 2>&1; echo $?
+echo "a => b" > /var/lib/manticore/wordforms1.txt; echo "c => d" > /var/lib/manticore/exc.txt; echo "abcstop" > /var/lib/manticore/stop.txt
 ––– output –––
-0
 ––– input –––
-yum install -y -q https://repo.manticoresearch.com/manticore-repo.noarch.rpm > /dev/null 2>&1; echo $?
+ls -1 /var/lib/manticore/
 ––– output –––
-0
+binlog
+exc.txt
+manticore.json
+state.sql
+stop.txt
+wordforms1.txt
 ––– input –––
-yum install -y -q manticore manticore-extra > /dev/null 2>&1; echo $?
+mysql -h0 -P9306 -e "DROP TABLE IF EXISTS table1; CREATE TABLE table1 (title TEXT, tag INTEGER) exceptions='/var/lib/manticore/exc.txt' wordforms='/var/lib/manticore/wordforms1.txt' stopwords='/var/lib/manticore/stop.txt';"
 ––– output –––
-0
 ––– input –––
-yum install -y -q binutils > /dev/null 2>&1; echo $?
+mysql -h0 -P9306 -e "INSERT INTO table1 (id, title, tag) values (1, 'zxczxc', 77); FLUSH RAMCHUNK table1;"
 ––– output –––
-0
 ––– input –––
-manticore-executor -v
+mysql -h0 -P9306 -e "INSERT INTO table1 (id, title, tag) values (2, 'srthh', 88); FLUSH RAMCHUNK table1;"
 ––– output –––
-PHP %{SEMVER} (cli) (built: #!/[a-zA-Z]{3}/!# #!/[0-9]+/!# %{YEAR} %{TIME}) (ZTS)
-Copyright (c) The PHP Group
-Zend Engine #!/v[0-9]+\.[0-9]+\.[0-9]+/!#, Copyright (c) Zend Technologies
-––– block: start-searchd-release –––
-––– block: check-version/export-current-version –––
-––– block: check-version/ex-sw-wf –––
 ––– input –––
-yum -y --enablerepo manticore-dev update manticore manticore-extra manticore-common manticore-server manticore-server-core manticore-tools manticore-executor manticore-buddy manticore-backup manticore-columnar-lib manticore-server-core-debuginfo manticore-tools-debuginfo manticore-columnar-lib-debuginfo  manticore-icudata manticore-galera > /dev/null 2>&1; echo $?
+mysql -h0 -P9306 -e "INSERT INTO table1 (id, title, tag) values (3, 'srthgrth', 99); FLUSH RAMCHUNK table1;"
 ––– output –––
-0
-––– block: stop-searchd-dev –––
-––– block: start-searchd-dev –––
-––– block: check-version/export-new-version –––
-––– block: check-version/comparison-version –––
 ––– input –––
 mysql -h0 -P9306 -e "SHOW TABLES; SELECT * FROM table1; SHOW CREATE TABLE table1;"
 ––– output –––
-+--------+------+
+ +--------+------+
 | Index  | Type |
 +--------+------+
 | table1 | rt   |

--- a/test/clt-tests/installation/ex-sw-wf.recb
+++ b/test/clt-tests/installation/ex-sw-wf.recb
@@ -2,16 +2,7 @@
 echo "a => b" > /var/lib/manticore/wordforms1.txt; echo "c => d" > /var/lib/manticore/exc.txt; echo "abcstop" > /var/lib/manticore/stop.txt
 ––– output –––
 ––– input –––
-ls -1 /var/lib/manticore/
-––– output –––
-binlog
-exc.txt
-manticore.json
-state.sql
-stop.txt
-wordforms1.txt
-––– input –––
-mysql -h0 -P9306 -e "DROP TABLE IF EXISTS table1; CREATE TABLE table1 (title TEXT, tag INTEGER) exceptions='/var/lib/manticore/exc.txt' wordforms='/var/lib/manticore/wordforms1.txt' stopwords='/var/lib/manticore/stop.txt';"
+mysql -h0 -P9306 -e "CREATE TABLE table1 (title TEXT, tag INTEGER) exceptions='/var/lib/manticore/exc.txt' wordforms='/var/lib/manticore/wordforms1.txt' stopwords='/var/lib/manticore/stop.txt';"
 ––– output –––
 ––– input –––
 mysql -h0 -P9306 -e "INSERT INTO table1 (id, title, tag) values (1, 'zxczxc', 77); FLUSH RAMCHUNK table1;"

--- a/test/clt-tests/installation/exceptions-stopwords-wordforms-validation-release-to-dev.rec
+++ b/test/clt-tests/installation/exceptions-stopwords-wordforms-validation-release-to-dev.rec
@@ -1,0 +1,33 @@
+––– input –––
+yum install -y --skip-broken mariadb mariadb105 which > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yum install -y -q https://repo.manticoresearch.com/manticore-repo.noarch.rpm > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yum install -y -q manticore manticore-extra > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yum install -y -q binutils > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+manticore-executor -v
+––– output –––
+PHP %{SEMVER} (cli) (built: #!/[a-zA-Z]{3}/!# #!/[0-9]+/!# %{YEAR} %{TIME}) (ZTS)
+Copyright (c) The PHP Group
+Zend Engine #!/v[0-9]+\.[0-9]+\.[0-9]+/!#, Copyright (c) Zend Technologies
+––– block: start-searchd-release –––
+––– block: check-buddy –––
+––– block: check-version/export-current-version –––
+––– input –––
+yum -y --enablerepo manticore-dev update manticore manticore-extra manticore-common manticore-server manticore-server-core manticore-tools manticore-executor manticore-buddy manticore-backup manticore-columnar-lib manticore-server-core-debuginfo manticore-tools-debuginfo manticore-columnar-lib-debuginfo  manticore-icudata manticore-galera > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– block: stop-searchd-dev –––
+––– block: start-searchd-dev –––
+––– block: check-version/export-new-version –––
+––– block: check-version/comparison-version –––

--- a/test/clt-tests/installation/exceptions-stopwords-wordforms-validation-release-to-dev.rec
+++ b/test/clt-tests/installation/exceptions-stopwords-wordforms-validation-release-to-dev.rec
@@ -1,28 +1,7 @@
-––– input –––
-yum install -y --skip-broken mariadb mariadb105 which > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-yum install -y -q https://repo.manticoresearch.com/manticore-repo.noarch.rpm > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-yum install -y -q manticore manticore-extra > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-yum install -y -q binutils > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-manticore-executor -v
-––– output –––
-PHP %{SEMVER} (cli) (built: #!/[a-zA-Z]{3}/!# #!/[0-9]+/!# %{YEAR} %{TIME}) (ZTS)
-Copyright (c) The PHP Group
-Zend Engine #!/v[0-9]+\.[0-9]+\.[0-9]+/!#, Copyright (c) Zend Technologies
+––– block: manticore-and-packages-installation –––
 ––– block: start-searchd-release –––
 ––– block: check-version/export-current-version –––
-––– block: check-version/ex-sw-wf –––
+––– block: ex-sw-wf –––
 ––– input –––
 yum -y --enablerepo manticore-dev update manticore manticore-extra manticore-common manticore-server manticore-server-core manticore-tools manticore-executor manticore-buddy manticore-backup manticore-columnar-lib manticore-server-core-debuginfo manticore-tools-debuginfo manticore-columnar-lib-debuginfo  manticore-icudata manticore-galera > /dev/null 2>&1; echo $?
 ––– output –––

--- a/test/clt-tests/installation/manticore-and-packages-installation.recb
+++ b/test/clt-tests/installation/manticore-and-packages-installation.recb
@@ -1,0 +1,22 @@
+––– input –––
+yum install -y --skip-broken mariadb mariadb105 which > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yum install -y -q https://repo.manticoresearch.com/manticore-repo.noarch.rpm > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yum install -y -q manticore manticore-extra > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yum install -y -q binutils > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+manticore-executor -v
+––– output –––
+PHP %{SEMVER} (cli) (built: #!/[a-zA-Z]{3}/!# #!/[0-9]+/!# %{YEAR} %{TIME}) (ZTS)
+Copyright (c) The PHP Group
+Zend Engine #!/v[0-9]+\.[0-9]+\.[0-9]+/!#, Copyright (c) Zend Technologies

--- a/test/clt-tests/installation/manticore-and-packages-installation.recb
+++ b/test/clt-tests/installation/manticore-and-packages-installation.recb
@@ -15,6 +15,10 @@ yum install -y -q binutils > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––
+yum install -y procps > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
 manticore-executor -v
 ––– output –––
 PHP %{SEMVER} (cli) (built: #!/[a-zA-Z]{3}/!# #!/[0-9]+/!# %{YEAR} %{TIME}) (ZTS)

--- a/test/clt-tests/installation/rhel-dev-update.rec
+++ b/test/clt-tests/installation/rhel-dev-update.rec
@@ -1,21 +1,4 @@
-––– input –––
-yum install -y --skip-broken mariadb mariadb105 which procps binutils > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-yum install -y -q https://repo.manticoresearch.com/manticore-repo.noarch.rpm > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-yum install -y -q manticore manticore-extra > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-manticore-executor -v
-––– output –––
-PHP %{SEMVER} (cli) (built: #!/[a-zA-Z]{3}/!# #!/[0-9]+/!# %{YEAR} %{TIME}) (ZTS)
-Copyright (c) The PHP Group
-Zend Engine #!/v[0-9]+\.[0-9]+\.[0-9]+/!#, Copyright (c) Zend Technologies
+––– block: manticore-and-packages-installation –––
 ––– block: start-searchd-release –––
 ––– block: check-searchd-process –––
 ––– block: check-backup –––

--- a/test/clt-tests/installation/start-searchd-dev.recb
+++ b/test/clt-tests/installation/start-searchd-dev.recb
@@ -1,34 +1,36 @@
 ––– input –––
 mkdir -p /var/run/manticore
-––– output –––
 ––– input –––
-sleep 5; searchd
+sleep 5; searchd | head -n 9
+––– output –––
+[#!/[a-zA-Z]{3}\s[a-zA-Z]{3}\s+[0-9]{1,2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s[0-9]{4}/!#] [%{NUMBER}] using config file '/etc/manticoresearch/manticore.conf' (%{NUMBER} chars)...
+Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
+Copyright (c) 2001-2016, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
+starting daemon version '%{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})' ...
+listening on %{IPADDR}:9312 for sphinx and http(s)
+listening on %{IPADDR}:9306 for mysql
+––– input –––
+rm /var/log/manticore/searchd.log; searchd --stopwait; searchd | head -n 15; if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; fi
 ––– output –––
 Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
 Copyright (c) 2001-2016, Andrew Aksyonoff
 Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
 Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
-[#!/[0-9]{2}:[0-9]{2}.[0-9]{3}/!#] [#!/[0-9]+/!#] using config file '/etc/manticoresearch/manticore.conf' (%{NUMBER} chars)...
+[#!/[0-9]{2}:[0-9]{2}.[0-9]{3}/!#] [%{NUMBER}] using config file '/etc/manticoresearch/manticore.conf' (%{NUMBER} chars)...
+[#!/[0-9]{2}:[0-9]{2}.[0-9]{3}/!#] [%{NUMBER}] stop: successfully sent SIGTERM to pid %{NUMBER}
+[#!/[a-zA-Z]{3}\s[a-zA-Z]{3}\s+[0-9]{1,2}\s[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s[0-9]{4}/!#] [%{NUMBER}] using config file '/etc/manticoresearch/manticore.conf' (%{NUMBER} chars)...
+Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
+Copyright (c) 2001-2016, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
 starting daemon version '%{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})' ...
 listening on %{IPADDR}:9312 for sphinx and http(s)
 listening on %{IPADDR}:9306 for mysql
 listening on %{IPADDR}:9308 for sphinx and http(s)
-––– input –––
-rm /var/log/manticore/searchd.log; searchd --stopwait; searchd; if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; fi
-––– output –––
 Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
 Copyright (c) 2001-2016, Andrew Aksyonoff
 Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
 Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
-[#!/[0-9]{2}:[0-9]{2}.[0-9]{3}/!#] [#!/[0-9]+/!#] using config file '/etc/manticoresearch/manticore.conf' (%{NUMBER} chars)...
-[#!/[0-9]{2}:[0-9]{2}.[0-9]{3}/!#] [#!/[0-9]+/!#] stop: successfully sent SIGTERM to pid %{NUMBER}
-Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
-Copyright (c) 2001-2016, Andrew Aksyonoff
-Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
-Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
-[#!/[0-9]{2}:[0-9]{2}.[0-9]{3}/!#] [#!/[0-9]+/!#] using config file '/etc/manticoresearch/manticore.conf' (%{NUMBER} chars)...
-starting daemon version '%{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})' ...
-listening on %{IPADDR}:9312 for sphinx and http(s)
-listening on %{IPADDR}:9306 for mysql
-listening on %{IPADDR}:9308 for sphinx and http(s)
 Buddy started!


### PR DESCRIPTION
Created test/clt-tests/installation/exceptions-stopwords-wordforms-validation-release-to-dev.rec to verify that there are no errors and no errors and warnings when using exceptions, stopwords and wordforms, after migrating from release version to dev