### PR TITLE
chore(ci): upgrade clt to v0.7.3 and set ui_host

### DIFF
--- a/.github/workflows/clt_nightly.yml
+++ b/.github/workflows/clt_nightly.yml
@@ -144,12 +144,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: ${{ matrix.test_prefix }}
           image: ${{ matrix.image }}
           comment_mode: failures
           run_args: --privileged 
+          ui_host: "https://clt.manticoresearch.com"
           
   clt-arm64:
     name: CLT-Arm64
@@ -233,9 +234,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: ${{ matrix.test_prefix }}
           image: ${{ matrix.image }}
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
+

--- a/.github/workflows/clt_tests.yml
+++ b/.github/workflows/clt_tests.yml
@@ -76,7 +76,7 @@ jobs:
             test_prefix: test/clt-tests/vector-knn/
               
     steps:
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           artifact: ${{ inputs.artifact_name }}
           image: ${{ inputs.docker_image }}
@@ -84,3 +84,5 @@ jobs:
           ref: ${{ inputs.ref }}
           test_prefix: ${{ matrix.test-suite.test_prefix }}
           comment_mode: failures
+          ui_host: "https://clt.manticoresearch.com"
+

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -31,11 +31,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/mysqldump/versions/
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   clt_test_migration_es_ms:
     name: Testing data migration from elastic to manticore
@@ -44,14 +45,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
+
       - name: Upload .rep File
         if: always()  
         uses: actions/upload-artifact@v4
         with:
           name: test-migration-es-ms-rep
           path: test/clt-tests/migration-es-ms/test-migration-es-ms.rep
+

--- a/.github/workflows/nightly_integration.yml
+++ b/.github/workflows/nightly_integration.yml
@@ -32,12 +32,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-dbeaver
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   test_filebeat:
     name: Test Filebeat integration
@@ -46,12 +47,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-filebeat
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   test_fluentbit:
     name: Test Fluentbit integration
@@ -60,7 +62,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-fluentbit
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -74,12 +76,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-logstash
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   test_support_filebeat_versions:
     name: Test Filebeat versions support
@@ -88,12 +91,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-support-filebeat-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   test_support_logstash_versions:
     name: Test Logstash versions support
@@ -102,12 +106,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-support-logstash-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   test_vector:
     name: Test Vector integration
@@ -116,12 +121,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/test-integrations-vector
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"
 
   test_kafka:
     name: Test Kafka integration
@@ -130,9 +136,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           test_prefix: test/clt-tests/integrations/kafka/test-integration-
           image: manticoresearch/dind:v1
           comment_mode: failures
           run_args: --privileged
+          ui_host: "https://clt.manticoresearch.com"

--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -456,11 +456,12 @@ jobs:
         image: [ "almalinux:8", "almalinux:9", "almalinux:10", "oraclelinux:9", "amazonlinux:latest" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/rhel-dev-
           run_args: -e TELEMETRY=0
+          ui_host: "https://clt.manticoresearch.com"
 
   clt_deb_dev_installation:
     name: Testing DEB dev packages installation
@@ -471,8 +472,10 @@ jobs:
         image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/deb-dev-
           run_args: -e TELEMETRY=0
+          ui_host: "https://clt.manticoresearch.com"
+

--- a/.github/workflows/pack_publish_galera.yml
+++ b/.github/workflows/pack_publish_galera.yml
@@ -205,10 +205,11 @@ jobs:
         image: [ "almalinux:8", "almalinux:9", "almalinux:10", "oraclelinux:9", "amazonlinux:latest" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/rhel-dev-
+          ui_host: "https://clt.manticoresearch.com"
 
   clt_deb_dev_installation:
     name: Testing DEB dev packages installation
@@ -219,7 +220,8 @@ jobs:
         image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.6.9
+      - uses: manticoresoftware/clt@0.7.3
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/deb-dev-
+          ui_host: "https://clt.manticoresearch.com"


### PR DESCRIPTION
- Update clt version to v0.7.3 in workflows
- Configure ui_host environment variable in CI workflows

<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change (select one):**
- Bug fix 
- New feature
- Documentation update

**Description of the Change:**

**Related Issue (provide the link):**
