### PR TITLE
test: update FluentBit integration test installation

### DIFF
--- a/test/clt-tests/integrations/fluentbit/test-integrations-fluentbit.rec
+++ b/test/clt-tests/integrations/fluentbit/test-integrations-fluentbit.rec
@@ -19,16 +19,28 @@ mkdir -p /usr/share/fluentbit/fluentbit && cd /usr/share/fluentbit
 echo -e "[SERVICE]\n    flush        1\n    daemon       On\n    log_level    info\n\n[INPUT]\n    name tail\n    path /var/log/dpkg.log\n    inotify_watcher false\n    read_from_head true\n\n[OUTPUT]\n    name es\n    match *\n    host 127.0.0.1\n    port 9308\n    index dpkg_log" > /usr/share/fluentbit/fluentbit/fluentbit.conf
 ––– output –––
 ––– input –––
-bash -c "$(curl -s https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh)" > /dev/null 2>&1;echo $?
+curl -fsSL https://packages.fluentbit.io/fluentbit.key | gpg --dearmor -o /usr/share/keyrings/fluentbit-keyring.gpg; echo $?
 ––– output –––
 0
 ––– input –––
-ln -s /opt/fluent-bit/bin/fluent-bit /usr/bin/fluent-bit
+echo "deb [signed-by=/usr/share/keyrings/fluentbit-keyring.gpg] https://packages.fluentbit.io/ubuntu/noble noble main" > /etc/apt/sources.list.d/fluent-bit.list
 ––– output –––
+––– input –––
+apt-get update > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+apt-get install -y fluent-bit > /dev/null 2>&1; echo $?
+––– output –––
+0
+––– input –––
+ln -sf /opt/fluent-bit/bin/fluent-bit /usr/bin/fluent-bit 2>/dev/null; echo $?
+––– output –––
+0
 ––– input –––
 fluent-bit --version | grep 'Fluent Bit'
 ––– output –––
-Fluent Bit v#!/[0-9]{1}\.[0-9]{1}\.[0-9]{1,2}/!#
+Fluent Bit v#!/[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}/!#
 ––– input –––
 echo -e "2023-05-31 10:42:55 status triggers-awaited ca-certificates-java:all 20190405ubuntu1.1\n2023-05-31 10:42:55 trigproc libc-bin:amd64 2.31-0ubuntu9.9 <none>\n2023-05-31 10:42:55 status half-configured libc-bin:amd64 2.31-0ubuntu9.9\n2023-05-31 10:42:55 status installed libc-bin:amd64 2.31-0ubuntu9.9\n2023-05-31 10:42:55 trigproc systemd:amd64 245.4-4ubuntu3.21 <none>" > /var/log/dpkg.log; echo $?
 ––– output –––


### PR DESCRIPTION
**Type of Change:**
- Test fix

**Description of the Change:**
Fixed FluentBit integration test failing on Ubuntu Noble due to GPG key verification errors and foreground execution blocking.

**Changes:**
- Replaced `bash -c "$(curl install.sh)"` with explicit 5-step apt installation
- Added proper GPG key import and signed repository configuration
- Changed FluentBit execution from foreground to background mode (`&` + PID check)
- Added initialization delay (`sleep 1`) for daemon startup
- Extended version regex to support v10+ releases