### PR TITLE
Created tests for declaring duplicate attributes or fields

### DIFF
--- a/test/clt-tests/base/searchd-without-table-details.recb
+++ b/test/clt-tests/base/searchd-without-table-details.recb
@@ -1,7 +1,7 @@
 ––– input –––
 rm -f /var/log/manticore/searchd.log; searchd --stopwait > /dev/null; searchd | grep -v precach; if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; cat /var/log/manticore/searchd.log;fi
 ––– output –––
-[#!/[A-Za-z]{3}\s+[A-Za-z]{3}\s+[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\s+[0-9]{4}/!#] [%{NUMBER}] using config file '%{PATH}' (%{NUMBER} chars)...
+[#!/[A-Za-z]{3}\s+[A-Za-z]{3}\s+[0-9]{1,2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\s+[0-9]{4}/!#] [%{NUMBER}] using config file '%{PATH}' (%{NUMBER} chars)...
 Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
 Copyright (c) 2001-2016, Andrew Aksyonoff
 Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)

--- a/test/clt-tests/core/test-declaration-of-duplicate-attributes.rec
+++ b/test/clt-tests/core/test-declaration-of-duplicate-attributes.rec
@@ -1,0 +1,21 @@
+––– input –––
+echo '<?xml version="1.0" encoding="utf-8"?><sphinx:docset xmlns:sphinx="http://sphinxsearch.com/"><sphinx:schema><sphinx:attr name="a" type="int" /><sphinx:attr name="a" type="string" /></sphinx:schema><sphinx:document id="10"><a>1</a><a>a</a></sphinx:document></sphinx:docset>' > /tmp/xml
+––– output –––
+––– input –––
+echo -e "source min {\n  type = xmlpipe2\n  xmlpipe_command = cat /tmp/xml\n}\n\nindex idx {\n  path = /tmp/idx\n  source = min\n}" > /tmp/xml_crash.conf
+––– output –––
+––– input –––
+indexer -c /tmp/xml_crash.conf --all
+––– output –––
+Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
+Copyright (c) 2001-2016, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
+using config file '/tmp/xml_crash.conf'...
+indexing table 'idx'...
+WARNING: duplicate attribute node <a> - using first value
+ERROR: table 'idx': source 'min': attribute 'a' is added twice (line=1, pos=143, docid=0).
+total 0 docs, 0 bytes
+total #!/[0-9]+\.[0-9]+/!# sec, 0 bytes/sec, 0.00 docs/sec
+total 0 reads, 0.000 sec, 0.0 kb/call avg, 0.0 msec/call avg
+total 0 writes, 0.000 sec, 0.0 kb/call avg, 0.0 msec/call avg

--- a/test/clt-tests/core/test-declaration-of-duplicate-fields.rec
+++ b/test/clt-tests/core/test-declaration-of-duplicate-fields.rec
@@ -1,0 +1,20 @@
+––– input –––
+echo '<?xml version="1.0" encoding="utf-8"?><sphinx:docset xmlns:sphinx="http://sphinxsearch.com/"><sphinx:schema><sphinx:field name="title"/><sphinx:field name="title"/><sphinx:attr name="a" type="string" /></sphinx:schema><sphinx:document id="10"><title>b</title><title>c</title><a>a</a></sphinx:document></sphinx:docset>' > /tmp/xml
+––– output –––
+––– input –––
+echo -e "source min {\n  type = xmlpipe2\n  xmlpipe_command = cat /tmp/xml\n}\n\nindex idx {\n  path = /tmp/idx\n  source = min\n}" > /tmp/xml_crash.conf
+––– output –––
+––– input –––
+indexer -c /tmp/xml_crash.conf --all
+––– output –––
+Manticore %{SEMVER} %{COMMITDATE}#!/(\sdev)?\s/!#(columnar %{SEMVER} %{COMMITDATE}) (secondary %{SEMVER} %{COMMITDATE}) (knn %{SEMVER} %{COMMITDATE})
+Copyright (c) 2001-2016, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+Copyright (c) 2017-%{YEAR}, Manticore Software LTD (https://manticoresearch.com)
+using config file '/tmp/xml_crash.conf'...
+indexing table 'idx'...
+ERROR: table 'idx': source 'min': field 'title' is added twice (line=1, pos=136, docid=0).
+total 0 docs, 0 bytes
+total #!/[0-9]+\.[0-9]+/!# sec, 0 bytes/sec, 0.00 docs/sec
+total 0 reads, 0.000 sec, 0.0 kb/call avg, 0.0 msec/call avg
+total 0 writes, 0.000 sec, 0.0 kb/call avg, 0.0 msec/call avg


### PR DESCRIPTION
**Type of Change:** 
- Bug fix - added tests for declaring duplicate attributes or fields 

**Description of the Change:** 
- When duplicate attributes or fields are used, the indexer terminates with an error message, but does not crash. 

**Related Issue (provide the link):** 
https://github.com/manticoresoftware/manticoresearch/issues/2460