### PR TITLE
Clt-test generation-of-document-auto-id-in-replication.rec

### DIFF
--- a/test/clt-tests/replication/test-generation-of-document-auto-id-in-replication.rec
+++ b/test/clt-tests/replication/test-generation-of-document-auto-id-in-replication.rec
@@ -1,0 +1,38 @@
+––– input –––
+mkdir -p /tmp/{run,lib,log}/manticore-1 /tmp/{run,lib,log}/manticore-2
+––– output –––
+––– input –––
+echo -e "searchd {\n  listen = 1306:mysql\n  listen = 1312\n  log = /tmp/log/manticore-1/searchd.log\n  query_log = /tmp/log/manticore-1/query.log\n  pid_file = /tmp/run/manticore-1/searchd.pid\n  data_dir = /tmp/lib/manticore-1\n  server_id = 1\n}" > /tmp/manticore1.conf; echo $?
+––– output –––
+0
+––– input –––
+searchd -c /tmp/manticore1.conf > /dev/null
+––– output –––
+––– input –––
+if timeout 10 grep -qm1 'accepting connections' <(tail -n 1000 -f /tmp/log/manticore-1/searchd.log); then echo 'Accepting connections!'; else echo 'Timeout or failed!'; fi
+––– output –––
+Accepting connections!
+––– input –––
+echo -e "searchd {\n  listen = 2306:mysql\n  listen = 2312\n  log = /tmp/log/manticore-2/searchd.log\n  query_log = /tmp/log/manticore-2/query.log\n  pid_file = /tmp/run/manticore-2/searchd.pid\n  data_dir = /tmp/lib/manticore-2\n  server_id = 1\n}" > /tmp/manticore2.conf; echo $?
+––– output –––
+0
+––– input –––
+searchd -c /tmp/manticore2.conf > /dev/null
+––– output –––
+––– input –––
+if timeout 10 grep -qm1 'accepting connections' <(tail -n 1000 -f /tmp/log/manticore-2/searchd.log); then echo 'Accepting connections!'; else echo 'Timeout or failed!'; fi
+––– output –––
+Accepting connections!
+––– input –––
+mysql -h0 -P1306 -e "CREATE CLUSTER t"
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e "CREATE TABLE t(id bigint)"
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e "ALTER CLUSTER t ADD t;"
+––– output –––
+––– input –––
+mysql -h0 -P2306 -e "JOIN CLUSTER t AT '127.0.0.1:1312';"
+––– output –––
+ERROR 1064 (42000) at line 1: server_id conflict, duplicate server_id:1 detected in the cluster 't'. Please set a unique server_id at the config.


### PR DESCRIPTION
**Type of Change:**
- Bug fix 

**Description of the Change:**
- This PR added with SLT-test testing fixes a bug where auto-ID generation in Manticore Search only checked for duplicates in RAM segments, ignoring disk segments. As a result, when multiple nodes in a cluster had the same server_id , INSERT operations with auto-ID from different nodes would overwrite the same document, resulting in data loss and inconsistency. This fix improves data integrity in clustered environments by preventing auto-ID conflicts when multiple nodes are running concurrently.


**Related Issue (provide the link):**
https://github.com/manticoresoftware/manticoresearch/issues/3186