### PR TITLE
🆕 Update buddy version from 3.27.3 to 3.28.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.1+25040420-c6e46da2-dev
-buddy 3.27.3+25041710-16c4b372-dev
+buddy 3.28.0+25050619-ba0b7452-dev
 mcl 4.2.1 25032818 aeac3b3
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.1+25040420-c6e46da2-dev
-buddy 3.27.3+25041621-d40ff5f3-dev
+buddy 3.27.3+25041710-16c4b372-dev
 mcl 4.2.1 25032818 aeac3b3
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a

--- a/test/clt-tests/base/replication/start-searchd-precach.recb
+++ b/test/clt-tests/base/replication/start-searchd-precach.recb
@@ -5,6 +5,6 @@ mkdir -p /var/{run,lib,log}/manticore-${INSTANCE}
 stdbuf -oL searchd -c test/clt-tests/base/searchd-with-flexible-ports.conf > /dev/null
 ––– output –––
 ––– input –––
-if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore-${INSTANCE}/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; cat /var/log/manticore-${INSTANCE}/searchd.log; exit 1; fi
+if timeout 10 grep -qm1 '\[BUDDY\] started' <(tail -n 1000 -f /var/log/manticore-${INSTANCE}/searchd.log); then echo 'Buddy started!'; else echo 'Timeout or failed!'; cat /var/log/manticore-${INSTANCE}/searchd.log; fi
 ––– output –––
 Buddy started!

--- a/test/clt-tests/core/test-truncate-distributed-table.rec
+++ b/test/clt-tests/core/test-truncate-distributed-table.rec
@@ -1,0 +1,34 @@
+––– input –––
+export INSTANCE=1
+––– output –––
+––– block: ../base/replication/start-searchd-precach –––
+––– input –––
+export INSTANCE=2
+––– output –––
+––– block: ../base/replication/start-searchd-precach –––
+––– input –––
+mysql -h0 -P1306 -e "
+CREATE TABLE t1 (title TEXT, content TEXT);
+INSERT INTO t1 (title, content) VALUES ('Local Title 1', 'Local Content 1'), ('Local Title 2', 'Local Content 2');
+"
+––– output –––
+––– input –––
+mysql -h0 -P2306 -e "
+CREATE TABLE t2 (title TEXT, content TEXT);
+INSERT INTO t2 (title, content) VALUES ('Local Title 3', 'Local Content 3'), ('Local Title 4', 'Local Content 4');
+"
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e " CREATE TABLE dist_table type='distributed' local='t1' agent='127.0.0.1:2312:t2' "
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e "SELECT COUNT(*) FROM dist_table\G" | grep count
+––– output –––
+count(*): 4
+––– input –––
+mysql -h0 -P1306 -e "TRUNCATE TABLE dist_table"
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e "SELECT COUNT(*) FROM dist_table\G" | grep count
+––– output –––
+count(*): 0


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.27.3 to 3.28.0 which includes:

[`ba0b745`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/ba0b7452ae9f7edeed336f6a25c0aa82bdfa6dc8) feat: Updated logic to handle requests from latest logstash/beats (#532)
