### PR TITLE
Add automatic documentation update for mysqldump supported versions

### DIFF
--- a/test/clt-tests/mysqldump/versions/script_versions.sh
+++ b/test/clt-tests/mysqldump/versions/script_versions.sh
@@ -1,18 +1,58 @@
 #!/bin/bash
 set -e
 
-# Check for new major.minor versions
-echo "🔍 Checking for new major.minor versions..."
-
+# Latest supported versions - UPDATE THESE when adding new versions
 LATEST_MARIADB="12.0"
 LATEST_MYSQL="9.4"
+
+# Path to documentation file
+DOC_FILE="../../../manual/english/Securing_and_compacting_a_table/Backup_and_restore.md"
+
+# Function to update documentation with latest versions
+update_documentation() {
+    if [ ! -f "$DOC_FILE" ]; then
+        echo "⚠️ Documentation file not found at $DOC_FILE, skipping documentation update"
+        return
+    fi
+
+    # Create backup of documentation
+    cp "$DOC_FILE" "$DOC_FILE.bak"
+
+    # Update MariaDB version in documentation
+    # Matches patterns like "MariaDB up to 12.0", "MariaDB (up to version 12.0)", etc.
+    sed -i \
+        -e "s/MariaDB\( up to\| versions up to\| up to version\)\? [0-9]\+\.[0-9]\+/MariaDB up to $LATEST_MARIADB/g" \
+        -e "s/mariadb-dump (up to [0-9]\+\.[0-9]\+)/mariadb-dump (up to $LATEST_MARIADB)/g" \
+        "$DOC_FILE"
+
+    # Update MySQL version in documentation
+    # Matches patterns like "MySQL up to 9.4", "MySQL (up to version 9.4)", etc.
+    sed -i \
+        -e "s/MySQL\( up to\| versions up to\| up to version\)\? [0-9]\+\.[0-9]\+/MySQL up to $LATEST_MYSQL/g" \
+        -e "s/mysqldump (up to [0-9]\+\.[0-9]\+)/mysqldump (up to $LATEST_MYSQL)/g" \
+        "$DOC_FILE"
+
+    # Check if documentation was actually changed
+    if diff -q "$DOC_FILE.bak" "$DOC_FILE" > /dev/null; then
+        echo "📝 Documentation already up to date"
+        rm "$DOC_FILE.bak"
+    else
+        echo "📝 Documentation updated: MariaDB up to $LATEST_MARIADB, MySQL up to $LATEST_MYSQL"
+        echo "   Backup saved as $DOC_FILE.bak"
+    fi
+}
+
+# Check for new major.minor versions on Docker Hub
+echo "🔍 Checking for new major.minor versions..."
 
 if command -v curl >/dev/null 2>&1; then
     found_new=false
 
+    # Fetch available versions from Docker Hub
     mariadb_versions=$(curl -s "https://hub.docker.com/v2/repositories/library/mariadb/tags/?page_size=100" 2>/dev/null | grep -o '"name":"[0-9]*\.[0-9]*"' | grep -o '[0-9]*\.[0-9]*' | sort -V)
     mysql_versions=$(curl -s "https://hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" 2>/dev/null | grep -o '"name":"[0-9]*\.[0-9]*"' | grep -o '[0-9]*\.[0-9]*' | sort -V)
 
+    # Check for newer MariaDB versions
     newer_mariadb=$(echo "$mariadb_versions" | awk -v latest="$LATEST_MARIADB" '
     function version_compare(v1, v2) {
         split(v1, a, ".")
@@ -25,9 +65,15 @@ if command -v curl >/dev/null 2>&1; then
     if [ -n "$newer_mariadb" ]; then
         echo "🆕 NEW MariaDB versions detected:"
         echo "$newer_mariadb" | sed 's/^/  - mariadb:/'
+        echo ""
+        echo "Action required:"
+        echo "1. Update LATEST_MARIADB variable to the new version"
+        echo "2. Add new version(s) to the versions array"
+        echo "3. Run the test again"
         found_new=true
     fi
 
+    # Check for newer MySQL versions
     newer_mysql=$(echo "$mysql_versions" | awk -v latest="$LATEST_MYSQL" '
     function version_compare(v1, v2) {
         split(v1, a, ".")
@@ -40,13 +86,21 @@ if command -v curl >/dev/null 2>&1; then
     if [ -n "$newer_mysql" ]; then
         echo "🆕 NEW MySQL versions detected:"
         echo "$newer_mysql" | sed 's/^/  - mysql:/'
+        echo ""
+        echo "Action required:"
+        echo "1. Update LATEST_MYSQL variable to the new version"
+        echo "2. Add new version(s) to the versions array"
+        echo "3. Run the test again"
         found_new=true
     fi
 
-    if [ "$found_new" = false ]; then
-        echo "✅ No new versions found after MariaDB $LATEST_MARIADB and MySQL $LATEST_MYSQL"
+    if [ "$found_new" = true ]; then
+        echo ""
+        echo "❗ Please update the script with new versions and run again!"
+        echo "❗ Documentation will be automatically updated after successful tests"
+        exit 1
     else
-        echo "❗ Please update the versions array and test new versions!"
+        echo "✅ No new versions found after MariaDB $LATEST_MARIADB and MySQL $LATEST_MYSQL"
     fi
 
     echo "✅ Version check completed"
@@ -55,12 +109,25 @@ else
 fi
 echo ""
 
-# MariaDB and MySQL versions
-versions=("mariadb:10.5" "mariadb:10.6" "mariadb:10.7" "mariadb:10.8" "mariadb:10.9" "mariadb:10.10" "mariadb:10.11" "mariadb:11.0" "mariadb:11.1" "mariadb:11.2" "mariadb:11.3-rc" "mariadb:11.4" "mariadb:11.5" "mariadb:11.6" "mariadb:11.7" "mariadb:11.8" "mariadb:12.0" "mariadb:latest" "mysql:5.6" "mysql:5.7" "mysql:8.0" "mysql:8.2" "mysql:8.3" "mysql:8.4" "mysql:9.0" "mysql:9.1" "mysql:9.2" "mysql:9.3" "mysql:9.4" "mysql:latest")
+# Array of versions to test - ADD NEW VERSIONS HERE
+versions=(
+    # MariaDB versions
+    "mariadb:10.5" "mariadb:10.6" "mariadb:10.7" "mariadb:10.8"
+    "mariadb:10.9" "mariadb:10.10" "mariadb:10.11"
+    "mariadb:11.0" "mariadb:11.1" "mariadb:11.2" "mariadb:11.3-rc"
+    "mariadb:11.4" "mariadb:11.5" "mariadb:11.6" "mariadb:11.7"
+    "mariadb:11.8" "mariadb:12.0"
+    "mariadb:latest"
+    # MySQL versions
+    "mysql:5.6" "mysql:5.7"
+    "mysql:8.0" "mysql:8.2" "mysql:8.3" "mysql:8.4"
+    "mysql:9.0" "mysql:9.1" "mysql:9.2" "mysql:9.3" "mysql:9.4"
+    "mysql:latest"
+)
 
-# Going through all the versions
+# Test all versions
 for version in "${versions[@]}"; do
-    # Defining the database type
+    # Determine database type and dump command
     if [[ $version == mariadb* ]]; then
         db_type="mariadb"
         dump_command="mariadb-dump"
@@ -71,29 +138,45 @@ for version in "${versions[@]}"; do
 
     echo "Testing version: $version"
 
-    # Start the container
+    # Start the database container
     docker pull --platform linux/amd64 -q $version > /dev/null
-    docker run --rm -d --network=test_network --platform linux/amd64 --name db-test -e MYSQL_ROOT_PASSWORD=my-secret-pw $version bash -c "tail -f /dev/null" > /dev/null
+    docker run --rm -d --network=test_network --platform linux/amd64 --name db-test \
+        -e MYSQL_ROOT_PASSWORD=my-secret-pw $version bash -c "tail -f /dev/null" > /dev/null
     sleep 5
 
-    # Executing dump
+    # Execute dump from the database container to Manticore
     docker exec db-test $dump_command -hmanticore -P9306 manticore t > dump.sql 2> >(grep -E -v "Warning: column statistics|Warning: version string returned by server is incorrect." >&2)
+
+    # Drop the table in Manticore to prepare for restore
     docker exec manticore mysql -h0 -P9306 -e "DROP TABLE t;"
 
-    # Restore dump
+    # Restore dump back to Manticore
     docker exec -i db-test $db_type -hmanticore -P9306 manticore < dump.sql
+
+    # Verify restore was successful by selecting data
     docker exec db-test $db_type -hmanticore -t -P9306 -e "select * from t order by id asc limit 20;" manticore
 
-    # Checking for errors
+    # Check for errors
     if [ -s dump.sql ]; then
         echo "Dump $version completed successfully"
     else
         echo "Error: dump.sql is empty for $version"
+        docker stop db-test > /dev/null
+        exit 1
     fi
 
-    # Stopping and deleting a container
+    # Stop and remove container
     docker stop db-test > /dev/null
     rm dump.sql
 done
 
 echo "All database versions tested successfully!"
+
+# Update documentation after successful tests
+echo ""
+echo "Updating documentation with latest supported versions..."
+update_documentation
+
+echo ""
+echo "✅ Test completed successfully!"
+echo "✅ Supported versions: MariaDB up to $LATEST_MARIADB, MySQL up to $LATEST_MYSQL"


### PR DESCRIPTION
**Type of Change:**
- Documentation update

**Description of the Change:**
This PR automates the documentation update process for supported mysqldump versions in Manticore Search.

1. **Modified `script_versions.sh`:**
   - Added `LATEST_MARIADB` and `LATEST_MYSQL` variables to track maximum supported versions
   - Implemented `update_documentation()` function that automatically updates the documentation after successful tests
   - Enhanced version checking to fail early if new versions are detected on Docker Hub

2. **Documentation update:**
   - Added information about supported mysqldump versions to `Backup_and_restore.md`
   - Format: "MariaDB up to X.X" and "MySQL up to X.X"
   - Versions are automatically updated when new ones are tested

### How it works:
- When a new MariaDB/MySQL version is released, the test fails and notifies about the new version
- QA engineer updates the version variables and adds the new version to the test array
- After successful testing, documentation is automatically updated with the new maximum version
- A backup file (.bak) is created for safety

**Related Issue (provide the link):**
- https://github.com/manticoresoftware/manticoresearch/issues/3741