### PR TITLE
Excluding the Debian Buster image from nightly testing in CI

### DIFF
--- a/.github/workflows/clt_nightly.yml
+++ b/.github/workflows/clt_nightly.yml
@@ -75,9 +75,6 @@ jobs:
           - name: Jammy release installation
             image: ubuntu:jammy
             test_prefix: test/clt-tests/installation/deb-release-
-          - name: Buster release installation
-            image: debian:buster
-            test_prefix: test/clt-tests/installation/deb-release-
           - name: Bullseye release installation
             image: debian:bullseye
             test_prefix: test/clt-tests/installation/deb-release-
@@ -110,9 +107,6 @@ jobs:
             test_prefix: test/clt-tests/installation/deb-dev-u
           - name: Jammy upgrade to dev
             image: ubuntu:jammy
-            test_prefix: test/clt-tests/installation/deb-dev-u
-          - name: Buster upgrade to dev
-            image: debian:buster
             test_prefix: test/clt-tests/installation/deb-dev-u
           - name: Bullseye upgrade to dev
             image: debian:bullseye
@@ -200,9 +194,6 @@ jobs:
           - name: Jammy release installation
             image: ubuntu:jammy
             test_prefix: test/clt-tests/installation/deb-release-
-          - name: Buster release installation
-            image: debian:buster
-            test_prefix: test/clt-tests/installation/deb-release-
           - name: Bullseye release installation
             image: debian:bullseye
             test_prefix: test/clt-tests/installation/deb-release-
@@ -235,9 +226,6 @@ jobs:
             test_prefix: test/clt-tests/installation/deb-dev-u
           - name: Jammy upgrade to dev
             image: ubuntu:jammy
-            test_prefix: test/clt-tests/installation/deb-dev-u
-          - name: Buster upgrade to dev
-            image: debian:buster
             test_prefix: test/clt-tests/installation/deb-dev-u
           - name: Bullseye upgrade to dev
             image: debian:bullseye

--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -193,7 +193,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
+        DISTR: [bionic, focal, jammy, bullseye, bookworm]
         arch: [x86_64, aarch64]
     with:
       COLUMNAR_LOCATOR: ${{ needs.check_branch.outputs.columnar_locator }}
@@ -338,7 +338,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
+        DISTR: [bionic, focal, jammy, bullseye, bookworm]
         arch: [x86_64, aarch64]
     runs-on: ubuntu-22.04
     name: ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
@@ -468,7 +468,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:buster", "debian:bullseye", "debian:bookworm" ]
+        image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
       - uses: manticoresoftware/clt@0.6.9

--- a/.github/workflows/pack_publish_galera.yml
+++ b/.github/workflows/pack_publish_galera.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
+        DISTR: [bionic, focal, jammy, bullseye, bookworm]
         arch: [x86_64, aarch64]
     with:
       DISTR: ${{ matrix.DISTR }}
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
+        DISTR: [bionic, focal, jammy, bullseye, bookworm]
         arch: [x86_64, aarch64]
     runs-on: ubuntu-22.04
     name: ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:buster", "debian:bullseye", "debian:bookworm" ]
+        image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
       - uses: manticoresoftware/clt@0.6.9


### PR DESCRIPTION
**Type of Change):**
- Bug fix

**Description of the Change:**
- Remove Debian Buster from nightly CI testing as it has reached end-of-life and is no longer supported. The failing tests are caused by outdated packages and lack of security updates. Testing continues on supported Debian versions (Bullseye and Bookworm).