### PR TITLE
ci: Add build-local-test-kit script for Docker image creation

### DIFF
--- a/misc/build-local-test-kit.sh
+++ b/misc/build-local-test-kit.sh
@@ -1,0 +1,41 @@
+# Handle --clean parameter
+if [ "$1" = "--clean" ]; then
+	rm -rf ../build
+fi
+
+mkdir -p ../build
+docker run -it --rm \
+-v $(pwd)/../cache:/cache \
+-e CACHEB="/cache" \
+-e DIAGNOSTIC=1 \
+-e PACK_ICUDATA=0 \
+-e NO_TESTS=1 \
+-e DISTR=jammy \
+-e boost=boost_nov22 \
+-e sysroot=roots_nov22 \
+-e arch=x86_64 \
+-e CTEST_CMAKE_GENERATOR=Ninja \
+-e CTEST_CONFIGURATION_TYPE=RelWithDebInfo \
+-e WITH_COVERAGE=0 \
+-e SYSROOT_URL="https://repo.manticoresearch.com/repository/sysroots" \
+-e HOMEBREW_PREFIX="" \
+-e PACK_GALERA=0 \
+-e UNITY_BUILD=1 \
+-v $(pwd)/../:/manticore_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+manticoresearch/external_toolchain:vcpkg331_20250114 bash -c 'cd /manticore_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/build && cmake -DDISTR=jammy .. -DCMAKE_BUILD_TYPE=Debug && export CMAKE_TOOLCHAIN_FILE=$(pwd)/dist/build_dockers/cross/linux.cmake && cmake --build .'
+
+# Build Docker image with compiled binaries
+if [ -f ../build/src/searchd ] && [ -f ../build/src/indexer ] && [ -f ../build/src/indextool ]; then
+	cat > ../build/Dockerfile <<EOF
+FROM ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
+COPY src/searchd /usr/bin/searchd
+COPY src/indexer /usr/bin/indexer
+COPY src/indextool /usr/bin/indextool
+EOF
+	docker build --load -t test-kit ../build
+	rm -f ../build/Dockerfile
+	echo "Docker image 'test-kit' created successfully"
+else
+	echo "Error: Compiled binaries not found. Cannot create Docker image."
+	exit 1
+fi


### PR DESCRIPTION
The image can then be used for local CTL testing. Should work on Macos and Linux.
