### PR TITLE
min_infix_len to fuzzy/autocomplete 

### DIFF
--- a/test/clt-tests/buddy/test-fuzzy-search-negative.rec
+++ b/test/clt-tests/buddy/test-fuzzy-search-negative.rec
@@ -17,16 +17,44 @@ ERROR 1064 (42000) at line 1: P01: syntax error, unexpected '-' near '-1'
 ––– input –––
 mysql -h0 -P9306 -e "SELECT * FROM name WHERE MATCH('SMITH') OPTION fuzzy='0';"
 ––– output –––
-ERROR 1064 (42000) at line 1: unknown option 'fuzzy'
+ERROR 1064 (42000) at line 1: Fuzzy plugin requires min_infix_len to be set
 ––– input –––
 mysql -h0 -P9306 -e "SELECT * FROM name WHERE MATCH('SMYTH') OPTION fuzzy='2';"
 ––– output –––
-ERROR 1064 (42000) at line 1: unknown option 'fuzzy'
+ERROR 1064 (42000) at line 1: Fuzzy plugin requires min_infix_len to be set
 ––– input –––
 mysql -h0 -P9306 -e "SELECT * FROM name WHERE MATCH('john') OPTION fuzzy=a;"
 ––– output –––
-ERROR 1064 (42000) at line 1: unknown option 'fuzzy'
+ERROR 1064 (42000) at line 1: Fuzzy plugin requires min_infix_len to be set
 ––– input –––
 mysql -h0 -P9306 -e "SELECT * FROM name WHERE MATCH('jane') OPTION fuzzy=@;"
 ––– output –––
-ERROR 1064 (42000) at line 1: unknown option 'fuzzy'
+ERROR 1064 (42000) at line 1: Fuzzy plugin requires min_infix_len to be set
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('j', 'name', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Autocomplete plugin requires min_infix_len to be set
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE(123, 'name', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Something went wrong
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('', 'name', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Something went wrong
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('@#$', 'name', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Autocomplete plugin requires min_infix_len to be set
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('thisisaverylonginputstring', 'name', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Autocomplete plugin requires min_infix_len to be set
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('jo', 'non_existing_table', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: no such table 'non_existing_table'
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('jo', 'name', 123 AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Autocomplete plugin requires min_infix_len to be set

--- a/test/clt-tests/buddy/test-fuzzy-search-non-min-infix-len.rec
+++ b/test/clt-tests/buddy/test-fuzzy-search-non-min-infix-len.rec
@@ -1,0 +1,21 @@
+––– block: ../base/start-searchd –––
+––– input –––
+mysql -h0 -P9306 -e "create table test (id bigint, value text);"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('jo', 'test', 'us' AS layouts);"
+––– output –––
+ERROR 1064 (42000) at line 1: Autocomplete plugin requires min_infix_len to be set
+––– input –––
+mysql -h0 -P9306 -e "SELECT * FROM test WHERE MATCH('RICH') OPTION fuzzy=1;"
+––– output –––
+ERROR 1064 (42000) at line 1: Fuzzy plugin requires min_infix_len to be set
+––– input –––
+mysql -h0 -P9306 -e "ALTER TABLE test min_infix_len='2';"
+––– output –––
+––– input –––
+sleep 30; mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('jo', 'test', 'us' AS layouts);"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SELECT * FROM test WHERE MATCH('RICH') OPTION fuzzy=1;"
+––– output –––

--- a/test/clt-tests/buddy/test-fuzzy-search.rec
+++ b/test/clt-tests/buddy/test-fuzzy-search.rec
@@ -1,7 +1,11 @@
 ––– block: ../base/start-searchd –––
 ––– input –––
-php -d memory_limit=-1 ./test/clt-tests/scripts/load_us_names.php 1000 10 1000000 5 > /dev/null
+php -d memory_limit=-1 ./test/clt-tests/scripts/load_us_names.php 1000 10 1000000 5 2 > /dev/null
 ––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SHOW CREATE TABLE name;" | grep "min_infix_len='2'" | sed "s/.*\(min_infix_len='2'\).*/\1/"
+––– output –––
+min_infix_len='2'
 ––– input –––
 mysql -h0 -P9306 -e "SELECT COUNT(*) FROM name;"
 ––– output –––

--- a/test/clt-tests/scripts/load_us_names.php
+++ b/test/clt-tests/scripts/load_us_names.php
@@ -1,6 +1,6 @@
 #!/usr/bin/php
 <?php
-if (count($argv) < 5) die("Usage: ".__FILE__." <batch size> <concurrency> <docs> <multiplier>\n");
+if (count($argv) < 5) die("Usage: ".__FILE__." <batch size> <concurrency> <docs> <multiplier> [min_infix_len]\n");
 
 function connectDb() {
     $host = '127.0.0.1';
@@ -30,7 +30,11 @@ for ($i = 0; $i < $argv[2]; $i++) {
 // init
 $pdo = $all_links[0];
 mysqli_query($pdo, "DROP TABLE IF EXISTS name");
-mysqli_query($pdo, "CREATE TABLE name(id INTEGER, username TEXT) min_infix_len='2' expand_keywords='1'");
+
+// Определение значения min_infix_len из аргумента командной строки
+$min_infix_len = isset($argv[5]) ? "min_infix_len='" . intval($argv[5]) . "'" : "";
+
+mysqli_query($pdo, "CREATE TABLE name(id INTEGER, username TEXT) $min_infix_len expand_keywords='1'");
 
 $batch = [];
 $query_start = "INSERT INTO name(id, username) VALUES ";


### PR DESCRIPTION
**Type of Change:**
- New feature - The test checks the min_infix_len setting for the autocomplete and fuzzy search plugins in Manticore Search to ensure that these features work correctly.

**Description of the Change:**
- If the `min_infix_len` parameter is not set, autocomplete and fuzzy search plugins will not work correctly and will display an error. This parameter is needed to determine when to enable infix (internal) word search.

**Related Issue (provide the link):**
https://github.com/manticoresoftware/manticoresearch-buddy/issues/330