### PR TITLE
Revert "use 64-bit memory limit for SI builder"

### DIFF
--- a/cmake/GetColumnar.cmake
+++ b/cmake/GetColumnar.cmake
@@ -19,7 +19,7 @@ include ( update_bundle )
 
 # Versions of API headers we are need to build with.
 set ( NEED_COLUMNAR_API 25 )
-set ( NEED_SECONDARY_API 15 )
+set ( NEED_SECONDARY_API 14 )
 set ( NEED_KNN_API 3 )
 
 # Note: we don't build, neither link with columnar. Only thing we expect to get is a few interface headers, aka 'columnar_api'.

--- a/src/secondaryindex.cpp
+++ b/src/secondaryindex.cpp
@@ -1416,7 +1416,7 @@ static void GetAttrsProxy ( const ISphSchema & tSchema, common::Schema_t & tSISc
 }
 
 
-std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int64_t iMemoryLimit, const CSphSchema & tSchema, CSphBitvec & tSIAttrs, const CSphString & sFile, int iBufferSize, CSphString & sError )
+std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int iMemoryLimit, const CSphSchema & tSchema, CSphBitvec & tSIAttrs, const CSphString & sFile, int iBufferSize, CSphString & sError )
 {
 	common::Schema_t tSISchema;
 	ConvertSchema ( tSchema, tSISchema, tSIAttrs );
@@ -1424,7 +1424,7 @@ std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int64_t iMemoryLimit, const 
 }
 
 
-std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int64_t iMemoryLimit, const CSphSchema & tSchema, const CSphString & sFile, CSphVector<PlainOrColumnar_t> & dAttrs, int iBufferSize, CSphString & sError )
+std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int iMemoryLimit, const CSphSchema & tSchema, const CSphString & sFile, CSphVector<PlainOrColumnar_t> & dAttrs, int iBufferSize, CSphString & sError )
 {
 	common::Schema_t tSISchema;
 	CSphBitvec tSIAttrs ( tSchema.GetAttrsCount() );

--- a/src/secondaryindex.h
+++ b/src/secondaryindex.h
@@ -57,8 +57,8 @@ using RowIteratorsWithEstimates_t = CSphVector<std::pair<RowidIterator_i *,int64
 
 RowIteratorsWithEstimates_t CreateSecondaryIndexIterator ( const SI::Index_i * pSIIndex, CSphVector<SecondaryIndexInfo_t> & dSIInfo, const CSphVector<CSphFilterSettings> & dFilters, ESphCollation eCollation, const ISphSchema & tSchema, RowID_t uRowsCount, int iCutoff );
 
-std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int64_t iMemoryLimit, const CSphSchema & tSchema, CSphBitvec & tSIAttrs, const CSphString & sFile, int iBufferSize, CSphString & sError );
-std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int64_t iMemoryLimit, const CSphSchema & tSchema, const CSphString & sFile, CSphVector<PlainOrColumnar_t> & dAttrs, int iBufferSize, CSphString & sError );
+std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int iMemoryLimit, const CSphSchema & tSchema, CSphBitvec & tSIAttrs, const CSphString & sFile, int iBufferSize, CSphString & sError );
+std::unique_ptr<SI::Builder_i> CreateIndexBuilder ( int iMemoryLimit, const CSphSchema & tSchema, const CSphString & sFile, CSphVector<PlainOrColumnar_t> & dAttrs, int iBufferSize, CSphString & sError );
 
 void BuildStoreSI ( RowID_t tRowID, const CSphRowitem * pRow, const BYTE * pPool, CSphVector<ScopedTypedIterator_t> & dIterators, const CSphVector<PlainOrColumnar_t> & dAttrs, SI::Builder_i * pBuilder, CSphVector<int64_t> & dTmp );
 

--- a/src/secondarylib.cpp
+++ b/src/secondarylib.cpp
@@ -21,7 +21,7 @@ using CheckStorage_fn =			void (*) ( const std::string & sFilename, uint32_t uNu
 using VersionStr_fn =			const char * (*)();
 using GetVersion_fn	=			int (*)();
 using CreateSI_fn =				SI::Index_i * (*) ( const char * sFile, std::string & sError );
-using CreateBuilder_fn =		SI::Builder_i *	(*) ( const common::Schema_t & tSchema, size_t tMemoryLimit, const std::string & sFile, size_t tBufferSize, std::string & sError );
+using CreateBuilder_fn =		SI::Builder_i *	(*) ( const common::Schema_t & tSchema, int iMemoryLimit, const std::string & sFile, size_t tBufferSize, std::string & sError );
 
 static void *					g_pSecondaryLib = nullptr;
 static VersionStr_fn			g_fnVersionStr = nullptr;
@@ -126,7 +126,7 @@ SI::Index_i * CreateSecondaryIndex ( const char * sFile, CSphString & sError )
 	return pSIdx;
 }
 
-std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int64_t iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError )
+std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError )
 {
 	if ( !IsSecondaryLibLoaded() )
 	{

--- a/src/secondarylib.h
+++ b/src/secondarylib.h
@@ -23,7 +23,7 @@ const char *	GetSecondaryVersionStr();
 bool			IsSecondaryLibLoaded();
 
 SI::Index_i *		CreateSecondaryIndex ( const char * sFile, CSphString & sError );
-std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int64_t iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError );
+std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError );
 
 enum class SIDefault_e
 {


### PR DESCRIPTION
This reverts commit d3e2a27eedfcd633ce9c95179412b6cfbdba3fea, so other pull requests can be completed.