### PR TITLE
🆕 Update buddy version from 3.31.0 to 3.32.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.5+25060614-6bfc96f0-dev
-buddy 3.31.0+25070312-2cdcee31-dev
+buddy 3.32.0+25070311-52cd2f76-dev
 mcl 8.0.0+25070113-1f686815-dev
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.31.0 to 3.32.0 which includes:

[`52cd2f7`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/52cd2f76238584e2f2ec33a6321e060be1b4793a) Feat: @@collation_database query support (#576)
