### PR TITLE
Fixing test-integrations-filebeat.rec

### DIFF
--- a/test/clt-tests/integrations/test-integrations-filebeat.rec
+++ b/test/clt-tests/integrations/test-integrations-filebeat.rec
@@ -32,7 +32,7 @@ cat /var/log/dpkg.log | wc -l
 ––– output –––
 5
 ––– input –––
-filebeat -c /filebeat.yml -strict.perms=false -e 2>/var/log/filebeat.log &
+filebeat -c /filebeat.yml --strict.perms=false -e 2>/var/log/filebeat.log &
 ––– output –––
 [1] #!/[0-9]+/!#
 ––– input –––


### PR DESCRIPTION
On Mac os, if you run `Filebeat` as root, you must change the ownership of the configuration file and all configurations included in the modules.d directory, or run `Filebeat` with `--strict.perms=false.`