### PR TITLE
fix build with Boost 1.87.0

### DIFF
--- a/src/searchdbuddy.cpp
+++ b/src/searchdbuddy.cpp
@@ -14,7 +14,7 @@
 #include "netreceive_ql.h"
 #include "client_session.h"
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/read_until.hpp>
 #include <boost/process.hpp>
 #if _WIN32
@@ -32,7 +32,7 @@ static CSphString g_sUrlBuddy;
 static CSphString g_sStartArgs;
 
 static const int PIPE_BUF_SIZE = 2048;
-static std::unique_ptr<boost::asio::io_service> g_pIOS;
+static std::unique_ptr<boost::asio::io_context> g_pIOS;
 static std::vector<char> g_dPipeBuf ( PIPE_BUF_SIZE );
 static CSphVector<char> g_dLogBuf ( PIPE_BUF_SIZE );
 static std::unique_ptr<boost::process::async_pipe> g_pPipe;
@@ -357,7 +357,7 @@ BuddyState_e TryToStart ( const char * sArgs, CSphString & sError )
 	g_pPipe.reset();
 	g_pIOS.reset();
 
-	g_pIOS.reset ( new boost::asio::io_service );
+	g_pIOS.reset ( new boost::asio::io_context );
 	g_pPipe.reset ( new boost::process::async_pipe ( *g_pIOS ) );
 
 	std::unique_ptr<boost::process::child> pBuddy;


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Description of the Change:**

`io_service` was deprecated back in 1.66.0 (https://github.com/boostorg/asio/commit/b60e92b13ef68dfbb9af180d76eae41d22e19356) and removed in 1.87.0 (https://github.com/boostorg/asio/commit/ec0908c562102915423d8bd7aefd3079efbb6c86).

Official replacement is `io_context` (`io_service` has been an alias for `io_context` from 1.66.0 thru 1.86.0) - https://www.boost.org/doc/libs/1_86_0/doc/html/boost_asio/net_ts.html

**Related Issue (provide the link):**

Fixes #3099 