### PR TITLE
🆕 Update buddy version from 3.40.4 to 3.40.5

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.40.4+25121514-ff33bb03-dev
+buddy 3.40.5+25122612-d075954a-dev
 mcl 9.0.2+25122309-5b73f8d1-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.40.4 to 3.40.5 which includes:

[`d075954`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/d075954a33964d42d5eed7442dcc075c7b999b0d) fix: Revert unnecessary protocol changes (#633)
