### PR TITLE
🆕 Update mcl version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.3.9 24052309 fa1fecd
 buddy 2.3.11 24060410 f944ba8
-mcl 2.3.1 24052309 4383a90
+mcl 2.3.1 24060612 89ed74a
 executor 1.1.9 24053109 0844fba
 tzdata 1.0.1 240531 fbae2c1
 ---


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version to: 2.3.1 24060612 89ed74a which includes:

[`89ed74a`](https://github.com/manticoresoftware/columnar/commit/89ed74a3d767a4a9dfdfe20d7c954fbc36c5ab72) fixed a crash on mismatched filter/SI type
[`db4fcac`](https://github.com/manticoresoftware/columnar/commit/db4fcacc9b9ba8abab1323fc52f1497702857fe2) Updated issue templates (#64)
