### PR TITLE
Checking for FATAL error on invalid replication ports

### DIFF
--- a/test/clt-tests/core/fatal-invalid-port.rec
+++ b/test/clt-tests/core/fatal-invalid-port.rec
@@ -26,6 +26,6 @@ binlog_path =
 mkdir -p data; rm -f searchd.log; searchd --stopwait > /dev/null; searchd -c /replication.conf > /dev/null
 ––– output –––
 ––– input –––
-grep 'FATAL: invalid replication ports count 1, should be at least 2' searchd.log
+grep 'FATAL: invalid replication ports count 1, should be at least 2' searchd.log |wc -l
 ––– output –––
-[#!/[A-Za-z]{3}\s+[A-Za-z]{3}\s+[0-9]{1,2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\s+[0-9]{4}/!#] [%{NUMBER}] FATAL: invalid replication ports count 0, should be at least 2
+1

--- a/test/clt-tests/core/fatal-invalid-port.rec
+++ b/test/clt-tests/core/fatal-invalid-port.rec
@@ -1,0 +1,31 @@
+# Test: Verify that the daemon terminates with a FATAL error if the replication ports are configured incorrectly.
+# Steps:
+# 1. Create a `/replication.conf` configuration file with incorrectly configured replication ports.
+# 2. Run the daemon and check for a FATAL error in the logs.
+# Expected result:
+# - The daemon terminates with a FATAL error.
+# - The logs contain: ‘FATAL: invalid replication ports count 0, must be at least 2’.
+
+––– input –––
+echo -e 'searchd\n{\n\tlisten = 3103\n\tlisten = 9315:mysql\n\tlisten = 127.0.0.1:3104:replication\n\tdata_dir = data\n\n\tlog = searchd.log\n\tpid_file = searchd.pid\n\tbinlog_path =\n}' > /replication.conf
+––– output –––
+––– input –––
+cat /replication.conf
+––– output –––
+searchd
+{
+listen = 3103
+listen = 9315:mysql
+listen = 127.0.0.1:3104:replication
+data_dir = data
+log = searchd.log
+pid_file = searchd.pid
+binlog_path =
+}
+––– input –––
+mkdir -p data; rm -f searchd.log; searchd --stopwait > /dev/null; searchd -c /replication.conf > /dev/null
+––– output –––
+––– input –––
+grep 'FATAL: invalid replication ports count 0, should be at least 2' searchd.log
+––– output –––
+[#!/[A-Za-z]{3}\s+[A-Za-z]{3}\s+[0-9]{1,2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\s+[0-9]{4}/!#] [%{NUMBER}] FATAL: invalid replication ports count 0, should be at least 2

--- a/test/clt-tests/core/fatal-invalid-port.rec
+++ b/test/clt-tests/core/fatal-invalid-port.rec
@@ -26,6 +26,6 @@ binlog_path =
 mkdir -p data; rm -f searchd.log; searchd --stopwait > /dev/null; searchd -c /replication.conf > /dev/null
 ––– output –––
 ––– input –––
-grep 'FATAL: invalid replication ports count 0, should be at least 2' searchd.log
+grep 'FATAL: invalid replication ports count 1, should be at least 2' searchd.log
 ––– output –––
 [#!/[A-Za-z]{3}\s+[A-Za-z]{3}\s+[0-9]{1,2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\s+[0-9]{4}/!#] [%{NUMBER}] FATAL: invalid replication ports count 0, should be at least 2


### PR DESCRIPTION
**Type of Change:**
- Bug fix 

**Description of the Change:**
- Created a CLT-test in which the daemon properly checks replication ports during startup. The daemon now terminates with a `FATAL error if the number of replication ports is insufficient (less than 2)`. This ensures that replication is properly configured before running the daemon.

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch/issues/2931
