### PR TITLE
Add comprehensive tests for force_bigrams option

### DIFF
--- a/test/clt-tests/core/call-autocomplete-force-bigrams.rec
+++ b/test/clt-tests/core/call-autocomplete-force-bigrams.rec
@@ -42,7 +42,7 @@ mysql -P9306 -h0 -e "call autocomplete('geroge', 't', 0 as force_bigrams)\G"
 ––– output –––
 ––– comment –––
 Test 5: 6-char word "planet" (boundary case), force_bigrams=0, expect: found
-Note: "lanet" (5 chars) uses bigrams automatically, so it can match "planet" (6 chars)
+Note: "lanet" uses bigrams, "planet" uses trigrams, but fuzzy matching still works (edit distance=1)
 ––– input –––
 mysql -P9306 -h0 -e "call autocomplete('lanet', 't', 0 as force_bigrams)\G"
 ––– output –––


### PR DESCRIPTION
## Summary
Add comprehensive test coverage for `force_bigrams` parameter in all three contexts from issue #3853.

## Changes
This PR adds a new test file `call-autocomplete-force-bigrams-vertical.rec` with 19 tests covering:

### 1. CALL AUTOCOMPLETE with force_bigrams (9 tests)
- Verifies `force_bigrams=1` finds transposition errors in long words
- Verifies `force_bigrams=0` does NOT find transpositions in long words  
- Tests combinations with append, prepend, and fuzziness options

### 2. CALL SUGGEST with force_bigrams (5 tests)
- Tests fuzzy suggestions with bigram matching
- CALL SUGGEST is fuzzy by default, so tests verify force_bigrams behavior

### 3. SELECT with OPTION fuzzy=1 and force_bigrams (5 tests)
- Tests regular search queries with fuzzy option and force_bigrams
- Verifies the combination works correctly
