### PR TITLE
🆕 Update load version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.0.1 24123112 a489ccb
 mcl 2.3.1 24122408 9d9a466
 executor 1.2.7 24122617 b420a52
 tzdata 1.0.1 240904 3ba592a
-load 1.0.21 25010206 5e75007
+load 1.0.23 25010307 f1a1c27
 ---
 ! Do not change the separator that splits this desc from the data
 This file should contain one line per package with a version lock.


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version to: 1.0.23 25010307 f1a1c27 which includes:

[`f1a1c27`](https://github.com/manticoresoftware/manticore-load/commit/f1a1c273c16a00219ff49cc17b214e81847fc2d6) 1.0.23
[`fa9c4cb`](https://github.com/manticoresoftware/manticore-load/commit/fa9c4cb652721874d60838e12fa99670f4c4abd4) Show usage info when no params are passed
[`42e8709`](https://github.com/manticoresoftware/manticore-load/commit/42e870906a5f54c16f939337952debc504121a46) CLT tests (#3)
