### PR TITLE
Created test-facet-with-option-fuzzy.rec

### DIFF
--- a/test/clt-tests/buddy/test-facet-with-option-fuzzy.rec
+++ b/test/clt-tests/buddy/test-facet-with-option-fuzzy.rec
@@ -1,0 +1,33 @@
+––– block: ../base/start-searchd-with-buddy –––
+––– input –––
+mysql -h0 -P9306 -e "DROP TABLE IF EXISTS test; CREATE TABLE test(column1 int, column2 int, column3 text) min_infix_len = '2'; INSERT INTO test(column1, column2, column3) VALUES (123, 3333, 'text here'), (456, 22222, 'text here');"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "
+SELECT * FROM test WHERE MATCH('text')
+OPTION fuzzy=1, cutoff=1;"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "
+SELECT column1, column2, column3
+FROM test
+WHERE MATCH('text')
+OPTION fuzzy=1
+FACET column1;"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "
+SELECT column1, column2, column3
+FROM test
+WHERE MATCH('text')
+OPTION fuzzy=1, cutoff=1
+FACET column2;"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "
+SELECT column1, column2, column3
+FROM test
+WHERE MATCH('text')
+OPTION fuzzy=1, cutoff=1
+FACET column2;"
+––– output –––


### PR DESCRIPTION
**Type of Change:**
- Bug fix 

**Description of the Change:**
- This PR includes a Clt-test testing fix for a problem where queries combining OPTION fuzzy=1 with FACET fail with syntax errors ([42000][1064] Invalid options in query string, make sure they are separated by commas or P01: syntax error, unexpected FACET). 

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch/issues/3130