### PR TITLE
ci: fixed a bug that skipped build failures for Manticore in PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,7 +275,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Download built x86_64 Ubuntu Jammy packages
         uses: manticoresoftware/download_artifact_with_retries@v3
-        continue-on-error: true
         with:
           name: build_jammy_RelWithDebInfo_x86_64
           path: .


### PR DESCRIPTION
Fixed a bug that skipped build failures for Manticore in PRs and still ran CLT tests using the default Manticore from the latest Docker image as a base. This caused unstable Manticore versions (sometimes 0.0.0, sometimes 13.4.2), which is bad for tests since mysqldump is sensitive to the version (its behaviour differs depending on whether the version is 0.0.0 or not)