### PR TITLE
Fixed errors in export blocks for nightly-tests

### DIFF
--- a/test/clt-tests/installation/check-version/comparison-version.recb
+++ b/test/clt-tests/installation/check-version/comparison-version.recb
@@ -17,7 +17,7 @@ Upgrade successful. New version knn: %{VERSION}
 ––– input –––
 if [[ "$new_version_galera" > "$current_version_galera" ]] || [[ "$new_version_galera" == "$current_version_galera" ]]; then echo "Upgrade successful. New version galera: $new_version_galera"; else echo "Upgrade failed. Current version galera: $current_version_galera, new version: $new_version_galera"; fi
 ––– output –––
-Upgrade successful. New version galera: #!/[0-9]{1}\.[0-9]{2}/!#
+Upgrade successful. New version galera: #!/[0-9]+\.[0-9]+/!#
 ––– input –––
 if [[ "$new_version_buddy" > "$current_version_buddy" ]]; then echo "Upgrade successful. New version buddy: $new_version_buddy"; else echo "Upgrade failed. Current version buddy: $current_version_buddy, new version: $new_version_buddy"; fi
 ––– output –––

--- a/test/clt-tests/installation/check-version/export-current-version.recb
+++ b/test/clt-tests/installation/check-version/export-current-version.recb
@@ -17,7 +17,6 @@ export current_version_knn=$(searchd --version | sed -n 's/.*knn \([^ )]*\).*/\1
 ––– input –––
 export current_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so | grep -oE '[0-9]+\.[0-9]+' | head -n1); echo $current_version_galera
 ––– output –––
-––– output –––
 #!/[0-9]+\.[0-9]+/!#
 ––– input –––
 export current_version_buddy=$(mysql -h0 -P9306 -e "SHOW STATUS LIKE 'version'\G" | awk -F'[ v()]+' '/buddy v/{print $(NF-1)}'); echo $current_version_buddy

--- a/test/clt-tests/installation/check-version/export-current-version.recb
+++ b/test/clt-tests/installation/check-version/export-current-version.recb
@@ -17,7 +17,8 @@ export current_version_knn=$(searchd --version | sed -n 's/.*knn \([^ )]*\).*/\1
 ––– input –––
 export current_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so | grep -oE '[0-9]+\.[0-9]+' | head -n1); echo $current_version_galera
 ––– output –––
-#!/[0-9]{1}\.[0-9]{2}/!#
+––– output –––
+#!/[0-9]+\.[0-9]+/!#
 ––– input –––
 export current_version_buddy=$(mysql -h0 -P9306 -e "SHOW STATUS LIKE 'version'\G" | awk -F'[ v()]+' '/buddy v/{print $(NF-1)}'); echo $current_version_buddy
 ––– output –––

--- a/test/clt-tests/installation/check-version/export-current-version.recb
+++ b/test/clt-tests/installation/check-version/export-current-version.recb
@@ -3,19 +3,19 @@ export current_version_searchd=$(searchd --version | head -n 1 | cut -d" " -f2);
 ––– output –––
 %{VERSION}
 ––– input –––
-export current_version_columnar=$(searchd --version | head -n 1 | cut -d" " -f5); echo $current_version_columnar
+export current_version_columnar=$(searchd --version | sed -n 's/.*columnar \([^ )]*\).*/\1/p'); echo $current_version_columnar
 ––– output –––
 %{VERSION}
 ––– input –––
-export current_version_secondary=$(searchd --version | head -n 1 | cut -d" " -f8); echo $current_version_secondary
+export current_version_secondary=$(searchd --version | sed -n 's/.*secondary \([^ )]*\).*/\1/p'); echo $current_version_secondary
 ––– output –––
 %{VERSION}
 ––– input –––
-export current_version_knn=$(searchd --version | head -n 1 | cut -d" " -f11); echo $current_version_knn
+export current_version_knn=$(searchd --version | sed -n 's/.*knn \([^ )]*\).*/\1/p'); echo $current_version_knn
 ––– output –––
 %{VERSION}
 ––– input –––
-export current_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so|grep -i -E "[0-9]{1}\.[0-9]{2}\([a-z0-9]+\)" | cut -d"(" -f1); echo $current_version_galera
+export current_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so | grep -oE '[0-9]+\.[0-9]+' | head -n1); echo $current_version_galera
 ––– output –––
 #!/[0-9]{1}\.[0-9]{2}/!#
 ––– input –––

--- a/test/clt-tests/installation/check-version/export-new-version.recb
+++ b/test/clt-tests/installation/check-version/export-new-version.recb
@@ -17,7 +17,7 @@ export new_version_knn=$(searchd --version | sed -n 's/.*knn \([^ )]*\).*/\1/p')
 ––– input –––
 export new_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so | grep -oE '[0-9]+\.[0-9]+' | head -n1); echo $new_version_galera
 ––– output –––
-#!/[0-9]{1}\.[0-9]{2}/!#
+#!/[0-9]+\.[0-9]+/!#
 ––– input –––
 export new_version_buddy=$(mysql -h0 -P9306 -e "SHOW STATUS LIKE 'version'\G" | grep -oP 'buddy v\K[^ )]+'); echo $new_version_buddy
 ––– output –––

--- a/test/clt-tests/installation/check-version/export-new-version.recb
+++ b/test/clt-tests/installation/check-version/export-new-version.recb
@@ -3,22 +3,23 @@ export new_version_searchd=$(searchd --version | head -n 1 | cut -d" " -f2); ech
 ––– output –––
 %{VERSION}
 ––– input –––
-export new_version_columnar=$(searchd --version | head -n 1 | cut -d" " -f6); echo $new_version_columnar
+export new_version_columnar=$(searchd --version | sed -n 's/.*columnar \([^ )]*\).*/\1/p'); echo $new_version_columnar
 ––– output –––
 %{VERSION}
 ––– input –––
-export new_version_secondary=$(searchd --version | head -n 1 | cut -d" " -f9); echo $new_version_secondary
+export new_version_secondary=$(searchd --version | sed -n 's/.*secondary \([^ )]*\).*/\1/p'); echo $new_version_secondary
 ––– output –––
 %{VERSION}
 ––– input –––
-export new_version_knn=$(searchd --version | head -n 1 | cut -d" " -f12); echo $new_version_knn
+export new_version_knn=$(searchd --version | sed -n 's/.*knn \([^ )]*\).*/\1/p'); echo $new_version_knn
 ––– output –––
 %{VERSION}
 ––– input –––
-export new_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so|grep -i -E "[0-9]{1}\.[0-9]{2}\([a-z0-9]+\)" | cut -d"(" -f1); echo $current_version_galera
+export new_version_galera=$(strings /usr/share/manticore/modules/libgalera_manticore.so | grep -oE '[0-9]+\.[0-9]+' | head -n1); echo $new_version_galera
 ––– output –––
 #!/[0-9]{1}\.[0-9]{2}/!#
 ––– input –––
-export new_version_buddy=$(mysql -h0 -P9306 -e "SHOW STATUS LIKE 'version'\G" | grep -oP 'buddy v\K[0-9]+\.[0-9]+\.[0-9]\+[^ )]*'); echo $new_version_buddy
+export new_version_buddy=$(mysql -h0 -P9306 -e "SHOW STATUS LIKE 'version'\G" | grep -oP 'buddy v\K[^ )]+'); echo $new_version_buddy
 ––– output –––
 #!/[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}\+[0-9]{8}-[0-9a-z]{8}.*/!#
+

--- a/test/clt-tests/integrations/kafka/test-integration-kafka-ms.rec
+++ b/test/clt-tests/integrations/kafka/test-integration-kafka-ms.rec
@@ -28,7 +28,7 @@ docker run -it --network=app-network --platform linux/amd64 --name manticore -d 
 ––– output –––
 0
 ––– input –––
-docker exec manticore sed -i '/data_dir = \/var\/lib\/manticore/a\    buddy_path = manticore-executor -n /usr/share/manticore/modules/manticore-buddy/src/main.php --debugv\n' /etc/manticoresearch/manticore.conf
+docker exec manticore sed -i '/data_dir = \/var\/lib\/manticore/a\    buddy_path = manticore-executor -n /usr/share/manticore/modules/manticore-buddy/src/main.php --debugvv\n' /etc/manticoresearch/manticore.conf
 ––– output –––
 ––– input –––
 docker exec manticore stdbuf -oL searchd


### PR DESCRIPTION
Fixed errors in export blocks: cut -f6, -f9, -f12 - get `aeac3b3@25032818)` with extra closing bracket.
