### PR TITLE
🆕 Update executor version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,7 +1,7 @@
 backup 1.3.9 24052309 fa1fecd
 buddy 2.3.11 24052907 e498b67
 mcl 2.3.1 24052309 4383a90
-executor 1.1.7 24052309 460c43e
+executor 1.1.9 24053109 0844fba
 tzdata 1.0.1 240523 e65e94d
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [executor](https://github.com/manticoresoftware/executor) version to: 1.1.9 24053109 0844fba which includes:

[`0844fba`](https://github.com/manticoresoftware/executor/commit/0844fba1c887110b2c455ff1e8ec897c0bf5236a) Revert "Remove QEMU and use native arm64 with buildx to build linux arm64 packages"
[`f7cc2b8`](https://github.com/manticoresoftware/executor/commit/f7cc2b8e9a55e8c5c49db0198bc877523fbb962f) Improve action logging and move back to ubuntu instead of osx due to M1 does not support nested virtualization
[`2b6b53e`](https://github.com/manticoresoftware/executor/commit/2b6b53eac46f768584893129d1bc19d30c0910ba) Remove QEMU and use native arm64 with buildx to build linux arm64 packages
[`abdd4ea`](https://github.com/manticoresoftware/executor/commit/abdd4eae9ebc97b73267bc945ff4279e308996a6) Use auto-pr by using new action
