### PR TITLE
ci: fix PHP 8.4 deprecation warnings in test/helpers.inc

### DIFF
--- a/test/helpers.inc
+++ b/test/helpers.inc
@@ -1,7 +1,11 @@
 <?php
 
 ini_set ( "display_errors", 1 );
-ini_set ( "error_reporting", (E_ALL | E_STRICT) & ~E_USER_DEPRECATED );
+$error_reporting = E_ALL & ~E_USER_DEPRECATED;
+if ( defined ( 'E_STRICT' ) && PHP_VERSION_ID < 80400 ) {
+	$error_reporting |= E_STRICT;
+}
+ini_set ( "error_reporting", $error_reporting );
 ini_set ('memory_limit', '256M');
 
 require_once ( $g_locals['api'] );
@@ -4047,7 +4051,7 @@ class SphinxConfig
 							else
 								$justcopy = true;
 							break;
-						case "source";
+						case "source":
 							{
 								$idxbody .= "\ttype\t= rt\n";
 								if ( $collectdata )


### PR DESCRIPTION
## Fix PHP 8.4+ deprecation warnings in test helpers

This PR fixes deprecation warnings that appear when running tests with PHP 8.4 and later versions.

### Changes

1. **Fixed case statement syntax** (line 4054)
   - Changed `case "source";` to `case "source":`
   - The semicolon syntax was deprecated in PHP 8.5
   - The colon syntax is the standard and works in all PHP versions

2. **Made E_STRICT conditional** (lines 4-8)
   - Conditionally include `E_STRICT` in error reporting only for PHP < 8.4
   - `E_STRICT` constant was deprecated in PHP 8.4
   - Maintains backwards compatibility with older PHP versions

### Impact

- Eliminates deprecation warnings when running tests with PHP 8.4+
- Maintains full backwards compatibility with older PHP versions
- No functional changes to test behavior