### PR TITLE
🆕 Update buddy version from 3.27.2 to 3.27.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.1+25040420-c6e46da2-dev
-buddy 3.27.2+25040720-e650598d-dev
+buddy 3.27.3+25041621-d40ff5f3-dev
 mcl 4.2.1 25032818 aeac3b3
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.27.2 to 3.27.3 which includes:

[`d40ff5f`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/d40ff5f35436dd556c6060985bfcb4a025e9e825) #3032 Partitions selection support (#522)
