### PR TITLE
Add CLT test for RT table locking during cluster operations

### DIFF
--- a/test/clt-tests/bugs/3247-rt-save-disk-chunk-race.rec
+++ b/test/clt-tests/bugs/3247-rt-save-disk-chunk-race.rec
@@ -1,4 +1,3 @@
-
 –––– comment –––
 Test verifies that RT table locking functions wait for active disk chunk write completion and prevent changes after table lock
 ––– input –––
@@ -19,13 +18,19 @@ mysql -h0 -P1306 -e "create cluster test;"
 mysql -h0 -P1306 -e "alter cluster test add t2;"
 ––– output –––
 ––– input –––
-manticore-load --quiet --port=1306 --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" > /dev/null 2>&1 &
+manticore-load --quiet --port=1306 --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" > /dev/null 2>&1
+––– output –––
+––– input –––
+manticore-load --quiet --port=1306 --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=500000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" > /dev/null 2>&1 &
+––– output –––
+––– input –––
+timeout 10 bash -c 'while ! pgrep -f "manticore-load.*1306" > /dev/null; do sleep 0.1; done'
 ––– output –––
 ––– input –––
 mysql -h0 -P2306 -e "join cluster test at '127.0.0.1:1312';"
 ––– output –––
 ––– input –––
-sleep 20
+timeout 30 bash -c 'while ! mysql -h0 -P2306 -e "SHOW TABLES;" 2>/dev/null | grep -q "t2"; do sleep 1; done'
 ––– output –––
 ––– input –––
 mysql -h0 -P2306 -e "SHOW TABLES;"

--- a/test/clt-tests/bugs/3247-rt-save-disk-chunk-race.rec
+++ b/test/clt-tests/bugs/3247-rt-save-disk-chunk-race.rec
@@ -1,0 +1,62 @@
+
+–––– comment –––
+Test verifies that RT table locking functions wait for active disk chunk write completion and prevent changes after table lock
+––– input –––
+export INSTANCE=1
+––– output –––
+––– block: ../base/replication/start-searchd-precach –––
+––– input –––
+export INSTANCE=2
+––– output –––
+––– block: ../base/replication/start-searchd-precach –––
+––– input –––
+mysql -h0 -P1306 -e "CREATE TABLE t2 ( id bigint, f1 text, f2 text, idd bigint, tag bigint ) optimize_cutoff='4' rt_mem_limit='64M';"
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e "create cluster test;"
+––– output –––
+––– input –––
+mysql -h0 -P1306 -e "alter cluster test add t2;"
+––– output –––
+––– input –––
+manticore-load --quiet --port=1306 --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" --together --batch-size=1000 --threads=2 --total=1000000 --load="replace INTO test:t2(idd,tag,f1) VALUES(<increment>,<int/1/100>,'<text/10/100>')" > /dev/null 2>&1 &
+––– output –––
+––– input –––
+mysql -h0 -P2306 -e "join cluster test at '127.0.0.1:1312';"
+––– output –––
+––– input –––
+sleep 20
+––– output –––
+––– input –––
+mysql -h0 -P2306 -e "SHOW TABLES;"
+––– output –––
++-------+------+
+| Table | Type |
++-------+------+
+| t2    | rt   |
++-------+------+
+––– input –––
+mysql -h0 -P1306 -e "SHOW TABLE t2 STATUS\G" | grep -A1 -E "ram_bytes|disk_bytes"
+––– output –––
+Variable_name: ram_bytes
+        Value: %{NUMBER}
+--
+Variable_name: disk_bytes
+        Value: %{NUMBER}
+--
+Variable_name: ram_bytes_retired
+        Value: 0
+––– input –––
+mysql -h0 -P2306 -e "SHOW TABLE t2 STATUS\G" | grep -A1 -E "ram_bytes|disk_bytes"
+––– output –––
+Variable_name: ram_bytes
+        Value: %{NUMBER}
+--
+Variable_name: disk_bytes
+        Value: %{NUMBER}
+--
+Variable_name: ram_bytes_retired
+        Value: 0
+––– input –––
+pkill -f manticore-load
+––– output –––


### PR DESCRIPTION
**Type of Change:**
- Bug fix

**Description of the Change:**
- Added clt test to lock the RT table during cluster join operations. This test checks for a race condition between saving RT disk fragments and SST operations, which could cause “failed to open *.ram” errors when joining clusters under heavy data load.

**Related Issue (provide the link):**
-  https://github.com/manticoresoftware/manticoresearch/issues/3247
