### PR TITLE
feat: optimize infix hash builder with improved radix sort and increased arena size

### DIFF
--- a/src/dict/infix/infix_builder.cpp
+++ b/src/dict/infix/infix_builder.cpp
@@ -25,7 +25,7 @@
 // KEYWORDS STORING DICTIONARY, INFIX HASH BUILDER
 //////////////////////////////////////////////////////////////////////////
 
-static constexpr int INFIX_ARENA_LENGTH = 1 << 24; // 16M buckets (was 1M)
+static constexpr int INFIX_ARENA_LENGTH = 1 << 24; // 16M buckets provides better performance than 1M which was used previously
 
 template<int SIZE>
 struct Infix_t
@@ -481,10 +481,9 @@ void InfixBuilder_c<SIZE>::SaveEntries ( CSphWriter& wrDict )
 	wrDict.PutBlob ( g_sTagInfixEntries );
 
 	CSphVector<int> dIndex;
-	int iTotalEntries = m_dArena.GetLength() - 1;
-	dIndex.Resize ( iTotalEntries );
+	dIndex.Resize ( m_dArena.GetLength() - 1 );
 	dIndex.FillSeq(1);
-	// Use radix sort for O(n) performance instead of O(n log n)
+	// Use radix sort for O(n) performance instead of O(n log n) which std::sort provides
 	RadixSortIndices<SIZE> ( dIndex, m_dArena );
 
 	m_dBlocksWords.Reserve ( m_dArena.GetLength() / INFIX_BLOCK_SIZE * sizeof ( DWORD ) * SIZE );


### PR DESCRIPTION
```
manticore-load --port=9306 --drop --batch-size=1 --threads=5 --total=100000 --init="CREATE TABLE t(f text) min_infix_len='2'" --load="INSERT INTO t(f) values('<string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42> <string/42/42>')";
```

Master branch:
```
[Tue Nov 25 10:13:47.325 2025] [1918600] rt: table t: diskchunk 0(1), segments 32  saved in 113.287358 (113.288013) sec, RAM saved/new 44738922/89474521 ratio 0.333342 (soft limit 44740350, conf limit 134217728)
[Tue Nov 25 10:13:54.455 2025] [1918606] rt: table t: diskchunk 1(2), segments 32  saved in 112.899586 (112.933800) sec, RAM saved/new 44743457/86447102 ratio 0.341057 (soft limit 45775894, conf limit 134217728)
[Tue Nov 25 10:15:40.540 2025] [1918609] rt: table t: diskchunk 2(3), segments 32  saved in 113.141336 (113.141897) sec, RAM saved/new 44741287/89474498 ratio 0.333353 (soft limit 44741934, conf limit 134217728)
[Tue Nov 25 10:15:51.816 2025] [1918610] rt: table t: diskchunk 3(4), segments 32  saved in 116.618959 (116.619502) sec, RAM saved/new 45771884/88440004 ratio 0.341042 (soft limit 45773875, conf limit 134217728)
[Tue Nov 25 10:17:33.867 2025] [1918612] rt: table t: diskchunk 4(5), segments 32  saved in 113.132860 (113.133430) sec, RAM saved/new 44733586/89478590 ratio 0.333333 (soft limit 44739197, conf limit 134217728)
[Tue Nov 25 10:17:48.771 2025] [1918606] rt: table t: diskchunk 5(6), segments 32  saved in 116.462339 (116.462895) sec, RAM saved/new 45771396/88445594 ratio 0.341025 (soft limit 45771647, conf limit 134217728)
[Tue Nov 25 10:19:28.656 2025] [1918608] rt: table t: diskchunk 6(7), segments 32  saved in 114.524230 (114.524747) sec, RAM saved/new 44731400/89489845 ratio 0.333333 (soft limit 44739197, conf limit 134217728)
[Tue Nov 25 10:19:46.771 2025] [1918609] rt: table t: diskchunk 7(8), segments 32  saved in 117.516967 (117.517525) sec, RAM saved/new 45768703/88441304 ratio 0.341023 (soft limit 45771336, conf limit 134217728)
[Tue Nov 25 10:21:23.372 2025] [1918610] rt: table t: diskchunk 8(9), segments 32  saved in 114.437871 (114.438446) sec, RAM saved/new 44738690/89475923 ratio 0.333337 (soft limit 44739728, conf limit 134217728)
[Tue Nov 25 10:21:43.966 2025] [1918603] rt: table t: diskchunk 9(10), segments 32  saved in 116.706442 (116.706937) sec, RAM saved/new 45768703/58115316 ratio 0.440575 (soft limit 59132977, conf limit 134217728)
[Tue Nov 25 10:23:11.956 2025] [1918605] rt: table t: diskchunk 10(11), segments 32  saved in 108.308400 (108.309066) sec, RAM saved/new 44738153/13377163 ratio 0.769817 (soft limit 103323076, conf limit 134217728)
```

This branch:
```
[Tue Nov 25 10:07:18.656 2025] [1897162] rt: table t: diskchunk 0(1), segments 32  saved in 30.944205 (30.944761) sec, RAM saved/new 44737133/89471067 ratio 0.333341 (soft limit 44740309, conf limit 134217728)
[Tue Nov 25 10:07:26.422 2025] [1897170] rt: table t: diskchunk 1(2), segments 32  saved in 31.278867 (31.282967) sec, RAM saved/new 44734008/89069584 ratio 0.334326 (soft limit 44872464, conf limit 134217728)
[Tue Nov 25 10:07:51.330 2025] [1897172] rt: table t: diskchunk 2(3), segments 32  saved in 32.518803 (32.519357) sec, RAM saved/new 44737059/89480110 ratio 0.333333 (soft limit 44739197, conf limit 134217728)
[Tue Nov 25 10:07:58.731 2025] [1897165] rt: table t: diskchunk 3(4), segments 32  saved in 32.112853 (32.114522) sec, RAM saved/new 44868478/87330823 ratio 0.339400 (soft limit 45553532, conf limit 134217728)
[Tue Nov 25 10:08:23.398 2025] [1897170] rt: table t: diskchunk 4(5), segments 32  saved in 31.892372 (31.893017) sec, RAM saved/new 44733385/89479394 ratio 0.333333 (soft limit 44739197, conf limit 134217728)
[Tue Nov 25 10:08:31.997 2025] [1897171] rt: table t: diskchunk 5(6), segments 32  saved in 32.594372 (32.594889) sec, RAM saved/new 45560058/88654453 ratio 0.339457 (soft limit 45561150, conf limit 134217728)
[Tue Nov 25 10:08:55.375 2025] [1897162] rt: table t: diskchunk 6(7), segments 32  saved in 31.657734 (31.658331) sec, RAM saved/new 44737396/89476638 ratio 0.333333 (soft limit 44739197, conf limit 134217728)
[Tue Nov 25 10:09:04.768 2025] [1897168] rt: table t: diskchunk 7(8), segments 32  saved in 32.312303 (32.312831) sec, RAM saved/new 45561893/88651305 ratio 0.339474 (soft limit 45563430, conf limit 134217728)
[Tue Nov 25 10:09:28.566 2025] [1897163] rt: table t: diskchunk 8(9), segments 32  saved in 32.851123 (32.851750) sec, RAM saved/new 44743075/89469447 ratio 0.333375 (soft limit 44744810, conf limit 134217728)
[Tue Nov 25 10:09:37.910 2025] [1897160] rt: table t: diskchunk 9(10), segments 32  saved in 32.640951 (32.641557) sec, RAM saved/new 45566919/58606699 ratio 0.437413 (soft limit 58708610, conf limit 134217728)
[Tue Nov 25 10:09:58.466 2025] [1897167] rt: table t: diskchunk 10(11), segments 32  saved in 29.593349 (29.593861) sec, RAM saved/new 44746669/13860030 ratio 0.763508 (soft limit 102476275, conf limit 134217728)
```