### PR TITLE
Expand the "Creating a table" section in the manual 

### DIFF
--- a/manual/Creating_a_table.md
+++ b/manual/Creating_a_table.md
@@ -1,2 +1,39 @@
 # Creating a table
 <!-- proofread -->
+
+Manticore Search offers several ways to create tables, each designed for different use cases and requirements. This section covers the main approaches and their specific configurations.
+
+## Table Types
+
+Manticore supports different types of tables:
+
+- **Real-time tables** - For real-time updates and immediate searchability
+- **Plain tables** - For static data that doesn't require frequent updates
+- **Percolate tables** - For storing and matching search queries
+- **Template tables** - For creating table templates
+- **Distributed tables** - For scaling across multiple nodes
+
+## Key Components
+
+When creating a table, you'll need to consider:
+
+1. **Data Types** - Understanding the available data types and their storage options
+2. **NLP and Tokenization** - Configuring how your text data is processed and indexed
+3. **Table Structure** - Defining the schema and settings for your specific use case
+
+## Getting Started
+
+To create a table, you'll need to:
+
+1. Choose the appropriate table type for your use case
+2. Define the table schema with the required fields and attributes
+3. Configure the necessary settings for your specific requirements
+
+For detailed information about each aspect, refer to the following sections:
+
+- [Data types](Creating_a_table/Data_types.md) - Learn about supported data types and storage options
+- [Creating a local table](Creating_a_table/Local_tables.md) - Detailed guide for creating different types of local tables
+- [NLP and tokenization](Creating_a_table/NLP_and_tokenization/Data_tokenization.md) - Configure text processing and indexing
+- [Creating a distributed table](Creating_a_table/Creating_a_distributed_table/Creating_a_distributed_table.md) - Set up distributed tables for scaling
+
+Each of these sections provides in-depth information about their specific aspects of table creation in Manticore Search.


### PR DESCRIPTION
Now it's just empty which looks bad - https://manual.manticoresearch.com/Creating_a_table

![image](https://github.com/user-attachments/assets/b6299463-cc85-48e7-af50-c5ca5fd55e47)
