### PR TITLE
🆕 Update load version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.15.0+25012401-003bbc21-dev
 mcl 2.3.1 25012210 0be00ac
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a
-load 1.16.0+25011101-7ce70afb-dev
+load 1.16.1+25012511-d0cc8f55
 ---
 ! Do not change the separator that splits this desc from the data
 This file should contain one line per package with a version lock.


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version to: 1.16.1+25012511-d0cc8f55 which includes:


