### PR TITLE
🆕 Update backup version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,4 +1,4 @@
-backup 1.3.7 24051704 f4b6c03
+backup 1.3.9 24052309 fa1fecd
 buddy 2.3.9 24052109 f22b4f9
 mcl 2.2.5 24051705 b41a4fc
 executor 1.1.5 24052203 c55bc2b


### PR DESCRIPTION
Update [backup](https://github.com/manticoresoftware/manticoresearch-backup) version to: 1.3.9 24052309 fa1fecd which includes:

[`fa1fecd`](https://github.com/manticoresoftware/manticoresearch-backup/commit/fa1fecdf149e60248b47e1acfe64cf23d9c83fee) Bumped version to 1.3.9 (dev)
[`ba02936`](https://github.com/manticoresoftware/manticoresearch-backup/commit/ba02936bfe01a235d3796103a69cd3abf0b72a9c) Update tests due to latest change in the date for columnar version
[`680c83f`](https://github.com/manticoresoftware/manticoresearch-backup/commit/680c83f52fe717e3960189c0662ac4834119e128) Uncomment important env for release
