### PR TITLE
Fix Docker image compatibility

### DIFF
--- a/test/clt-tests/sharding/drop/test-drop-sharded-table.rec
+++ b/test/clt-tests/sharding/drop/test-drop-sharded-table.rec
@@ -12,7 +12,7 @@ if timeout 30 sh -c "docker logs -f manticore_remote 2>&1 | grep -qm1 'accepting
 ––– output –––
 accepting connections
 ––– input –––
-docker run -d --name manticore_dist --network manticore_network --platform linux/amd64 manticoresearch/manticore:latest > /dev/null 2>&1; echo $?
+docker run -d --name manticore_dist --network manticore_network manticoresearch/manticore:latest > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––

--- a/test/clt-tests/tables-interaction/test-tables-interaction.rec
+++ b/test/clt-tests/tables-interaction/test-tables-interaction.rec
@@ -12,7 +12,7 @@ if timeout 30 sh -c "docker logs -f manticore_remote 2>&1 | grep -qm1 'accepting
 ––– output –––
 accepting connections
 ––– input –––
-docker run -d --name manticore_dist --network manticore_network --platform linux/amd64 manticoresearch/manticore:latest > /dev/null 2>&1; echo $?
+docker run -d --name manticore_dist --network manticore_network manticoresearch/manticore:latest > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––


### PR DESCRIPTION
Fixing Docker image compatibility

**Description:**
The tests `test-tables-interaction.rec` and `test-drop-sharded-table.rec` failed because the `manticoresearch/manticore:latest` image does not have a manifest for the `linux/amd64` architecture, which caused the container creation to fail with the error:
`docker: no suitable manifest for linux/amd64 in manifest entry list`.
As a result, all subsequent `docker exec` commands ended with the error `“No such container”`.

**Changes:**
Fixed the test error by removing the `--platform linux/amd64` flag from 
container creation. The manticoresearch/manticore:latest image 
does not support explicit specification of the `linux/amd64 platform`, 
but works when Docker automatically selects the platform.