### PR TITLE
🆕 Update buddy version from 3.28.1 to 3.28.2

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.1+25040420-c6e46da2-dev
-buddy 3.28.1+25050814-7518e5dd-dev
+buddy 3.28.2+25051611-f551499b-dev
 mcl 4.2.1 25032818 aeac3b3
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.28.1 to 3.28.2 which includes:

[`f551499`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/f551499b67b35d8065abfb67d028bfe21e8951ea) Fix critical bug with fuzzy matching in some cases (#538)
