### PR TITLE
🆕 Update buddy version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.5.1 24102308 ea34859
-buddy 3.0.1 24121208 04dd8cd
+buddy 3.0.1 24121212 c6f1cde
 mcl 2.3.1 24112219 edadc69
 executor 1.1.23 24111613 dbade9d
 tzdata 1.0.1 240904 3ba592a

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.5.1 24102308 ea34859
-buddy 3.0.1 24121011 b02bf18
+buddy 3.0.1 24121208 04dd8cd
 mcl 2.3.1 24112219 edadc69
 executor 1.1.23 24111613 dbade9d
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version to: 3.0.1 24121212 c6f1cde which includes:

[`c6f1cde`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/c6f1cdebd1439b0d6acbdc65c8080e64f79c3375) Fix issue with incorrect error and KNN plugin due big refactoring (#417)
[`04dd8cd`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/04dd8cdf5ff153d51f9c24a1eade08d89814b064) Feature/cli table output (#386)
