### PR TITLE
[FIX] broken link to ProxySQL in Introduction.

### DIFF
--- a/manual/Introduction.md
+++ b/manual/Introduction.md
@@ -68,7 +68,7 @@ Manticore is equipped with an external tool [manticore-backup](Securing_and_comp
 The `indexer` tool and comprehensive configuration syntax of Manticore make it easy to sync data from sources like MySQL, PostgreSQL, ODBC-compatible databases, XML, and CSV.
 
 #### Integration options
-You can integrate Manticore Search with a MySQL/MariaDB server using the [FEDERATED engine](Extensions/FEDERATED.md) or via [ProxySQL](https://manticoresearch.com/2018/06/18/using-proxysql-to-route-inserts-in-a-distributed-realtime-index/).
+You can integrate Manticore Search with a MySQL/MariaDB server using the [FEDERATED engine](Extensions/FEDERATED.md) or via [ProxySQL](https://manticoresearch.com/blog/using-proxysql-to-route-inserts-in-a-distributed-realtime-index/).
 
 You can use [Apache Superset](https://manticoresearch.com/blog/manticoresearch-apache-superset-integration/) and [Grafana](https://manticoresearch.com/blog/manticoresearch-grafana-integration/) to visualize data stored in Manticore. Various MySQL tools can be used to develop Manticore queries interactively, such as [HeidiSQL](https://www.heidisql.com/) and [DBForge](https://www.devart.com/dbforge/).
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change :**
- Documentation update

**Description of the Change:**
Corrected the broken link to the ProxySQL documentation, which previously led to a 404 error. This update ensures users have direct access to the correct resource for routing inserts in a distributed real-time index.

**Related Issue (provide the link):**
