### PR TITLE
fixed windows crash handler to ignore some harmless exceptions

### DIFF
--- a/src/daemon/crash_logger.cpp
+++ b/src/daemon/crash_logger.cpp
@@ -211,6 +211,21 @@ void HandleCrash ( int sig ) NO_THREAD_SAFETY_ANALYSIS
 LONG WINAPI HandleCrash ( EXCEPTION_POINTERS * pExc )
 #endif // !_WIN32
 {
+
+#if _WIN32
+	if ( pExc && pExc->ExceptionRecord )
+	{
+		switch ( pExc->ExceptionRecord->ExceptionCode )
+		{
+			case DBG_CONTROL_C:
+			case 0x406D1388: // MS_VC_EXCEPTION
+			case 0x40010006: // DBG_PRINTEXCEPTION_C
+			case 0xE06D7363: // C++ exception
+				CRASH_EXIT_CORE;
+		}
+	}
+#endif // _WIN32
+
 	sphSetDied();
 	auto iLogFile = GetDaemonLogFD();
 	if ( iLogFile < 0 )


### PR DESCRIPTION
need to check for any mdmp files after Windows ubertesters finished