### PR TITLE
Added comprehensive tests for fuzzy search via /sql endpoint

### DIFF
--- a/test/clt-tests/expected-errors/test-fuzzy-sql-endpoint-negative.rec
+++ b/test/clt-tests/expected-errors/test-fuzzy-sql-endpoint-negative.rec
@@ -1,0 +1,43 @@
+––– block: ../base/start-searchd-with-buddy –––
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE neg_test (id INT, content TEXT) min_infix_len='2'; INSERT INTO neg_test VALUES (1, 'test data');"
+––– output –––
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from neg_test where match('test') option fuzzy='1'"
+––– output –––
+{"error":"Invalid value for option 'fuzzy'"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from neg_test where match('test') option fuzzy=-1"
+––– output –––
+{"error":"P01: syntax error, unexpected '-' near '-1'"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from neg_test where match('test') option fuzzy=abc"
+––– output –––
+{"error":"Invalid value for option 'fuzzy'"}
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE no_infix (id INT, content TEXT);"
+––– output –––
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from no_infix option fuzzy=1"
+––– output –––
+{"error":"The 'fuzzy' option requires a full-text query. Use: MATCH('search query') or MATCH('search query', table_name)"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "insert into neg_test values (2, 'new data')"
+––– output –––
+{"error":"only SELECT queries are supported"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "create table new_table (id int)"
+––– output –––
+{"error":"only SELECT queries are supported"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "drop table neg_test"
+––– output –––
+{"error":"only SELECT queries are supported"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "show tables"
+––– output –––
+{"error":"only SELECT queries are supported"}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from neg_test where match('test') option fuzzy=1 layouts=''"
+––– output –––
+{"error":"Invalid options in query string, make sure they are separated by commas"}

--- a/test/clt-tests/http-interface/test-fuzzy-search-sql-endpoint.rec
+++ b/test/clt-tests/http-interface/test-fuzzy-search-sql-endpoint.rec
@@ -1,0 +1,50 @@
+––– block: ../base/start-searchd-with-buddy –––
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE fuzzy_test (id INT, content TEXT, title TEXT) min_infix_len='2'; INSERT INTO fuzzy_test VALUES (1, 'example text', 'example'), (2, 'test data', 'testing'), (3, 'hello world', 'greeting');"
+––– output –––
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from fuzzy_test where match('exmaple') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":1,"_score":%{NUMBER},"_source":{"content":"example text","title":"example"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from fuzzy_test where match('testin') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":2,"_score":%{NUMBER},"_source":{"content":"test data","title":"testing"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from fuzzy_test where match('helo') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":3,"_score":%{NUMBER},"_source":{"content":"hello world","title":"greeting"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select id, content from fuzzy_test where match('exmaple') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":1,"_score":%{NUMBER},"_source":{"content":"example text"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select count(*) from fuzzy_test where match('exmaple') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_score":%{NUMBER},"_source":{"count(*)":1}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from fuzzy_test where match('test') option fuzzy=0"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":2,"_score":%{NUMBER},"_source":{"content":"test data","title":"testing"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from fuzzy_test where match('example') option fuzzy=1, layouts=''"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":1,"_score":%{NUMBER},"_source":{"content":"example text","title":"example"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from fuzzy_test where match('wrld') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":3,"_score":%{NUMBER},"_source":{"content":"hello world","title":"greeting"}}]}}
+––– input –––
+mysql -h0 -P9306 -e "DROP TABLE IF EXISTS multi_word; CREATE TABLE multi_word (id INT, msg TEXT) min_infix_len='2';"
+––– output –––
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO multi_word VALUES (1, 'quick brown fox'), (2, 'slow red dog'), (3, 'fast blue cat');"
+––– output –––
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from multi_word where match('quik bron') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":1,"_score":%{NUMBER},"_source":{"msg":"quick brown fox"}}]}}
+––– input –––
+curl -s -X POST "http://localhost:9308/sql" -d "select * from multi_word where match('fst blu') option fuzzy=1"
+––– output –––
+{"took":%{NUMBER},"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":3,"_score":%{NUMBER},"_source":{"msg":"fast blue cat"}}]}}


### PR DESCRIPTION
**Type of Change**
- Bug fix 
- New Test

**Description of the Change:**
- Added comprehensive test coverage for fuzzy search functionality via `/sql` HTTP endpoint (issue #3962). The tests validate that fuzzy search works correctly through the `/sql` endpoint after the fix in buddy 3.40.2.

**Related Issue:** 
- https://github.com/manticoresoftware/manticoresearch/issues/3962