### PR TITLE
fix build with Boost 1.88.0

### DIFF
--- a/src/searchdbuddy.cpp
+++ b/src/searchdbuddy.cpp
@@ -16,7 +16,17 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/read_until.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 108800
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/async.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/error.hpp>
+#include <boost/process/v1/handles.hpp>
+#include <boost/process/v1/io.hpp>
+#else
 #include <boost/process.hpp>
+#endif
 #if _WIN32
 #include <boost/winapi/process.hpp>
 #endif
@@ -703,7 +713,7 @@ static bool SetSessionMeta ( const JsonObj_c & tBudyyReply )
 	// if no meta.total this is not a search query - do not log it into query.log
 	if ( !ConvertValue ( "total", tSrcMeta, tLastMeta.m_iMatches ) )
 		return false;
-		
+
 	// total_found => m_iTotalMatches
 	ConvertValue ( "total_found", tSrcMeta, tLastMeta.m_iTotalMatches );
 
@@ -803,7 +813,7 @@ bool ProcessHttpQueryBuddy ( HttpProcessResult_t & tRes, Str_t sSrcQuery, Option
 
 	dResult.Resize ( 0 );
 	ReplyBuf ( FromStr ( sDump ), eHttpStatus, bNeedHttpResponse, dResult );
-	
+
 	if ( SetSessionMeta ( tReplyParsed.m_tRoot ) )
 		LogBuddyQuery ( sSrcQuery, BuddyQuery_e::HTTP );
 


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Description of the Change:**
Support upcoming Boost 1.88.0. This works around Boost.Process change in https://github.com/boostorg/process/commit/2ccd97cd48c5468b0609a488b59253efaa381711 until switch to `boost::process::v2`

Was able to successfully build with Boost 1.88.0.Beta1 after these changes.

**Related Issue (provide the link):**
