### PR TITLE
fix: table DDL reflection with special chars in settings

### DIFF
--- a/src/indexing_sources/source_sql.h
+++ b/src/indexing_sources/source_sql.h
@@ -26,14 +26,6 @@ enum ESphUnpackFormat
 	SPH_UNPACK_MYSQL_COMPRESS	= 2
 };
 
-struct SqlQuotator_t
-{
-	static constexpr BYTE EscapingSpace ( BYTE c )
-	{
-		return ( c == '\\' || c == '\'' || c == '\t' ) ? 1 : 0;
-	}
-};
-
 using SqlEscapedBuilder_c = EscapedStringBuilder_T<BaseQuotation_T<SqlQuotator_t>>;
 
 struct CSphUnpackInfo

--- a/src/sphinxsort.cpp
+++ b/src/sphinxsort.cpp
@@ -686,14 +686,6 @@ void SendSqlSchema ( const ISphSchema& tSchema, RowBuffer_i* pRows, const VecTra
 	pRows->HeadEnd ( false, 0 );
 }
 
-struct SqlQuotator_t
-{
-	static constexpr BYTE EscapingSpace ( BYTE c )
-	{
-		return ( c == '\\' || c == '\'' || c == '\t' ) ? 1 : 0;
-	}
-};
-
 using SqlEscapedBuilder_c = EscapedStringBuilder_T<BaseQuotation_T<SqlQuotator_t>>;
 
 void SendSqlMatch ( const ISphSchema& tSchema, RowBuffer_i* pRows, CSphMatch& tMatch, const BYTE* pBlobPool, const VecTraits_T<int>& dOrder, bool bDynamicDocid )

--- a/src/std/escaped_builder.h
+++ b/src/std/escaped_builder.h
@@ -29,6 +29,14 @@ struct EscapeQuotator_t
 	}
 };
 
+struct SqlQuotator_t
+{
+	static constexpr BYTE EscapingSpace ( BYTE c )
+	{
+		return ( c == '\\' || c == '\'' || c == '\t' ) ? 1 : 0;
+	}
+};
+
 struct FixupSpace_t
 {
 	// replaces \t, \n, \r into spaces


### PR DESCRIPTION
**Type of Change:** Bug fix 


**Description of the Change:**
- add support for escaping in settings formatter
- use escaping for DDL reflection

**Related Issue:**
Fixes #1107 

PS: Sorry, I'm not familiar with your testing suite and couldn't find documentation on writing tests.