### PR TITLE
🆕 Update load version from 1.18.2 to 1.19.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.32.0+25070311-52cd2f76-dev
 mcl 8.0.0+25070113-1f686815-dev
 executor 1.3.1 25011510 1856ac9
 tzdata 1.0.1 240904 3ba592a
-load 1.18.2+25050118-8537968a-dev
+load 1.19.0+25063014-1ff59652
 ---
 ! Do not change the separator that splits this desc from the data
 This file should contain one line per package with a version lock.


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.18.2 to 1.19.0 which includes:

[`8f21b4c`](https://github.com/manticoresoftware/manticore-load/commit/8f21b4ccb03bc2a85185a0e15417061a57da6b75) Feat: RHEL 10 support Ref: manticoresoftware/manticoresearch/issues/3426
