### PR TITLE
Fixes night testing issue in test-migration-es-ms.rec

### DIFF
--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -7,12 +7,10 @@ on:
   pull_request:
     branches: [ master ]
     paths:
-      - 'test/clt-tests/migration-es-ms/**'       # trigger when changes are made in migration test files
-      - 'test/clt-tests/mysqldump/versions/**'     # trigger when changes are made in mysqldump test files
-      - '.github/workflows/nightly_dumps.yml'      # trigger when changes are made in the workflow config
+      - 'test/clt-tests/migration-es-ms/**'       
+      - 'test/clt-tests/mysqldump/versions/**'     
+      - '.github/workflows/nightly_dumps.yml'      
 
-# cancels the previous workflow run when a new one appears in the same branch (e.g. master or a PR's branch)
-concurrency:
   group: nightly_dumps_${{ github.ref }}
   cancel-in-progress: true
 
@@ -28,7 +26,7 @@ jobs:
   clt_test_supported_mysqldump_versions:
     name: Testing supported mysqldump versions
     runs-on: ubuntu-22.04
-    timeout-minutes: 60  
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,10 +47,10 @@ jobs:
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/
-          run_args: --privileged --memory=8g --cpus=4  
+          run_args: --privileged
       - name: Upload .rep File
         if: always()  
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4  
         with:
           name: test-migration-es-ms-rep
           path: test/clt-tests/migration-es-ms/test-migration-es-ms.rep

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -11,6 +11,7 @@ on:
       - 'test/clt-tests/mysqldump/versions/**'     
       - '.github/workflows/nightly_dumps.yml'      
 
+concurrency:
   group: nightly_dumps_${{ github.ref }}
   cancel-in-progress: true
 
@@ -34,7 +35,7 @@ jobs:
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/mysqldump/versions/
-          run_args: --privileged
+          run_args: --privileged --memory=4g --cpus=2
 
   clt_test_migration_es_ms:
     name: Testing data migration from elastic to manticore
@@ -47,10 +48,10 @@ jobs:
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/
-          run_args: --privileged
+          run_args: --privileged --memory=8g --cpus=4
       - name: Upload .rep File
         if: always()  
-        uses: actions/upload-artifact@v4  
+        uses: actions/upload-artifact@v4
         with:
           name: test-migration-es-ms-rep
           path: test/clt-tests/migration-es-ms/test-migration-es-ms.rep

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -28,6 +28,7 @@ jobs:
   clt_test_supported_mysqldump_versions:
     name: Testing supported mysqldump versions
     runs-on: ubuntu-22.04
+    timeout-minutes: 60  
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,6 +41,7 @@ jobs:
   clt_test_migration_es_ms:
     name: Testing data migration from elastic to manticore
     runs-on: ubuntu-22.04
+    timeout-minutes: 60  
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,4 +49,10 @@ jobs:
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/
-          run_args: --privileged
+          run_args: --privileged --memory=8g --cpus=4  
+      - name: Upload .rep File
+        if: always()  
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-migration-es-ms-rep
+          path: test/clt-tests/migration-es-ms/test-migration-es-ms.rep

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -1,16 +1,16 @@
 name: Nightly testing of supported versions of mysqldump and elasticdump
 run-name: 🌙 Nightly tests of mysqldump and elasticdump ${{ github.sha }}
-
 on:
   schedule:
     - cron: '00 20 * * *'
   pull_request:
     branches: [ master ]
     paths:
-      - 'test/clt-tests/migration-es-ms/**'       
-      - 'test/clt-tests/mysqldump/versions/**'     
-      - '.github/workflows/nightly_dumps.yml'      
+      - 'test/clt-tests/migration-es-ms/**'       # trigger when changes are made in migration test files
+      - 'test/clt-tests/mysqldump/versions/**'     # trigger when changes are made in mysqldump test files
+      - '.github/workflows/nightly_dumps.yml'      # trigger when changes are made in the workflow config
 
+# cancels the previous workflow run when a new one appears in the same branch (e.g. master or a PR's branch)
 concurrency:
   group: nightly_dumps_${{ github.ref }}
   cancel-in-progress: true
@@ -35,7 +35,7 @@ jobs:
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/mysqldump/versions/
-          run_args: --privileged --memory=4g --cpus=2
+          run_args: --privileged
 
   clt_test_migration_es_ms:
     name: Testing data migration from elastic to manticore
@@ -48,7 +48,7 @@ jobs:
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/
-          run_args: --privileged --memory=8g --cpus=4
+          run_args: --privileged
       - name: Upload .rep File
         if: always()  
         uses: actions/upload-artifact@v4

--- a/test/clt-tests/bugs/3037-secondary-indexes-bug.rec
+++ b/test/clt-tests/bugs/3037-secondary-indexes-bug.rec
@@ -1,27 +1,8 @@
 ––– block: ../base/start-searchd –––
 ––– input –––
-manticore-load --quiet --json --port=9306 --init="CREATE TABLE task (id BIGINT, status UINT, enddatetime TIMESTAMP, isoverdue BOOL)" --load="INSERT INTO task (id, status, enddatetime, isoverdue) VALUES (<increment>, <int/1/8>, <int/1577836800/1672531200>, 0)" --batch-size=1000 --threads=4 --total=10000
+manticore-load --quiet --json --port=9306 --init="CREATE TABLE task (id BIGINT, status UINT, enddatetime TIMESTAMP, isoverdue BOOL)" --load="INSERT INTO task (id, status, enddatetime, isoverdue) VALUES (<increment>, <int/1/8>, <int/1577836800/1672531200>, 0)" --batch-size=1000 --threads=4 --total=10000 > /dev/null; echo $?
 ––– output –––
-{
-"threads": %{NUMBER},
-"batch_size": %{NUMBER},
-"time": "%{NUMBER}:%{NUMBER}",
-"total_operations": %{NUMBER},
-"operations_per_second": %{NUMBER},
-"qps": {
-"avg": 0,
-"p99": 0,
-"p95": 0,
-"p5": 0,
-"p1": 0
-},
-"latency": {
-"avg": %{NUMBER}.%{NUMBER},
-"p50": %{NUMBER}.%{NUMBER},
-"p95": %{NUMBER}.%{NUMBER},
-"p99": %{NUMBER}.%{NUMBER}
-}
-}
+0
 ––– input –––
 mysql -P9306 -h0 -e "FLUSH RAMCHUNK task;"
 ––– output –––

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -16,6 +16,10 @@ apk add yarn > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––
+docker exec manticore apt-get install jq -y > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
 yarn config set registry https://registry.npmmirror.com > /dev/null 2>&1; echo $?
 ––– output –––
 0

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -12,7 +12,23 @@ docker run -it --privileged --network=test_network --entrypoint=docker-entrypoin
 ––– output –––
 0
 ––– input –––
-docker exec manticore apt-get install jq -y > /dev/null 2>&1; echo $?
+apk add curl > /dev/null 2>&1 && docker exec manticore apt-get install jq -y > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+apk add yarn > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+yarn config set registry https://registry.npmmirror.com > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+timeout 600 yarn global add elasticdump > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+export PATH="$(yarn global bin):$PATH"; echo $?
 ––– output –––
 0
 ––– input –––
@@ -33,24 +49,12 @@ docker run -d --network=test_network --name elastic -p 127.0.0.1:9200:9200 -e di
 ––– output –––
 0
 ––– input –––
-apk add npm > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-npm config set registry https://registry.npmmirror.com && npm cache clean --force > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
-timeout 600 npm install elasticdump -g > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
 docker exec manticore bash -c "page=1; while true; do result=\$(curl -s \"https://hub.docker.com/v2/repositories/elasticdump/elasticsearch-dump/tags/?page_size=100&page=\$page\" | jq -r '.results[].name' | grep -E '^v[0-9]{1}.[0-9]{3}.[0-9]+$' | grep -v '^latest$' | awk -F. '{print substr(\$1,2)}'); [ -z \"\$result\" ] && break; echo \"\$result\"; page=\$((page+1)); done | sort -V | uniq && echo 'latest'"
 ––– output –––
 6
 latest
 ––– input –––
-elasticdump --version
+NODE_OPTIONS="--no-warnings" elasticdump --version
 ––– output –––
 6.#!/[0-9]{3}.[0-9]{1,2}/!#
 ––– input –––
@@ -60,7 +64,7 @@ Archive:  ./test/clt-tests/migration-es-ms/index.zip
 inflating: index_mapping.json
 inflating: index_data.json
 ––– input –––
-elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output=http://localhost:9200/es-index --type=mapping
+NODE_OPTIONS="--no-warnings" timeout 300 elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output=http://localhost:9200/es-index --type=mapping
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source file (offset: 0)
@@ -69,7 +73,7 @@ elasticdump --input=./test/clt-tests/migration-es-ms/index_mapping.json --output
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 2
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
 ––– input –––
-elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=http://localhost:9200/es-index --type=data
+NODE_OPTIONS="--no-warnings" timeout 300 elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=http://localhost:9200/es-index --type=data
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source file (offset: 0)
@@ -86,7 +90,7 @@ elasticdump --input=./test/clt-tests/migration-es-ms/index_data.json --output=ht
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 464
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
 ––– input –––
-elasticdump --input=http://localhost:9200/es-index --output=http://localhost:9308/ms_index  --type=mapping
+NODE_OPTIONS="--no-warnings" timeout 300 elasticdump --input=http://localhost:9200/es-index --output=http://localhost:9308/ms_index  --type=mapping
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 1 objects from source elasticsearch (offset: 0)
@@ -95,7 +99,7 @@ elasticdump --input=http://localhost:9200/es-index --output=http://localhost:930
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | Total Writes: 2
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | dump complete
 ––– input –––
-elasticdump --input=http://localhost:9200/es-index   --output=http://localhost:9308/ms_index --type=data
+NODE_OPTIONS="--no-warnings" timeout 300 elasticdump --input=http://localhost:9200/es-index   --output=http://localhost:9308/ms_index --type=data
 ––– output –––
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | starting dump
 #!/[A-Za-z]{3},\s+\d{2}\s+[A-Za-z]{3}\s+\d{4}\s+\d{2}:\d{2}:\d{2}\s+GMT/!# | got 100 objects from source elasticsearch (offset: 0)

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -12,10 +12,6 @@ docker run -it --privileged --network=test_network --entrypoint=docker-entrypoin
 ––– output –––
 0
 ––– input –––
-apk add curl > /dev/null 2>&1 && docker exec manticore apt-get install jq -y > /dev/null 2>&1; echo $?
-––– output –––
-0
-––– input –––
 apk add yarn > /dev/null 2>&1; echo $?
 ––– output –––
 0

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -33,7 +33,15 @@ docker run -d --network=test_network --name elastic -p 127.0.0.1:9200:9200 -e di
 ––– output –––
 0
 ––– input –––
-apk add pnpm > /dev/null 2>&1; echo $?
+apk add npm > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+npm config set registry https://registry.npmmirror.com && npm cache clean --force > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+timeout 600 npm install elasticdump -g > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––
@@ -41,10 +49,6 @@ docker exec manticore bash -c "page=1; while true; do result=\$(curl -s \"https:
 ––– output –––
 6
 latest
-––– input –––
-pnpm install elasticdump -g > /dev/null 2>&1; echo $?
-––– output –––
-0
 ––– input –––
 elasticdump --version
 ––– output –––

--- a/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
+++ b/test/clt-tests/migration-es-ms/test-migration-es-ms.rec
@@ -33,7 +33,7 @@ docker run -d --network=test_network --name elastic -p 127.0.0.1:9200:9200 -e di
 ––– output –––
 0
 ––– input –––
-apk add npm > /dev/null 2>&1; echo $?
+apk add pnpm > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––
@@ -42,7 +42,7 @@ docker exec manticore bash -c "page=1; while true; do result=\$(curl -s \"https:
 6
 latest
 ––– input –––
-npm install elasticdump -g > /dev/null 2>&1; echo $?
+pnpm install elasticdump -g > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Change Description**
- This PR fixes a problem in the Nightly CI pipeline for the test-migration-es-ms.rec test by making the following changes:
Replace npm with yarn as the package manager for installing elasticdump because npm install elasticdump -g was causing long hangs in CI (5-6 hours).
Split yarn install commands into separate steps for better debugging:
yarn config set registry https://registry.npmmirror.com to set up a faster mirror.
timeout 600 yarn global add elasticdump to install the latest version of elasticdump with timeout.
Added option NODE_OPTIONS="--no-warnings" to suppress AWS SDK obsolescence warnings in elasticdump command output, making the logs cleaner.
Explicitly added export PATH="$(yarn global bin):$PATH" to allow access to globally installed elasticdump in the test environment.
These changes are aimed at stabilizing the test execution, reducing execution time (the test now completes successfully in 1-2 minutes) and improving debugging capabilities by loading the `.rep` file.

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/clt/issues/75
