### PR TITLE
🆕 Update mcl version from 9.0.1 to 9.0.2

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.9.6+25070510-5247d066
 buddy 3.40.4+25121514-ff33bb03-dev
-mcl 9.0.1+25121418-60baa521-dev
+mcl 9.0.2+25122309-5b73f8d1-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.19.0+25063014-1ff59652


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 9.0.1 to 9.0.2 which includes:

[`5b73f8d`](https://github.com/manticoresoftware/columnar/commit/5b73f8d16434a812d46c3496d0d36d2c2252a95a) switched to the new version of the hnsw library with fix of parial loaded hnsw index; fixed manticoresearch#2628
