### PR TITLE
fix 'filter with empty name' error

### DIFF
--- a/src/searchdsql.cpp
+++ b/src/searchdsql.cpp
@@ -1806,18 +1806,25 @@ bool SqlParser_c::AddNullFilter ( const SqlNode_t & tCol, bool bEqualsNull )
 
 void SqlParser_c::AddHaving ()
 {
-      // Move the last parsed filter into HAVING
-      assert ( m_pQuery->m_dFilters.GetLength() );
-      m_pQuery->m_tHaving = m_pQuery->m_dFilters.Pop();
+     assert ( m_pQuery->m_dFilters.GetLength() );
 
-      // FIX(#887): The filter tree (m_dFilterTree) still contains a leaf for the
-      // just-moved HAVING predicate. If we keep it, CreateFilterTree() for WHERE
-      // will attempt to build a node for a filter that was popped <E2><86><92> it will look
-      // like a filter with an empty name and throw "filter with empty name".
-      //
-      // Remove the trailing tree op that corresponds to the just-added HAVING item.
-      if ( m_dFilterTree.GetLength() > 0 )
-          m_dFilterTree.Pop();
+     // The filter we are about to move to HAVING has index (length-1).
+     // After Pop(), GetLength() equals that index.
+     const int iExpectHavingIdx = m_pQuery->m_dFilters.GetLength() - 1;
+     m_pQuery->m_tHaving = m_pQuery->m_dFilters.Pop();
+
+     // FIX(#887): The filter tree still contains a leaf for the just-moved HAVING filter.
+     // That leaf must be the *last* tree item and must reference the same filter index.
+     if ( m_dFilterTree.GetLength() > 0 )
+     {
+         const int iLastFilterItem = m_dFilterTree.Last().m_iFilterItem;
+         // Assert the tree's last leaf matches the moved filter.
+         assert ( iLastFilterItem == iExpectHavingIdx && "HAVING leaf must be the last filter-tree item" );
+
+         // Remove that dangling leaf so WHERE's CreateFilterTree() won't see an empty-name filter.
+         if ( iLastFilterItem == iExpectHavingIdx )
+             m_dFilterTree.Pop();
+     }
 }
 
 


### PR DESCRIPTION
**Type of Change (select one):**
- Bug fix 

**Description of the Change:**
Fixes the error "filter with empty name" 

**Related Issue (provide the link):**
https://github.com/manticoresoftware/manticoresearch/issues/887



### How to test:

```
mysql> drop table if exists t; create table t(a int, b int); insert into t values(0,1,2); select a, count(*) from t where a=1 or b=2 group by a having count(*) = 1;  
--------------  
drop table if exists t  
--------------  
Query OK, 0 rows affected (0.10 sec)  
  
--------------  
create table t(a int, b int)  
--------------  
Query OK, 0 rows affected (0.05 sec)  
  
--------------  
insert into t values(0,1,2)  
--------------  
Query OK, 1 row affected (0.00 sec)  
  
--------------  
select a, count(*) from t where a=1 or b=2 group by a having count(*) = 1  
--------------  
  
ERROR 1064 (42000): index t: filter with empty name  
```


Replacing or with and solves the problem:
```
select a, count(*) from t where a=1 and b=2 group by a having count(*) = 1  
--------------  
  
 ------ ----------   
| a    | count(*) |  
 ------ ----------   
|    1 |        1 |  
 ------ ----------   
1 row in set (0.01 sec)  
```

Removing HAVING also solves the problem:
```
select a, count(*) from t where a=1 or b=2 group by a  
--------------  
  
 ------ ----------   
| a    | count(*) |  
 ------ ----------   
|    1 |        1 |  
 ------ ----------   
1 row in set (0.00 sec)  
```
