### PR TITLE
🆕 Update buddy version from 3.28.0 to 3.28.1

### DIFF
--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -113,24 +113,10 @@ jobs:
   # Job to check dependencies using check_deps_in_repos.sh
   # Runs on every PR, workflow_run, or push event matching the conditions
   check_deps:
+    needs: pack
+    if: needs.pack.outputs.should_continue == 'true'
     name: Check deps test
     runs-on: ubuntu-22.04
-    if: |
-      github.event_name == 'pull_request'
-      ||
-      (
-        github.event_name == 'workflow_run'
-        &&
-        github.event.workflow_run.conclusion == 'success'
-        &&
-        github.ref == 'refs/heads/master'
-      )
-      ||
-      (
-        github.event_name == 'push'
-        &&
-        startsWith(github.ref, 'refs/heads/manticore-')
-      )
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -141,8 +127,7 @@ jobs:
   pack_debian_ubuntu:
     name: Debian/Ubuntu packages
     uses: ./.github/workflows/build_template.yml
-    needs: [pack, check_deps]
-    if: needs.pack.outputs.should_continue == 'true'
+    needs: check_deps
     strategy:
       fail-fast: false
       matrix:
@@ -165,8 +150,7 @@ jobs:
   pack_rhel:
     name: RHEL packages
     uses: ./.github/workflows/build_template.yml
-    needs: [pack, check_deps]
-    if: needs.pack.outputs.should_continue == 'true'
+    needs: check_deps
     strategy:
       fail-fast: false
       matrix:
@@ -192,8 +176,7 @@ jobs:
   pack_macos:
     name: MacOS packages
     uses: ./.github/workflows/build_template.yml
-    needs: [pack, check_deps]
-    if: needs.pack.outputs.should_continue == 'true'
+    needs: check_deps
     strategy:
       fail-fast: false
       matrix:
@@ -217,8 +200,7 @@ jobs:
   pack_windows:
     name: Windows x64 package
     uses: ./.github/workflows/build_template.yml
-    needs: [pack, check_deps]
-    if: needs.pack.outputs.should_continue == 'true'
+    needs: check_deps
     with:
       DISTR: windows
       arch: x64

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.1+25040420-c6e46da2-dev
-buddy 3.28.0+25050619-ba0b7452-dev
+buddy 3.28.1+25050814-7518e5dd-dev
 mcl 4.2.1 25032818 aeac3b3
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.28.0 to 3.28.1 which includes:

[`7518e5d`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/7518e5dd81ce68d2dec449ddfe9645ee39cbc681) Fix: Use truncate instead of delete from cuz its faster when truncate distributed table
