### PR TITLE
fix test-migration-es-ms.rec

### DIFF
--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '00 20 * * *'
   pull_request:
-    branches: [ '*' ]
+    branches: [ master ]
     paths:
       - 'test/clt-tests/migration-es-ms/**'       # trigger when changes are made in migration test files
       - 'test/clt-tests/mysqldump/versions/**'     # trigger when changes are made in mysqldump test files

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.2.3
+      - uses: manticoresoftware/clt@0.2.2
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -5,9 +5,11 @@ on:
   schedule:
     - cron: '00 20 * * *'
   pull_request:
-    branches: [ master ]
+    branches: [ '*' ]
     paths:
-      - 'test/clt-tests/mysqldump/versions/**'
+      - 'test/clt-tests/migration-es-ms/**'       # trigger when changes are made in migration test files
+      - 'test/clt-tests/mysqldump/versions/**'     # trigger when changes are made in mysqldump test files
+      - '.github/workflows/nightly_dumps.yml'      # trigger when changes are made in the workflow config
 
 # cancels the previous workflow run when a new one appears in the same branch (e.g. master or a PR's branch)
 concurrency:
@@ -41,7 +43,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.2.2
+      - uses: manticoresoftware/clt@0.2.3
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -35,49 +35,13 @@ inflating: index_data.json
 elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output=http://localhost:9200/es-index --type=mapping
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source file (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 1 objects to destination elasticsearch, wrote 2
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source file (offset: 1)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 2
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
-––– input –––
-elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=http://localhost:9200/es-index --type=data
-––– output –––
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 0)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 100)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 200)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 300)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 64 objects from source file (offset: 400)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 64 objects to destination elasticsearch, wrote 64
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source file (offset: 464)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 464
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
-––– input –––
-elasticdump --input=http://localhost:9200/es-index --output=http://localhost:9308/ms_index  --type=mapping
-––– output –––
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source elasticsearch (offset: 0)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 1 objects to destination elasticsearch, wrote 2
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source elasticsearch (offset: 1)
-#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 2
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
 ––– input –––
 elasticdump --input=http://localhost:9200/es-index   --output=http://localhost:9308/ms_index --type=data
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 100)

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -35,13 +35,49 @@ inflating: index_data.json
 elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output=http://localhost:9200/es-index --type=mapping
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
+(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source file (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 1 objects to destination elasticsearch, wrote 2
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source file (offset: 1)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 2
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
+––– input –––
+elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=http://localhost:9200/es-index --type=data
+––– output –––
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
+(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 0)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 100)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 200)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 300)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 64 objects from source file (offset: 400)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 64 objects to destination elasticsearch, wrote 64
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source file (offset: 464)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 464
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
+––– input –––
+elasticdump --input=http://localhost:9200/es-index --output=http://localhost:9308/ms_index  --type=mapping
+––– output –––
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
+(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source elasticsearch (offset: 0)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 1 objects to destination elasticsearch, wrote 2
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source elasticsearch (offset: 1)
+#!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 2
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
 ––– input –––
 elasticdump --input=http://localhost:9200/es-index   --output=http://localhost:9308/ms_index --type=data
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
+(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 100)

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -35,8 +35,6 @@ inflating: index_data.json
 elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output=http://localhost:9200/es-index --type=mapping
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source file (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 1 objects to destination elasticsearch, wrote 2
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source file (offset: 1)
@@ -46,8 +44,6 @@ elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output
 elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=http://localhost:9200/es-index --type=data
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 100)
@@ -65,8 +61,6 @@ elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=ht
 elasticdump --input=http://localhost:9200/es-index --output=http://localhost:9308/ms_index  --type=mapping
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source elasticsearch (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 1 objects to destination elasticsearch, wrote 2
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 0 objects from source elasticsearch (offset: 1)
@@ -76,8 +70,6 @@ elasticdump --input=http://localhost:9200/es-index --output=http://localhost:930
 elasticdump --input=http://localhost:9200/es-index   --output=http://localhost:9308/ms_index --type=data
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
-(node:%{NUMBER}) [DEP%{NUMBER}] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 0)
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | sent 100 objects to destination elasticsearch, wrote 100
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 100)


### PR DESCRIPTION
Description of Changes in GitHub Actions

Added configuration for automatic triggering of GitHub Actions in the following cases:
1.	When changes are made to the Elasticsearch/Manticore migration test files:
	•	Path: test/clt-tests/migration-es-ms/**
2.	When changes are made to the mysqldump test files for various versions:
	•	Path: test/clt-tests/mysqldump/versions/**
3.	When changes are made to the workflow configuration:
	•	Path: .github/workflows/nightly_dumps.yml

CLT-test test-migration-es-ms.rec has been updated.
