### PR TITLE
🆕 Update mcl version from 8.1.1 to 9.0.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.9.6+25070510-5247d066
 buddy 3.40.1+25112619-258a044b-dev
-mcl 8.1.1+25112309-38f499ef-dev
+mcl 9.0.0+25113009-b7e9e683-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.19.0+25063014-1ff59652


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 8.1.1 to 9.0.0 which includes:

[`b7e9e68`](https://github.com/manticoresoftware/columnar/commit/b7e9e6834a63b6a1bffe6dbe568f9936076e8350) chore: updated manticore revision
