### PR TITLE
🆕 Update load version from 1.18.1 to 1.18.2

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.27.3+25041621-d40ff5f3-dev
 mcl 4.2.1 25032818 aeac3b3
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a
-load 1.18.1+25043015-e3e62ba1-dev
+load 1.18.2+25050118-8537968a-dev
 ---
 ! Do not change the separator that splits this desc from the data
 This file should contain one line per package with a version lock.


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.18.1 to 1.18.2 which includes:

[`8537968`](https://github.com/manticoresoftware/manticore-load/commit/8537968a9609accd8c1b6afa1ea8d61cbdc98100) fix: ensure text ends with a period only if not empty in query generation
