### PR TITLE
Kafka integration fixes

### DIFF
--- a/test/clt-tests/integrations/kafka/test-integration-kafka-ms.rec
+++ b/test/clt-tests/integrations/kafka/test-integration-kafka-ms.rec
@@ -626,3 +626,21 @@ docker exec manticore mysql -h0 -P9306 -e "SELECT COUNT(*) FROM destination_drop
 +----------+
 |       57 |
 +----------+
+––– input –––
+docker exec manticore mysql -h0 -P9306 -e "ALTER MATERIALIZED VIEW view_drop_source suspended=1"; echo $?
+––– output –––
+0
+––– input –––
+docker exec manticore mysql -h0 -P9306 -e "ALTER MATERIALIZED VIEW view_drop_source suspended=1"; echo $?
+––– output –––
+ERROR 1064 (42000) at line 1: Selected materialized view has already suspended
+1
+––– input –––
+docker exec manticore mysql -h0 -P9306 -e "ALTER MATERIALIZED VIEW view_drop_source suspended=0"; echo $?
+––– output –––
+0
+––– input –––
+docker exec manticore mysql -h0 -P9306 -e "ALTER MATERIALIZED VIEW view_drop_source suspended=0"; echo $?
+––– output –––
+ERROR 1064 (42000) at line 1: Selected materialized view has already resumed
+1


### PR DESCRIPTION
**Type of Change:**
- Bug fix - In case of multiple requests to start or stop the vorker (e.g. 2-3 starts in a row), the system silently ignores the actions without returning an error to the user. Besides, due to the empty catch(Throwable) block, errors are not processed and logged, which makes diagnostics difficult. The user was not notified about incorrect repeated actions.

**Description of the Change:**
- Updated the CLT test for Kafka, added cases that check that Manticore returns an error when trying to suspend an already suspended materialised view (MV) or resume an already resumed MV. 

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch-buddy/issues/381