### PR TITLE
Created test-max-iops.rec and test-max-iosize.rec

### DIFF
--- a/.github/workflows/clt_tests.yml
+++ b/.github/workflows/clt_tests.yml
@@ -50,6 +50,8 @@ jobs:
             test_prefix: test/clt-tests/buddy/
           - name: Update
             test_prefix: test/clt-tests/optimisation-and-update/
+          - name: Indexer
+            test_prefix: test/clt-tests/indexer/
     steps:
       - uses: manticoresoftware/clt@0.3.5
         with:

--- a/test/clt-tests/indexer/test-max-iops.rec
+++ b/test/clt-tests/indexer/test-max-iops.rec
@@ -1,0 +1,27 @@
+––– block: ../base/start-searchd –––
+––– input –––
+(for n in `seq 1 100`; do echo "$n,abc"; done) > /tmp/csv
+––– output –––
+––– input –––
+echo -e 'indexer {\n    max_iops = 100\n}\nsource src {\n    type = csvpipe\n    csvpipe_command = cat /tmp/csv\n    csvpipe_field = f\n}\n\nindex idx {\n    type = plain\n    source = src\n    path = /tmp/idx\n}' > plain_min.conf
+––– output –––
+––– input –––
+cat plain_min.conf
+––– output –––
+indexer {
+max_iops = 100
+}
+source src {
+type = csvpipe
+csvpipe_command = cat /tmp/csv
+csvpipe_field = f
+}
+index idx {
+type = plain
+source = src
+path = /tmp/idx
+}
+––– input –––
+indexer -c plain_min.conf idx|grep reads|awk '{print $2}'
+––– output –––
+ 3

--- a/test/clt-tests/indexer/test-max-iosize.rec
+++ b/test/clt-tests/indexer/test-max-iosize.rec
@@ -1,0 +1,27 @@
+––– block: ../base/start-searchd –––
+––– input –––
+for n in $(seq 1 10000); do echo "$n,abc"; done > /tmp/csv
+––– output –––
+––– input –––
+echo -e 'indexer {\n    max_iops = 100\n}\nsource src {\n    type = csvpipe\n    csvpipe_command = cat /tmp/csv\n    csvpipe_field = f\n}\n\nindex idx {\n    type = plain\n    source = src\n    path = /tmp/idx\n}' > plain_min.conf
+––– output –––
+––– input –––
+cat plain_min.conf
+––– output –––
+ indexer {
+ max_iops = 100
+ }
+ source src {
+ type = csvpipe
+ csvpipe_command = cat /tmp/csv
+ csvpipe_field = f
+ }
+ index idx {
+ type = plain
+ source = src
+ path = /tmp/idx
+ }
+––– input –––
+indexer -c plain_min.conf idx|grep reads|awk '{print $2}'
+––– output –––
+ 3


### PR DESCRIPTION
**Type of Change:**
- Bug fix - 

**Description of the Change:**
- Added two tests to check indexer performance at different input data sizes (100 and 10,000 rows).
Both tests confirm that indexer processes data stably and returns the same reads value.

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch/issues/3038