### PR TITLE
Update test-supported-mysqldump-versions

### DIFF
--- a/test/clt-tests/mysqldump/versions/test-supported-mysqldump-versions.rec
+++ b/test/clt-tests/mysqldump/versions/test-supported-mysqldump-versions.rec
@@ -27,7 +27,6 @@ docker exec manticore bash -c "curl -s https://hub.docker.com/v2/repositories/li
 10.5
 10.6
 10.11
-11.1
 11.2
 11.4
 11.5


### PR DESCRIPTION
Update test-supported-mysqldump-versions.rec, version 11.1 has been removed from https://hub.docker.com/v2/repositories/library/mariadb/tags/?page_size=100.