### PR TITLE
Clt-test - Fix crash when creating a distributed table

### DIFF
--- a/test/clt-tests/core/test-replace-into.rec
+++ b/test/clt-tests/core/test-replace-into.rec
@@ -363,7 +363,7 @@ mysql -h0 -P9306 -e "select count(*) from tbl WHERE regex (color, 'silver[0-9]+'
 ––– input –––
 echo $((elapsed_time / elapsed_time2))
 ––– output –––
-#!/([0-9]{1}|1[0-2]{1})/!#
+#!/^([0-9]{1}|1[0-2]{1})$/!#
 ––– input –––
 mysql -v -h0 -P9306 -e "SHOW TABLES; create table abc(id, t1 text, t2 text indexed) engine='columnar'; insert into abc VALUES (1, 'abc', 'cde'); desc abc;"
 ––– output –––

--- a/test/clt-tests/sharding/test-dist-table-shards-5000.rec
+++ b/test/clt-tests/sharding/test-dist-table-shards-5000.rec
@@ -1,0 +1,32 @@
+––– block: ../base/start-searchd-with-buddy –––
+––– input –––
+cat << 'EOF' > /tmp/create_tables.sh
+#!/usr/bin/env bash
+locals=()
+for n in $(seq 1 5000); do
+	locals+=("local='system.t$n'")
+	mysql -h0 -P9306 -e "create table system.t$n (id int)"
+done
+mysql -h0 -P9306 -e "create table t type='distributed' ${locals[*]}"
+EOF
+––– output –––
+––– input –––
+chmod +x /tmp/create_tables.sh; echo $?
+––– output –––
+0
+––– input –––
+bash /tmp/create_tables.sh; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SHOW TABLES LIKE 't'"
+––– output –––
++-------+-------------+
+| Table | Type        |
++-------+-------------+
+| t     | distributed |
++-------+-------------+
+––– input –––
+mysql -h0 -P9306 -N -e "SHOW CREATE TABLE t OPTION force = 1\G" | grep -o "local='system\.t[0-9]\+'" | wc -l
+––– output –––
+5000

--- a/test/clt-tests/sharding/test-dist-table-shards-5000.rec
+++ b/test/clt-tests/sharding/test-dist-table-shards-5000.rec
@@ -1,23 +1,13 @@
 ––– block: ../base/start-searchd-with-buddy –––
 ––– input –––
-cat << 'EOF' > /tmp/create_tables.sh
-#!/usr/bin/env bash
 locals=()
 for n in $(seq 1 5000); do
 	locals+=("local='system.t$n'")
 	mysql -h0 -P9306 -e "create table system.t$n (id int)"
 done
-mysql -h0 -P9306 -e "create table t type='distributed' ${locals[*]}"
-EOF
+local_string=$(IFS=' '; echo "${locals[*]}")
+mysql -h0 -P9306 -e "create table t type='distributed' $local_string"
 ––– output –––
-––– input –––
-chmod +x /tmp/create_tables.sh; echo $?
-––– output –––
-0
-––– input –––
-bash /tmp/create_tables.sh; echo $?
-––– output –––
-0
 ––– input –––
 mysql -h0 -P9306 -e "SHOW TABLES LIKE 't'"
 ––– output –––


### PR DESCRIPTION
**Type of Change:**
 - Bug fix

**Change Description:**
- This PR created a CLT test (test-dist-table-shards-5000.rec) to test a fix for a failure in Manticore Search when creating a distributed table with a large number of local tables, which resulted in an invalid pointer error. 
The test ensures that the distributed table creation process no longer fails and correctly handles a large number of local tables.
This fix improves the stability of distributed table creation in scenarios with extensive sharding.

**Related issue:**
- https://github.com/manticoresoftware/manticoresearch/issues/3228