### PR TITLE
fix: remove extra EOF from mysql proto

### DIFF
--- a/src/netreceive_ql.cpp
+++ b/src/netreceive_ql.cpp
@@ -933,7 +933,6 @@ void SendTableSchema ( SqlRowBuffer_c & tSqlOut, CSphString sName )
 	auto pServed = GetServed ( sName );
 	if ( !pServed )
 	{
-		tSqlOut.Eof();
 		return;
 	}
 


### PR DESCRIPTION
If a table is absent in local set (i.e., if it is distributed), we twice
 fired 'eof' to the command 4 (show fields). That crushed cli mysql to
 the madness.

ref: #4052

