### PR TITLE
🆕 Update mcl version from 9.0.0 to 9.0.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.9.6+25070510-5247d066
 buddy 3.40.3+25120822-53dd47df-dev
-mcl 9.0.0+25113009-b7e9e683-dev
+mcl 9.0.1+25121418-60baa521-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.19.0+25063014-1ff59652


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 9.0.0 to 9.0.1 which includes:

[`5098c4c`](https://github.com/manticoresoftware/columnar/commit/5098c4c1d5775189faf7cdee0b8943dde3328eff) fix: disabled table compression for knn float vectors (because of block size=1)
