### PR TITLE
🆕 Update buddy version from 3.39.1 to 3.40.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.40.0+25112617-438edf82-dev
+buddy 3.40.1+25112619-258a044b-dev
 mcl 8.1.1+25112309-38f499ef-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.39.1 to 3.40.1 which includes:

[`258a044`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/258a044bc9f6e1ddf902190610a9ec897c738711) fix: Kafka view Invalid JSON error (#3860)
