### PR TITLE
Test-kist build script update, so it doesn't rely on the odd/even version approach

### DIFF
--- a/dist/test_kit_docker_build.sh
+++ b/dist/test_kit_docker_build.sh
@@ -7,20 +7,6 @@ cd docker
 # We set it later when parse deps.txt
 executor_dev_path=
 
-# Extra function to use
-# Get semver suffix in format -dev or empty string depending on version provided
-get_semver_suffix() {
-	local version="$1"
-
-	# Check if last digit is odd
-	last_digit=$(echo "$version" | awk -F. '{print $NF}')
-	if [ $(( last_digit % 2 )) -eq 0 ]; then
-		echo ""
-	else
-		echo "_dev"
-	fi
-}
-
 # Downloads a package from a repository by given package name, version, date, commit, and architecture
 download_package() {
 	package="$1"
@@ -39,20 +25,54 @@ download_package() {
 		file_name="${package}_${version}-${date}-${commit}_${arch}.deb"
 	fi
 
-	file_url="${repo_url}/${file_name}"
-	echo "Wgetting from $file_url"
-	wget -q -O "../build/${file_name}" "$file_url"
-
-	# For executor, we need to download the dev version and also extra package
-	if [ "$package" = 'manticore-executor' ]; then
-		echo "Wgetting from https://github.com/manticoresoftware/executor/releases/download/v${version}/manticore-executor_${version}-${date}-${commit}_linux_amd64-dev.tar.gz"
-		wget -q -O 'manticore-executor-dev.tar.gz' "https://github.com/manticoresoftware/executor/releases/download/v${version}/manticore-executor_${version}-${date}-${commit}_linux_amd64-dev.tar.gz"
-		tar -xzf 'manticore-executor-dev.tar.gz'
-		executor_dev_path=$(realpath "manticore-executor_${version}-${date}-${commit}_linux_amd64-dev/manticore-executor")
-
-		# Also add extra package
-		download_package "manticore-extra" "${version}" "${date}" "${commit}" "all"
-	fi
+	# Try both repositories (with and without _dev suffix)
+	for repo_suffix in "" "_dev"; do
+		repo_url="https://repo.manticoresearch.com/repository/manticoresearch_jammy${repo_suffix}/dists/jammy/main/binary-amd64"
+		file_url="${repo_url}/${file_name}"
+		echo "Trying to download from $file_url"
+		
+		if wget -q --spider "$file_url" 2>/dev/null; then
+			echo "Package found at $file_url"
+			wget -q -O "../build/${file_name}" "$file_url"
+			
+			# For executor, we need to download the dev version and also extra package
+			if [ "$package" = 'manticore-executor' ]; then
+				if [[ "$version_string" == *"+"* ]]; then
+					# Handle new format
+					echo "Downloading executor dev package for new format version"
+					# Extract version from version_string (before the +)
+					version=$(echo "$version_string" | cut -d'+' -f1)
+					# Extract date-commit from version_string (after the +)
+					date_commit=$(echo "$version_string" | cut -d'+' -f2)
+					
+					echo "Wgetting from https://github.com/manticoresoftware/executor/releases/download/v${version}/manticore-executor_${version}-${date_commit}_linux_amd64-dev.tar.gz"
+					wget -q -O 'manticore-executor-dev.tar.gz' "https://github.com/manticoresoftware/executor/releases/download/v${version}/manticore-executor_${version}-${date_commit}_linux_amd64-dev.tar.gz"
+				else
+					# Handle old format
+					echo "Wgetting from https://github.com/manticoresoftware/executor/releases/download/v${version}/manticore-executor_${version}-${date}-${commit}_linux_amd64-dev.tar.gz"
+					wget -q -O 'manticore-executor-dev.tar.gz' "https://github.com/manticoresoftware/executor/releases/download/v${version}/manticore-executor_${version}-${date}-${commit}_linux_amd64-dev.tar.gz"
+				fi
+				
+				tar -xzf 'manticore-executor-dev.tar.gz'
+				
+				# Find the extracted directory
+				executor_dev_dir=$(find . -type d -name "manticore-executor_*_linux_amd64-dev" | head -n 1)
+				executor_dev_path=$(realpath "${executor_dev_dir}/manticore-executor")
+				
+				# Also add extra package
+				if [[ "$version_string" == *"+"* ]]; then
+					download_package "manticore-extra" "${version_string}" "all"
+				else
+					download_package "manticore-extra" "${version}" "${date}" "${commit}" "all"
+				fi
+			fi
+			
+			return 0
+		fi
+	done
+	
+	echo "ERROR: Package not found in any repository: ${file_name}" >&2
+	exit 1
 }
 
 # Read deps.txt line by line
@@ -119,14 +139,6 @@ do
 			continue
 			;;
 	esac
-
-	# Update suffix logic
-	if [ "$suffix" = "dev" ]; then
-		repo_suffix="_dev"
-	else
-		repo_suffix=$(get_semver_suffix "$version")
-	fi
-	repo_url="https://repo.manticoresearch.com/repository/manticoresearch_jammy${repo_suffix}/dists/jammy/main/binary-amd64"
 
 	if [[ "$line" =~ ^([^[:space:]]+)[[:space:]]+([^[:space:]]+)\+([0-9]+)-([a-f0-9]+) ]]; then
 		download_package "${package}" "${version_string}" "${arch}"


### PR DESCRIPTION
We are moving to true semver, so the odd/even approach doesn't work anymore. Instead, it npow attemps downloading from both dev and release dirs.
