### PR TITLE
🆕 Update buddy version from 3.40.2 to 3.40.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.40.2+25112823-27a2f87e-dev
+buddy 3.40.3+25120822-53dd47df-dev
 mcl 9.0.0+25113009-b7e9e683-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.40.2 to 3.40.3 which includes:

[`53dd47d`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/53dd47df05434cbd827220beb7560bc85d42238e) Fix fuzzy search (#607)
