### PR TITLE
🆕 Update buddy version from 3.37.2 to 3.38.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.37.3+25111413-5e7a43f1-dev
+buddy 3.38.0+25111421-429f49a9-dev
 mcl 8.1.0+25100220-e1522a23-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.37.2 to 3.38.0 which includes:

[`429f49a`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/429f49a9b0f41de9e61cd359ec01cc57f19add3c) feat(autocomplete): improve suggestion handling and code organization
