### PR TITLE
Adjustment of night tests after the release of 13.6.8

### DIFF
--- a/test/clt-tests/installation/deb-dev-update.rec
+++ b/test/clt-tests/installation/deb-dev-update.rec
@@ -75,7 +75,7 @@ apt-get update -y > /dev/null; echo $?
 ––– input –––
 apt -y install manticore manticore-extra manticore-common manticore-server manticore-server-core manticore-tools manticore-executor manticore-buddy manticore-backup manticore-columnar-lib manticore-server-core-dbgsym manticore-tools-dbgsym manticore-columnar-lib-dbgsym manticore-icudata-65l manticore-galera > /dev/null 2>&1; echo $?
 ––– output –––
-100
+0
 ––– block: stop-searchd-dev –––
 ––– block: start-searchd-dev –––
 ––– block: check-version/export-new-version –––


### PR DESCRIPTION
Adjustment of night tests after the release of 13.6.8, as there was previously an error due to version mismatch.