### PR TITLE
test: add blog validation for Grafana versions

### DIFF
--- a/test/clt-tests/integrations/grafana/test-integrations-check-grafana-versions.rec
+++ b/test/clt-tests/integrations/grafana/test-integrations-check-grafana-versions.rec
@@ -26,6 +26,7 @@ TESTED_VERSIONS="10.0
 12.2"
 
 # Check for NEW versions (after latest tested)
+# WARNING: Also update GRAFANA_LATEST below when changing this!
 LATEST_TESTED_VERSION="12.2"
 NEW_VERSIONS=$(curl -s "https://hub.docker.com/v2/repositories/grafana/grafana/tags/?page_size=100" \
 | jq -r ".results[].name" \
@@ -43,27 +44,13 @@ function version_compare(v1, v2) {
 version_compare($0, latest) > 0')
 
 if [ -n "$NEW_VERSIONS" ]; then
-    echo "🆕 NEW Grafana versions detected:"
-    echo "$NEW_VERSIONS"
+    echo "🆕 NEW Grafana versions detected: $NEW_VERSIONS"
     echo ""
-    echo "❌ Need to test new versions and update the following:"
-    echo ""
-    echo "📝 Files to update:"
-    echo "  1. test/clt-tests/integrations/grafana/test-integrations-check-grafana-versions.rec"
-    echo "     - Update TESTED_VERSIONS list"
-    echo "     - Update LATEST_TESTED_VERSION='$LATEST_TESTED_VERSION' -> new version"
-    echo ""
-    echo "  2. test/clt-tests/integrations/grafana/test-integrations-test-grafana-versions.rec"
-    echo "     - Add new test section: timeout 300 bash /tmp/grafana-single-test.sh X.X"
-    echo ""
-    echo "  3. Update documentation with new version support:"
-    echo "     - manual/english/Changelog.md (add release note about new version support)"
-    echo ""
-    echo "  4. Update website content (separate repository):"
-    echo "     - https://github.com/manticoresoftware/site"
-    echo "     - content/english/blog/manticoresearch-grafana-integration/index.md"
-    echo "     - Search for: 'compatible with Grafana versions up to X.X'"
-    echo "     - Update version number to latest tested"
+    echo "📝 Update required:"
+    echo "  1. test-integrations-check-grafana-versions.rec - Update TESTED_VERSIONS and LATEST_TESTED_VERSION"
+    echo "  2. test-integrations-test-grafana-versions.rec - Add test for new version"
+    echo "  3. manual/english/Changelog.md - Add release note"
+    echo "  4. site repo: blog/manticoresearch-grafana-integration/index.md"
     echo ""
     exit 1
 else
@@ -89,9 +76,35 @@ Using tested versions:
 12.0
 12.1
 12.2
-––– comment –––
-If new versions are detected, test will fail with detailed instructions:
-- Lists files that need to be updated in manticoresearch repo
-- Shows where to add new version tests
-- Reminds to update documentation in manual/
-- Reminds to update website in site repo (manticoresearch-grafana-integration blog post)
+––– input –––
+bash << 'SCRIPT'
+# Check blog post for Grafana version
+echo "Checking Grafana version in blog post..."
+echo ""
+
+# Must match LATEST_TESTED_VERSION above
+GRAFANA_LATEST="12.2"
+
+echo "=== Checking website blog post ==="
+BLOG_URL="https://manticoresearch.com/blog/manticoresearch-grafana-integration/"
+echo "✓ Fetching $BLOG_URL"
+
+BLOG_CONTENT=$(curl -s "$BLOG_URL")
+
+if [ -z "$BLOG_CONTENT" ]; then
+    echo "⚠️  WARNING: Blog fetch failed - skipping" >&2
+elif echo "$BLOG_CONTENT" | grep -q "Grafana versions.*${GRAFANA_LATEST}"; then
+    FOUND_FORMAT=$(echo "$BLOG_CONTENT" | grep -o "Grafana versions [0-9.-]*${GRAFANA_LATEST}" | head -1)
+    echo "✅ Blog: $FOUND_FORMAT"
+else
+    BLOG_VERSION=$(echo "$BLOG_CONTENT" | grep -o "Grafana versions [0-9.-]*" | head -1)
+    echo "⚠️  WARNING: Blog does NOT contain ${GRAFANA_LATEST}" >&2
+    echo "   Found: $BLOG_VERSION" >&2
+    echo "   Expected: Grafana versions 10.0-${GRAFANA_LATEST}" >&2
+fi
+SCRIPT
+––– output –––
+Checking Grafana version in blog post...
+=== Checking website blog post ===
+✓ Fetching https://manticoresearch.com/blog/manticoresearch-grafana-integration/
+✅ Blog: Grafana versions 10.0-12.2


### PR DESCRIPTION
**Type of Change**
- New feature

**Description of the Change:**
Add blog validation to Grafana version test. The test now checks that blog contains latest Grafana version (12.2) in format "Grafana versions 10.0-12.2".

**Related Issue:**
- https://github.com/manticoresoftware/manticoresearch/issues/3867