### PR TITLE
Stricter branch comparison

### DIFF
--- a/actions/update-deps/action.yml
+++ b/actions/update-deps/action.yml
@@ -91,6 +91,7 @@ runs:
         if ! git ls-remote --exit-code --heads origin ${{ steps.branch.outputs.branch }}; then
           git checkout -b ${{ steps.branch.outputs.branch }} origin/master
         else
+          echo "HERE"
           git checkout ${{ steps.branch.outputs.branch }}
         fi
 

--- a/actions/update-deps/action.yml
+++ b/actions/update-deps/action.yml
@@ -88,10 +88,9 @@ runs:
         #
         # Fetch branch or create it
         git fetch origin
-        if ! git ls-remote --exit-code --heads origin ${{ steps.branch.outputs.branch }}; then
+        if ! git ls-remote --exit-code --heads origin refs/heads/${{ steps.branch.outputs.branch }}; then
           git checkout -b ${{ steps.branch.outputs.branch }} origin/master
         else
-          echo "HERE"
           git checkout ${{ steps.branch.outputs.branch }}
         fi
 

--- a/actions/update-deps/action.yml
+++ b/actions/update-deps/action.yml
@@ -76,7 +76,6 @@ runs:
       id: branch
       shell: bash
       run: |
-        echo "branch=update-${{ inputs.name }}-version"
         echo "branch=update-${{ inputs.name }}-version" >> $GITHUB_OUTPUT
         echo "source_branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
         echo "target=master" >> $GITHUB_OUTPUT

--- a/actions/update-deps/action.yml
+++ b/actions/update-deps/action.yml
@@ -76,6 +76,7 @@ runs:
       id: branch
       shell: bash
       run: |
+        echo "branch=update-${{ inputs.name }}-version"
         echo "branch=update-${{ inputs.name }}-version" >> $GITHUB_OUTPUT
         echo "source_branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
         echo "target=master" >> $GITHUB_OUTPUT


### PR DESCRIPTION
`refs/heads/` is required, otherwise `git ls-remote ... update-executor-version` matches:

```
f516730f874b1f2ab80e7eb4315d2964309e999c	refs/heads/feature/update-executor-version
```