### PR TITLE
Revert "don't build galera if no tests required"

### DIFF
--- a/cmake/GetGALERA.cmake
+++ b/cmake/GetGALERA.cmake
@@ -58,10 +58,6 @@ if (TARGET galera::galera)
 	return ()
 endif ()
 
-if (NOT BUILD_TESTING)
-	return ()
-endif ()
-
 # not found. Populate and build cache package for now and future usage.
 select_nearest_url ( GALERA_PLACE "galera" ${GALERA_BUNDLE} ${GALERA_GITHUB} )
 select_nearest_url ( WSREP_PLACE "wsrep" ${WSREP_BUNDLE} ${WSREP_GITHUB} ) # WSREP_PATH provides path to galera-imported for build


### PR DESCRIPTION
This reverts commit 8dd5b852f1d5ce32846628d0b0f0135123e43d44. Otherwise with an empty cache CI fails due to no built galera library (ex. https://github.com/manticoresoftware/manticoresearch/actions/runs/13607480956/job/38040684114?pr=3152)