### PR TITLE
Test/fix requests with knn

### DIFF
--- a/test/clt-tests/core/test-equests-with-knn.rec
+++ b/test/clt-tests/core/test-equests-with-knn.rec
@@ -1,13 +1,16 @@
 ––– block: ../base/start-searchd –––
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE knn_test (id BIGINT, model TEXT, vector float_vector)"
+mysql -h0 -P9306 -e "CREATE TABLE knn_test (id BIGINT, model TEXT, vector float_vector)"; echo $?
 ––– output –––
+0
 ––– input –––
-mysql -h0 -P9306 -e "INSERT INTO knn_test (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"
+mysql -h0 -P9306 -e "INSERT INTO knn_test (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"; echo $?
 ––– output –––
+0
 ––– input –––
-mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test WHERE knn(vector, 10, 1)"
+mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test WHERE knn(vector, 10, 1)"; echo $?
 ––– output –––
+0
 ––– input –––
 mysql -h0 -P9306 -e "SHOW CREATE TABLE knn_test"
 ––– output –––
@@ -21,11 +24,13 @@ vector float_vector
 ) |
 +----------+----------------------------------------------------------------------+
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE knn_test2 (id BIGINT, model TEXT, vector float_vector)"
+mysql -h0 -P9306 -e "CREATE TABLE knn_test2 (id BIGINT, model TEXT, vector float_vector)"; echo $?
 ––– output –––
+0
 ––– input –––
-mysql -h0 -P9306 -e "INSERT INTO knn_test2 (id, model, vector) VALUES (1, 'Model_1', (0.286569,-0.031816,0.066684,0.032926))"
+mysql -h0 -P9306 -e "INSERT INTO knn_test2 (id, model, vector) VALUES (1, 'Model_1', (0.286569,-0.031816,0.066684,0.032926))"; echo $?
 ––– output –––
+0
 ––– input –––
 mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test2 WHERE knn(vector, 10, 1)"
 ––– output –––
@@ -43,14 +48,17 @@ vector float_vector
 ) |
 +-----------+-----------------------------------------------------------------------+
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE knn_test3 (id BIGINT, model TEXT, vector float_vector)"
+mysql -h0 -P9306 -e "CREATE TABLE knn_test3 (id BIGINT, model TEXT, vector float_vector)"; echo $?
 ––– output –––
+0
 ––– input –––
-mysql -h0 -P9306 -e "INSERT INTO knn_test3 (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"
+mysql -h0 -P9306 -e "INSERT INTO knn_test3 (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"; echo $?
 ––– output –––
+0
 ––– input –––
-mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test3 WHERE knn(vector, 10, 1)"
+mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test3 WHERE knn(vector, 10, 1)"; echo $?
 ––– output –––
+0
 ––– input –––
 mysql -h0 -P9306 -e "SHOW CREATE TABLE knn_test3"
 ––– output –––

--- a/test/clt-tests/core/test-equests-with-knn.rec
+++ b/test/clt-tests/core/test-equests-with-knn.rec
@@ -1,0 +1,65 @@
+––– block: ../base/start-searchd –––
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE knn_test (id BIGINT, model TEXT, vector float_vector)"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO knn_test (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test WHERE knn(vector, 10, 1)"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SHOW CREATE TABLE knn_test"
+––– output –––
++----------+----------------------------------------------------------------------+
+| Table    | Create Table                                                         |
++----------+----------------------------------------------------------------------+
+| knn_test | CREATE TABLE knn_test (
+id bigint,
+model text,
+vector float_vector
+) |
++----------+----------------------------------------------------------------------+
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE knn_test2 (id BIGINT, model TEXT, vector float_vector)"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO knn_test2 (id, model, vector) VALUES (1, 'Model_1', (0.286569,-0.031816,0.066684,0.032926))"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test2 WHERE knn(vector, 10, 1)"
+––– output –––
+ERROR 1064 (42000) at line 1: table knn_test2: KNN index not enabled for attribute 'vector'
+––– input –––
+mysql -h0 -P9306 -e "SHOW CREATE TABLE knn_test2"
+––– output –––
++-----------+-----------------------------------------------------------------------+
+| Table     | Create Table                                                          |
++-----------+-----------------------------------------------------------------------+
+| knn_test2 | CREATE TABLE knn_test2 (
+id bigint,
+model text,
+vector float_vector
+) |
++-----------+-----------------------------------------------------------------------+
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE knn_test3 (id BIGINT, model TEXT, vector float_vector)"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO knn_test3 (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test3 WHERE knn(vector, 10, 1)"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "SHOW CREATE TABLE knn_test3"
+––– output –––
++-----------+-----------------------------------------------------------------------+
+| Table     | Create Table                                                          |
++-----------+-----------------------------------------------------------------------+
+| knn_test3 | CREATE TABLE knn_test3 (
+id bigint,
+model text,
+vector float_vector
+) |
++-----------+-----------------------------------------------------------------------+

--- a/test/clt-tests/core/test-equests-with-knn.rec
+++ b/test/clt-tests/core/test-equests-with-knn.rec
@@ -71,3 +71,27 @@ model text,
 vector float_vector
 ) |
 +-----------+-----------------------------------------------------------------------+
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE knn_test4 (id BIGINT, model TEXT, vector int)"; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO knn_test4 (id, model, vector) VALUES (1, 'Model_1', '[0.9012, 0.2126, 0.2879, 0.7552]')"; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SELECT count(*) FROM knn_test4 WHERE knn(vector, 10, 1)"; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SHOW CREATE TABLE knn_test4"
+––– output –––
++-----------+------------------------------------------------------------------+
+| Table     | Create Table                                                     |
++-----------+------------------------------------------------------------------+
+| knn_test4 | CREATE TABLE knn_test4 (
+id bigint,
+model text,
+vector integer
+) |
++-----------+------------------------------------------------------------------+


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Description of the Change:**
A test has been created confirming that:

- The issue with handling a string array when inserting into a float_vector field has been fixed. The system now correctly reports the need to use a numeric array.
- The error message for executing a KNN query on a table with an incorrect structure has been corrected. The system now returns an accurate message indicating the absence of index parameters for the float_vector field.
- The issue with executing KNN queries without explicitly specifying index parameters has been fixed. Previously, when creating a table with a float_vector field without parameters such as knn_type, knn_dims, and hnsw_similarity, KNN queries would return the error “Undefined array key 0”. Now, the system provides a proper message indicating that the indexing parameters must be defined.
- The issue with handling KNN queries when using an int field as the vector field has been addressed. Now, when attempting to execute a KNN query with an int field, the system correctly returns an error indicating the data type mismatch, instead of a message about incorrect return type in the getQueryVectorValue() function.

**Related Issue (provide the link):**
- [Incorrect handling of string array insertion into float_vector field](https://github.com/manticoresoftware/manticoresearch-buddy/issues/367)
- [Incorrect KNN query execution on a table with missing index parameters](https://github.com/manticoresoftware/manticoresearch-buddy/issues/363)
- [Incorrect KNN query execution without specifying index parameters](https://github.com/manticoresoftware/manticoresearch-buddy/issues/368)
- [Incorrect handling of KNN query when using an int field for the vector](https://github.com/manticoresoftware/manticoresearch-buddy/issues/366)