### PR TITLE
🆕 Update buddy version from 3.36.1 to 3.37.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.36.1+25102920-d07fe1af-dev
+buddy 3.37.0+25110512-4eee6020-dev
 mcl 8.1.0+25100220-e1522a23-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.36.1 to 3.37.0 which includes:

[`4eee602`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/4eee602044faad6d0a04d1957c1577be6fd9d19c) feat(fuzzy): add quorum option to search payload and parsing (#614)
