### PR TITLE
🆕 Update buddy version from 3.40.3 to 3.40.4

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.40.3+25120822-53dd47df-dev
+buddy 3.40.4+25121514-ff33bb03-dev
 mcl 9.0.1+25121418-60baa521-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.40.3 to 3.40.4 which includes:

[`ff33bb0`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/ff33bb031b2b1344d8d017e525dc226974e049fe) Updated format of Buddy error message (#631)
