### PR TITLE
🆕 Update executor version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,7 +1,7 @@
 backup 1.3.9 24070908 cce9fdb
 buddy 2.3.13 24071113 280df64
 mcl 2.3.1 24070110 42f2b06
-executor 1.1.11 24060610 e384f40
+executor 1.1.12 24071807 0565a65
 tzdata 1.0.1 240531 fbae2c1
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [executor](https://github.com/manticoresoftware/executor) version to: 1.1.12 24071807 0565a65 which includes:

[`0565a65`](https://github.com/manticoresoftware/executor/commit/0565a65cf09ddfe55563ee76e09816bc9638df64) updated versions in release.yml
[`64b3243`](https://github.com/manticoresoftware/executor/commit/64b3243b61797761bc49a70627a90eaf1145584a) CI: do not publish release in GitHub releases, keep it a draft
