### PR TITLE
🆕 Update executor version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,7 +1,7 @@
 backup 1.3.9 24090411 cce9fdb
 buddy 2.3.13 24091210 8e52233
 mcl 2.3.1 24090411 f9ef8b9
-executor 1.1.15 24090517 10e9c4c
+executor 1.1.17 24091806 cb8ad69
 tzdata 1.0.1 240904 3ba592a
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [executor](https://github.com/manticoresoftware/executor) version to: 1.1.17 24091806 cb8ad69 which includes:

[`cb8ad69`](https://github.com/manticoresoftware/executor/commit/cb8ad698d3d8475da590cc153f0f068c26f8dd80) Fix issue with arm64 for osx
[`ab461ef`](https://github.com/manticoresoftware/executor/commit/ab461ef812696d13382d6667dc837fdd2ee71c19) Reapply "Publish arm64 osx package also cuz we build it in CI" (#63)
