### PR TITLE
🆕 Update buddy version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.5.1 24102308 ea34859
-buddy 3.0.1 24121208 04dd8cd
+buddy 3.0.1 24121212 c6f1cde
 mcl 2.3.1 24112219 edadc69
 executor 1.1.23 24111613 dbade9d
 tzdata 1.0.1 240904 3ba592a

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.5.1 24102308 ea34859
-buddy 3.0.1 24121212 c6f1cde
+buddy 3.0.1 24121308 8dbc9a5
 mcl 2.3.1 24112219 edadc69
 executor 1.1.23 24111613 dbade9d
 tzdata 1.0.1 240904 3ba592a

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.5.1 24102308 ea34859
-buddy 3.0.1 24121011 b02bf18
+buddy 3.0.1 24121208 04dd8cd
 mcl 2.3.1 24112219 edadc69
 executor 1.1.23 24111613 dbade9d
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version to: 3.0.1 24121308 8dbc9a5 which includes:

[`8dbc9a5`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/8dbc9a59e4d3aa00b5136483c50765ae15b8e5da) Update buddy-core to fix trailing comma ; (#419)
