### PR TITLE
Test/improve conflict handling test

### DIFF
--- a/test/clt-tests/bugs/3847-conflict-handling-verification.rec
+++ b/test/clt-tests/bugs/3847-conflict-handling-verification.rec
@@ -108,9 +108,9 @@ conflicts=0; for i in {1..50}; do result=$( (mysql -h0 -P2306 -e "UPDATE test:tb
 Conflicts: %{NUMBER}/50
 PASS
 ––– comment –––
-Test 6: UPDATE WHERE id=14 & REPLACE (CONFLICT expected) - run 50 times, require ≥1 conflict
+Test 6: UPDATE WHERE id>13 & REPLACE (CONFLICT expected) - run 50 times, require ≥1 conflict
 ––– input –––
-conflicts=0; for i in {1..50}; do result=$( (mysql -h0 -P2306 -e "UPDATE test:tbl1 SET attr1=1 WHERE id=14" 2>&1 & mysql -h0 -P1306 -e "REPLACE INTO test:tbl1 (id, attr1) VALUES (14, 888)" 2>&1 & wait) ); if echo "$result" | grep -q "error at PostRollback"; then ((conflicts++)); fi; done; echo "Conflicts: $conflicts/50"; test $conflicts -ge 1 && echo "PASS" || echo "FAIL"
+conflicts=0; for i in {1..50}; do result=$( (mysql -h0 -P2306 -e "UPDATE test:tbl1 SET attr1=1 WHERE id>13" 2>&1 & mysql -h0 -P1306 -e "REPLACE INTO test:tbl1 (id, attr1) VALUES (14, 888)" 2>&1 & wait) ); if echo "$result" | grep -q "error at PostRollback"; then ((conflicts++)); fi; done; echo "Conflicts: $conflicts/50"; test $conflicts -ge 1 && echo "PASS" || echo "FAIL"
 ––– output –––
 Conflicts: %{NUMBER}/50
 PASS


### PR DESCRIPTION
**Type of Change:**
- Test fix 

**Description of the Change:**
This PR corrects bugs in the conflict detection test suite (PR #3910) that were causing failures in CI.

- Problems corrected:
   - Test 6 - Had incorrect logic where UPDATE operated on multiple documents (WHERE id>13 affects rows 14, 15, 20) while REPLACE targeted only one document (id=14). Changed to WHERE id=14 so both operations target the same single document.
   - Test 14 - Had incorrect logic where DELETE operations targeted id=14 but REPLACE targeted id=15 (different documents cannot produce conflicts). Changed REPLACE from id=15 to id=14 so all three operations conflict on the same document.
   - Tests 7-8 - These tests use UPDATE WHERE attr1=2 (non-PRIMARY KEY search) which requires the document to exist. Modified to restore the document inside the loop before each iteration to ensure it exists and is replicated before conflict operations run.
   - All conflict tests (5-14) - Increased iterations from 30 to 50 for better statistical reliability (Tests 7-8 use 100 iterations due to lower conflict probability with non-PK operations).

**Related Issue:** 
- https://github.com/manticoresoftware/manticoresearch/issues/3847