### PR TITLE
Autocomplete method does not throw an error for numeric queries

### DIFF
--- a/test/clt-tests/buddy/test-fuzzy-search.rec
+++ b/test/clt-tests/buddy/test-fuzzy-search.rec
@@ -741,3 +741,28 @@ mysql -h0 -P9306 -e "SELECT * FROM t WHERE MATCH('abcdef') OPTION fuzzy=1;"
 ––– input –––
 mysql -h0 -P9306 -e "SELECT * FROM t WHERE MATCH('\$#@\!') OPTION fuzzy=1;"
 ––– output –––
+––– input –––
+mysql -h0 -P9306 -e "DROP TABLE IF EXISTS idx1; CREATE TABLE idx1(value TEXT) min_infix_len='2';"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO idx1(value) VALUES ('340');"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('34', 'idx1');"
+––– output –––
++-------+
+| query |
++-------+
+| 340   |
++-------+
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('3', 'idx1');"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "CALL AUTOCOMPLETE('34', 'idx1', 1 AS fuzziness);"
+––– output –––
++-------+
+| query |
++-------+
+| 340   |
++-------+


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix

**Description of the Change:**
- Fixed an issue where CALL AUTOCOMPLETE did not return correct results for numeric values in a simple table. Fuzzy search and autocomplete test updated. 

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch-php/issues/224