### PR TITLE
Fix compilation failiure on older GCC

### DIFF
--- a/src/replication/wsrep_cxx_int.h
+++ b/src/replication/wsrep_cxx_int.h
@@ -98,7 +98,7 @@ extern std::atomic<uint64_t> uWritesetConnIds;
 template<typename WSREPWRAP>
 class Writeset_T final: public Wsrep::Writeset_i
 {
-	using Status_e = typename WSREPWRAP::Status_e;
+	using Status_e = typename WSREPWRAP::Status_e_;
 	CSphRefcountedPtr<WSREPWRAP> m_pWsrep;
 	uint64_t m_uConnId;
 	Wsrep::TrxMeta_t m_tMeta;
@@ -234,7 +234,7 @@ template<typename WSREPWRAP>
 class Provider_T: public Wsrep::Provider_i
 {
 protected:
-	using Status_e = typename WSREPWRAP::Status_e;
+	using Status_e = typename WSREPWRAP::Status_e_;
 	CSphRefcountedPtr<WSREPWRAP> m_pWsrep;
 	Wsrep::Cluster_i* m_pCluster;
 	Wsrep::ReceiverRefPtr_c m_pReceiver;

--- a/src/replication/wsrep_v25.cpp
+++ b/src/replication/wsrep_v25.cpp
@@ -356,7 +356,7 @@ struct WrappedWsrep_t final : public ISphRefcountedMT
 	}
 
 public:
-	using Status_e = Status_e;
+	using Status_e_ = Status_e;
 	inline static const char* szGetStatus ( Status_e eStatus ) noexcept
 	{
 		return GetStatus ( eStatus );

--- a/src/replication/wsrep_v31.cpp
+++ b/src/replication/wsrep_v31.cpp
@@ -415,7 +415,7 @@ struct WrappedWsrep_t final : public ISphRefcountedMT
 	}
 
 public:
-	using Status_e = Status_e;
+	using Status_e_ = Status_e;
 	inline static const char* szGetStatus ( Status_e eStatus ) noexcept
 	{
 		return GetStatus ( eStatus );


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Description of the Change:**

GCC prior to 13 doesn't support exporting a type with the same name: https://godbolt.org/z/8GWsqec6r  
GCC 13 and later allows it, but will emit a warning.

This change renames the exported `Status_e` to avoid this conflict, and fixes #2393  
With this change, I'm able to successfully compile Manticoresearch Git on GCC 11.4

**Related Issue (provide the link):** https://github.com/manticoresoftware/manticoresearch/issues/2393
