### PR TITLE
Suppress galera reachable leaks

### DIFF
--- a/.github/workflows/nightly_memleaks.yml
+++ b/.github/workflows/nightly_memleaks.yml
@@ -9,7 +9,13 @@ on:
       - '**'
     paths:
       - '.github/workflows/nightly_memleaks.yml'    
-      
+      - 'test/valgrind.supp'      
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/nightly_memleaks.yml'    
+      - 'test/valgrind.supp'      
   
 # cancels the previous workflow run when a new one appears in the same branch (e.g. master or a PR's branch)
 concurrency:

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -62,6 +62,8 @@
 }
 
 # wsrep (galera)
+# Suppressions for reachable allocations inside the wsrep/galera provider.
+# These are provider-owned buffers left reachable at process exit.
 {
    galera_internal_reachable
    Memcheck:Leak
@@ -78,6 +80,36 @@
    fun:malloc
    ...
    fun:asio_handler_allocate
+}
+
+# Galera Monitor allocates large buffers that remain reachable on shutdown.
+{
+   galera_monitor_reachable
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:operator new[]
+   ...
+   fun:galera::Monitor*
+}
+
+# Galera GCS state machine allocates internal buffers that stay reachable.
+{
+   galera_gcs_sm_reachable
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:gcs_sm_create
+}
+
+# OpenSSL init inside galera/asio leaves tiny reachable allocations.
+{
+   galera_openssl_reachable
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:operator new
+   ...
+   fun:asio::ssl::detail::openssl_init_base::instance
 }
 
 #cctz


### PR DESCRIPTION
Test rt_383 about replication started failing in [Nightly valgrind checks](https://github.com/manticoresoftware/manticoresearch/actions/workflows/nightly_memleaks.yml) after commit 861bbc3557f857a8ed54090b622ff7ac5a74c044 on Dec 12, 2025, when the test was extended to include joiner restarts. The valgrind logs show only "still reachable" allocations coming from the external wsrep/galera provider (`galera::Monitor`, `gcs_sm_create`, and OpenSSL init via asio), not from Manticore-owned memory. These allocations remain reachable at process exit even after our cleanup and are owned by the provider library, so they are not actionable in our code.
This PR adds targeted suppressions in `valgrind.supp` for these specific Galera stacks so memcheck stays focused on real Manticore leaks while rt_383 continues to cover the restart/joiner path.

