### PR TITLE
Perf json sql recovery

### DIFF
--- a/test/clt-tests/buddy/test-fuzzy-search-negative.rec
+++ b/test/clt-tests/buddy/test-fuzzy-search-negative.rec
@@ -1,6 +1,6 @@
 ––– block: ../base/start-searchd –––
 ––– input –––
-php -d memory_limit=-1 ./test/clt-tests/scripts/load_us_names.php 1000 10 1000000 5 > /dev/null
+php -d memory_limit=-1 ./test/clt-tests/scripts/load_us_names_min_infix_len.php 1000 10 1000000 5 > /dev/null
 ––– output –––
 ––– input –––
 mysql -h0 -P9306 -e "SELECT COUNT(*) FROM name;"

--- a/test/clt-tests/buddy/test-fuzzy-search.rec
+++ b/test/clt-tests/buddy/test-fuzzy-search.rec
@@ -1,6 +1,6 @@
 ––– block: ../base/start-searchd –––
 ––– input –––
-php -d memory_limit=-1 ./test/clt-tests/scripts/load_us_names.php 1000 10 1000000 5 2 > /dev/null
+php -d memory_limit=-1 ./test/clt-tests/scripts/load_us_names_min_infix_len.php 1000 10 1000000 5 2 > /dev/null
 ––– output –––
 ––– input –––
 mysql -h0 -P9306 -e "SHOW CREATE TABLE name;" | grep "min_infix_len='2'" | sed "s/.*\(min_infix_len='2'\).*/\1/"

--- a/test/clt-tests/scripts/load_us_names_min_infix_len.php
+++ b/test/clt-tests/scripts/load_us_names_min_infix_len.php
@@ -1,6 +1,6 @@
 #!/usr/bin/php
 <?php
-if (count($argv) < 5) die("Usage: ".__FILE__." <batch size> <concurrency> <docs> <multiplier>\n");
+if (count($argv) < 5) die("Usage: ".__FILE__." <batch size> <concurrency> <docs> <multiplier> [min_infix_len]\n");
 
 function connectDb() {
     $host = '127.0.0.1';
@@ -30,7 +30,11 @@ for ($i = 0; $i < $argv[2]; $i++) {
 // init
 $pdo = $all_links[0];
 mysqli_query($pdo, "DROP TABLE IF EXISTS name");
-mysqli_query($pdo, "CREATE TABLE name(id INTEGER, username TEXT) min_infix_len='2' expand_keywords='1'");
+
+// Defining the value of min_infix_len from a command line argument
+$min_infix_len = isset($argv[5]) ? "min_infix_len='" . intval($argv[5]) . "'" : "";
+
+mysqli_query($pdo, "CREATE TABLE name(id INTEGER, username TEXT) $min_infix_len expand_keywords='1'");
 
 $batch = [];
 $query_start = "INSERT INTO name(id, username) VALUES ";


### PR DESCRIPTION
Restore past version of files to pass performance tests correctly. 
Fixes load_us_names.php script without min_infix_len setting.