### PR TITLE
🆕 Update buddy version from 3.34.1 to 3.34.2

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.34.1+25080614-4af98c50-dev
+buddy 3.34.2+25080617-ff540bfc-dev
 mcl 8.0.1+25072222-fc30df67-dev
 executor 1.3.5+25071517-8398b079
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.34.1 to 3.34.2 which includes:

[`ff540bf`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/ff540bfc8fbb351e81b99f0bba668a402a669f96) Updated handling of unsupported MySQL variables (#585)
