### PR TITLE
Clt-test configuration parameter for kibana version installation

### DIFF
--- a/.github/workflows/clt_tests.yml
+++ b/.github/workflows/clt_tests.yml
@@ -54,6 +54,8 @@ jobs:
             test_prefix: test/clt-tests/sharding/
           - name: Indexer
             test_prefix: test/clt-tests/indexer/
+          - name: Kibana
+            test_prefix: test/clt-tests/kibana/
     steps:
       - uses: manticoresoftware/clt@0.6.5
         with:

--- a/test/clt-tests/kibana/test-parameter-for-installing-the-kibana-version.rec
+++ b/test/clt-tests/kibana/test-parameter-for-installing-the-kibana-version.rec
@@ -1,0 +1,54 @@
+––– comment –––
+Creating a config with kibana_version_string = "7.10.2"
+––– input –––
+echo -e "searchd {\n  listen = 9306:mysql\n  listen = 9312\n  listen = 9308:http\n  log = /var/log/manticore/searchd.log\n  query_log = /var/log/manticore/query.log\n  pid_file = /var/run/manticore/searchd.pid\n  kibana_version_string = 7.10.2\n}" > /tmp/manticore.conf; echo $?
+––– output –––
+0
+––– comment –––
+Restarting searchd with the new config
+––– input –––
+pkill -9 searchd; stdbuf -oL searchd -c /tmp/manticore.conf > /dev/null; if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; cat /var/log/manticore/searchd.log; fi
+––– output –––
+Buddy started!
+––– comment –––
+Verifying kibana_version_string in SHOW SETTINGS
+––– input –––
+mysql -h0 -P9306 -e "SHOW SETTINGS;" | grep -i "kibana_version_string"
+––– output –––
+| searchd.kibana_version_string | 7.10.2                         |
+––– comment –––
+Updating config with kibana_version_string = "8.17.4"
+––– input –––
+echo -e "searchd {\n  listen = 9306:mysql\n  listen = 9312\n  listen = 9308:http\n  log = /var/log/manticore/searchd.log\n  query_log = /var/log/manticore/query.log\n  pid_file = /var/run/manticore/searchd.pid\n  kibana_version_string = 8.17.4\n}" > /tmp/manticore.conf; echo $?
+––– output –––
+0
+––– comment –––
+Restarting searchd
+––– input –––
+pkill -9 searchd; stdbuf -oL searchd -c /tmp/manticore.conf > /dev/null; if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; cat /var/log/manticore/searchd.log; fi
+––– output –––
+Buddy started!
+––– comment –––
+Checking updated kibana_version_string
+––– input –––
+mysql -h0 -P9306 -e "SHOW SETTINGS;" | grep -i "kibana_version_string"
+––– output –––
+| searchd.kibana_version_string | 8.17.4                         |
+––– comment –––
+Testing with an empty kibana_version_string
+––– input –––
+echo -e "searchd {\n  listen = 9306:mysql\n  listen = 9312\n  listen = 9308:http\n  log = /var/log/manticore/searchd.log\n  query_log = /var/log/manticore/query.log\n  pid_file = /var/run/manticore/searchd.pid\n  kibana_version_string = \n}" > /tmp/manticore.conf; echo $?
+––– output –––
+0
+––– comment –––
+Restarting searchd with an empty value
+––– input –––
+pkill -9 searchd; stdbuf -oL searchd -c /tmp/manticore.conf > /dev/null; if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; cat /var/log/manticore/searchd.log; fi
+––– output –––
+Buddy started!
+––– comment –––
+Verifying the empty kibana_version_string
+––– input –––
+mysql -h0 -P9306 -e "SHOW SETTINGS;" | grep -i "kibana_version_string"
+––– output –––
+| searchd.kibana_version_string |                                |


### PR DESCRIPTION
**Type of Change:**

- New feature

**Description of the Change:**

- Change Description:
This PR implements a new CLT test to check that the availability of a new configuration option, kibana_version_string, in the searchd section of Manticore Search. The purpose of this option is to allow users to specify the version of Kibana (or OpenSearch) they are working with, allowing Buddy to support multiple versions by including this information in their responses where appropriate. The kibana_version_string value is read from the configuration file and made available via the SHOW SETTINGS command.

**Related Issue (provide the link):**

- https://github.com/manticoresoftware/manticoresearch/issues/3172