### PR TITLE
🆕 Update load version

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.26.5+25032712-234c30c2-dev
 mcl 4.1.2 25031206 15bbcc7
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a
-load 1.18.0+25031816-ecbb7e88-dev
+load 1.18.0+25031816-ecbb7e88
 ---
 ! Do not change the separator that splits this desc from the data
 This file should contain one line per package with a version lock.


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version to: 1.18.0+25031816-ecbb7e88 which includes:

[`ecbb7e8`](https://github.com/manticoresoftware/manticore-load/commit/ecbb7e88cc9d769eed913ea5e6220525bd69ffcb) feat: add --json output option for quiet mode (#10)
