### PR TITLE
🆕 Update buddy version from 3.37.0 to 3.37.2

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.37.1+25111317-d08181a8-dev
+buddy 3.37.2+25111318-6805fd00-dev
 mcl 8.1.0+25100220-e1522a23-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.37.0 to 3.37.2 which includes:

[`6805fd0`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/6805fd00d03fdc9fae1ec17b4762273bd8f6d5cb) fix: remove lock and unlock table checks from command matching as it's now handled by the daemon (#617)
