### PR TITLE
Fix crash division by zero in bm25f()

### DIFF
--- a/src/sphinxsearch.cpp
+++ b/src/sphinxsearch.cpp
@@ -2807,7 +2807,7 @@ struct Expr_BM25F_T : public Expr_NoLocator_c
 
 		// compute avg length per field
 		m_dAvgDocFieldLens.Fill ( 0.0f );
-		if ( m_pState->m_pFieldLens )
+		if ( m_pState->m_pFieldLens && m_pState->m_iTotalDocuments )
 			for ( int i=0; i<m_pState->m_iFields; i++ )
 				m_dAvgDocFieldLens[i] = m_pState->m_pFieldLens[i] / m_pState->m_iTotalDocuments; // FIXME? Total of documents with non empty field value is actually needed here
 	}


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change (select one):**
- Bug fix 

**Description of the Change:**

This is fixes divide by zero searchd crash while using `bm25()` expression on index with zero document count

```
backtrace:
 0# sphBacktrace(int, bool) in /usr/bin/searchd
 1# CrashLogger::HandleCrash(int) in /usr/bin/searchd
 2# 0x0000764E97F1C0E0 in /lib/x86_64-linux-gnu/libpthread.so.0
 3# Expr_BM25F_T<false, false>::Expr_BM25F_T(RankerState_Expr_fn<false, false>*, float, float, ISphExpr*) in /usr/bin/searchd
 4# ExprRankerHook_T<false, false>::CreateNode(int, ISphExpr*, ISphSchema const*, ESphEvalStage*, bool*, CSphString&) in /usr/bin/searchd
 5# ExprParser_t::CreateTree(int) in /usr/bin/searchd
 6# ExprParser_t::CreateTree(int) in /usr/bin/searchd
 7# ExprParser_t::Create(bool*, CSphString&) in /usr/bin/searchd
 8# ExprParser_t::Parse(char const*, ISphSchema const&, CSphString const*, ESphAttr*, bool*, CSphString&) in /usr/bin/searchd
 9# sphExprParse(char const*, ISphSchema const&, CSphString const*, CSphString&, ExprParseArgs_t&) in /usr/bin/searchd
10# RankerState_Expr_fn<false, false>::Init(int, int const*, ExtRanker_T<true>*, CSphString&, unsigned int) in /usr/bin/searchd
11# sphCreateRanker(XQQuery_t const&, CSphQuery const&, CSphQueryResultMeta&, ISphQwordSetup const&, CSphQueryContext const&, ISphSchema const&) in /usr/bin/searchd
12# CSphIndex_VLN::ParsedMultiQuery(CSphQuery const&, CSphQueryResult&, VecTraits_T<ISphMatchSorter*> const&, XQQuery_t const&, CSphRefcountedPtr<CSphDict>, CSphMultiQueryArgs const&, CSphQueryNodeCache*, long) const in /usr/bin/searchd
13# 0x0000000000CD8A0F in /usr/bin/searchd
14# CSphIndex_VLN::RunParsedMultiQuery(int, CSphRefcountedPtr<CSphDict>&, bool, CSphQuery const&, CSphQueryResult&, VecTraits_T<ISphMatchSorter*>&, XQQuery_t const&, CSphMultiQueryArgs const&, long) const in /usr/bin/searchd
15# CSphIndex_VLN::MultiQuery(CSphQueryResult&, CSphQuery const&, VecTraits_T<ISphMatchSorter*> const&, CSphMultiQueryArgs const&) const in /usr/bin/searchd
16# 0x0000000000E4681B in /usr/bin/searchd
17# 0x0000000000F704DD in /usr/bin/searchd
18# Threads::Coro::ExecuteN(int, std::__1::function<void ()>&&) in /usr/bin/searchd
19# RtIndex_c::MultiQuery(CSphQueryResult&, CSphQuery const&, VecTraits_T<ISphMatchSorter*> const&, CSphMultiQueryArgs const&) const in /usr/bin/searchd
20# CSphIndexStub::MultiQueryEx(int, CSphQuery const*, CSphQueryResult*, ISphMatchSorter**, CSphMultiQueryArgs const&) const in /usr/bin/searchd
21# 0x0000000000B0CE8F in /usr/bin/searchd
22# 0x0000000000F702A3 in /usr/bin/searchd
23# Threads::CoRoutine_c::CreateContext(std::__1::function<void ()>, std::__1::pair<boost::context::stack_context, Threads::StackFlavour_E>)::'lambda'(boost::context::detail::transfer_t)::__invoke(boost::context::detail::transfer_t) in /usr/bin/searchd
24# make_fcontext in /usr/lib/x86_64-linux-gnu/libboost_context.so.1.74.0
```

I just create empty plain index, add this to distributed and selects fields with `MATCH()` clause and ranker opt `expr('bm25f(1.2, 0.85, {field1=10, field2=120})'`

**Related Issue (provide the link):**
