### PR TITLE
🆕 Update buddy version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.1+25021722-22bd3a05-dev
-buddy 3.26.0+25031221-aeb39da3-dev
+buddy 3.26.1+25031419-267e357b-dev
 mcl 4.1.2 25031206 15bbcc7
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version to: 3.26.1+25031419-267e357b-dev which includes:


