### PR TITLE
Update Plain_and_real-time_table_settings.md with KNN attributes

### DIFF
--- a/manual/Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md
+++ b/manual/Creating_a_table/Local_tables/Plain_and_real-time_table_settings.md
@@ -418,6 +418,13 @@ Declares a vector of floating-point values.
 
 Value: field name. Multiple records allowed.
 
+To set KNN attributes for rt_attr_float_vector add 
+```ini
+rt_attr_float_vector = image_vector
+rt_attr_float_vector = text_vector
+knn = {"attrs":[{"name":"image_vector","type":"hnsw","dims":768,"hnsw_similarity":"COSINE","hnsw_m":16,"hnsw_ef_construction":200},{"name":"text_vector","type":"hnsw","dims":768,"hnsw_similarity":"COSINE","hnsw_m":16,"hnsw_ef_construction":200}]}
+```
+
 #### rt_attr_bool
 
 ```ini


### PR DESCRIPTION
The current docs online are missing the description on how exactly to define KNN attributes when defining RT index in config file, the suggested change is based upon example in the test.

<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change (select one):**
- Documentation update

**Description of the Change:**
Added an example for how knn definition would look like when RT index is defined in the config file.

**Related Issue (provide the link):**
https://manual.manticoresearch.com/Creating_a_table/Local_tables/Plain_and_real-time_table_settings#rt_attr_float_vector