### PR TITLE
Update test-performance-for-queries-with-multiple-disk-chunks.rec

### DIFF
--- a/test/clt-tests/performance-tests/test-performance-for-queries-with-multiple-disk-chunks.rec
+++ b/test/clt-tests/performance-tests/test-performance-for-queries-with-multiple-disk-chunks.rec
@@ -41,7 +41,7 @@ mysql -h0 -P9306 -e "OPTIMIZE TABLE name OPTION cutoff=1, sync=1;"
 ––– input –––
 mysql -h0 -P9306 -e "show table name status" | grep "disk_chunks"
 ––– output –––
-| disk_chunks                 | 1                                                                                                      |
+| disk_chunks                   | 1                                                                                                      |
 ––– input –––
 export start=$(date +%s%N)
 ––– output –––


### PR DESCRIPTION
Fixed output of `show table name status' | grep “disk_chunks”` command in `test-performance-for-queries-with-multiple-disk-chunks.rec`