### PR TITLE
fix: docstore attr count during ALTER

### DIFF
--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -7124,7 +7124,7 @@ bool CSphIndex_VLN::AddRemoveFromDocstore ( const CSphSchema & tOldSchema, const
 
 	for ( int i = 0; i < tNewSchema.GetAttrsCount(); i++ )
 		if ( tNewSchema.IsAttrStored(i) )
-			iOldNumStored++;
+			iNewNumStored++;
 
 	if ( iOldNumStored==iNewNumStored )
 		return true;


### PR DESCRIPTION
The docstore alter path mistakenly incremented the old stored-attribute count for the new schema, which made it try to rename a non-existent .spds file. This correction counts new stored attrs properly, preventing the rename failure and table corruption when adding columnar/MVA stored attrs.

Related issue https://github.com/manticoresoftware/manticoresearch/issues/3661

The script used to reproduce the issue and validate it's fixed:
```
 ~/manticore_github   issue-3661 ±  cat ~/issue-3661.sh
#!/usr/bin/env bash
set -euo pipefail

# Create table
echo "Creating table..."
mysql -P9306 -h0 <<'SQL'
DROP TABLE IF EXISTS test;
CREATE TABLE IF NOT EXISTS test (value STRING ATTRIBUTE INDEXED);
SQL

batch_count=8
rows_per_batch=100000
for ((i=0; i<batch_count; i++)); do
  start=$((i * rows_per_batch))
  echo "Inserting test data (batch $i)"

  values=""
  for ((j=0; j<rows_per_batch; j++)); do
    (( j > 0 )) && values+=", "
    values+="('test item $((start + j))')"
  done

  mysql -P9306 -h0 <<SQL
INSERT INTO test (value) VALUES $values;
SQL
done

# Flush data to disk
echo "Flushing data to disk..."
mysql -P9306 -h0 -e 'FLUSH ATTRIBUTES'

echo "Adding MVA columnar column..."
mysql -P9306 -h0 <<'SQL'
ALTER TABLE test ADD COLUMN mva MULTI64 ENGINE='columnar';
SQL

echo "Test access to table..."
mysql -P9306 -h0 <<'SQL'
INSERT INTO test (value, mva) VALUES ('test item data', (1,2,3));

SELECT GROUPBY() as key FROM test GROUP BY mva;
SQL
```

Before the fix:
```
 ✘  ~  ./issue-3661.sh
Creating table...
Inserting test data (batch 0)
Inserting test data (batch 1)
Inserting test data (batch 2)
Inserting test data (batch 3)
Inserting test data (batch 4)
Inserting test data (batch 5)
Inserting test data (batch 6)
Inserting test data (batch 7)
Flushing data to disk...
+------+
| tag  |
+------+
|    0 |
+------+
Adding MVA columnar column...
ERROR 1064 (42000) at line 1: table test: rename '/opt/homebrew/var/manticore/test/test.0.spds' to '/opt/homebrew/var/manticore/test/test.0.spds.old' failed: No such file or directory
```

After the fix:
```
 ✘  ~  ./issue-3661.sh
Creating table...
Inserting test data (batch 0)
Inserting test data (batch 1)
Inserting test data (batch 2)
Inserting test data (batch 3)
Inserting test data (batch 4)
Inserting test data (batch 5)
Inserting test data (batch 6)
Inserting test data (batch 7)
Flushing data to disk...
+------+
| tag  |
+------+
|    0 |
+------+
Adding MVA columnar column...
Test access to table...
key
3
2
1
```