### PR TITLE
🆕 Update buddy version from 3.36.0 to 3.36.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.36.0+25102120-cdfb9546-dev
+buddy 3.36.1+25102920-d07fe1af-dev
 mcl 8.1.0+25100220-e1522a23-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.36.0 to 3.36.1 which includes:

[`d07fe1a`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/d07fe1af8cca822d682c907bd0099a76128d9fa9) Added RT mode check in EmulateElastic plugin (#611)
