### PR TITLE
Update clt test-supported-mysqldump-versions

### DIFF
--- a/test/clt-tests/mysqldump/versions/test-supported-mysqldump-versions.rec
+++ b/test/clt-tests/mysqldump/versions/test-supported-mysqldump-versions.rec
@@ -29,7 +29,6 @@ docker exec manticore bash -c "curl -s https://hub.docker.com/v2/repositories/li
 10.11
 11.2
 11.4
-11.5
 11.6
 11.7
 ––– input –––


### PR DESCRIPTION
Mariadb version 11.5 has been removed from - https://hub.docker.com/v2/repositories/library/mariadb/tags/?page_size=100.