### PR TITLE
Incorrect request removed from test-alter-rename-http.rec test

### DIFF
--- a/test/clt-tests/core/test-alter-rename-http.rec
+++ b/test/clt-tests/core/test-alter-rename-http.rec
@@ -38,12 +38,6 @@ mysql -h0 -P9306 -e "SHOW TABLES"
 | products_new | rt   |
 +--------------+------+
 ––– comment –––
-Test HTTP API basic functionality
-––– input –––
-curl -s "http://localhost:9308/sql?query=SHOW+VERSION" | grep -o '"Component":"Daemon"'
-––– output –––
-"Component":"Daemon"
-––– comment –––
 Test data retrieval via HTTP API
 ––– input –––
 curl -s "http://localhost:9308/sql?query=SELECT+*+FROM+articles+LIMIT+1" | grep -o '"_id":1'


### PR DESCRIPTION
**Type of Change:**
- Bug fix 

**Description of the Change:**
- Removed an incorrect request from the test-alter-rename-http.rec test, performed in another test on the correct endpoint.

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch/issues/3520