### PR TITLE
🆕 Update mcl version from 9.0.2 to 10.0.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.9.6+25070510-5247d066
 buddy 3.40.5+25122612-d075954a-dev
-mcl 9.0.2+25122309-5b73f8d1-dev
+mcl 10.0.0+26011116-88c182b2
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.24.0+25122422-e5db1c82-dev

--- a/test/clt-tests/http-interface/show-version-http.rec
+++ b/test/clt-tests/http-interface/show-version-http.rec
@@ -1,14 +1,10 @@
 ––– block: ../base/start-searchd-with-buddy –––
 ––– input –––
-curl -s "http://localhost:9308/cli?show%20version" | sed 's/ *|/|/g' | awk '!/row.*in set/'; echo
+curl -s "http://localhost:9308/cli?show%20version" | sed 's/ *|/|/g' | awk '!/row.*in set/'|grep -v "\-\-\-"|grep -v Component
 ––– output –––
-+------------+----------------------------------+
-| Component| Version|
-+------------+----------------------------------+
 | Daemon| %{VERSION}|
 | Columnar| columnar %{VERSION}|
 | Secondary| secondary %{VERSION}|
 | Knn| knn %{VERSION}|
 | Embeddings| embeddings %{VERSION}|
 | Buddy| buddy %{VERSION}|
-+------------+----------------------------------+

--- a/test/clt-tests/http-interface/show-version-trailing-semicolon.rec
+++ b/test/clt-tests/http-interface/show-version-trailing-semicolon.rec
@@ -3,18 +3,14 @@
 mysql -h0 -P9306 -e "CREATE TABLE t (id INT, value TEXT); INSERT INTO t VALUES (1, 'example'), (2, 'test');"
 ––– output –––
 ––– input –––
-curl -s "http://localhost:9308/cli?show%20version" | awk '!/row.*in set/'; echo
+curl -s "http://localhost:9308/cli?show%20version" | awk '!/row.*in set/'|grep -v "\-\-\-"|grep -v Component; echo
 ––– output –––
-+------------+----------------------------------+
-| Component  | Version                          |
-+------------+----------------------------------+
 | Daemon     | %{VERSION} #!/\s*/!#|
 | Columnar   | columnar %{VERSION} #!/\s*/!#|
 | Secondary  | secondary %{VERSION} #!/\s*/!#|
 | Knn        | knn %{VERSION} #!/\s*/!#|
 | Embeddings | embeddings #!/([0-9]+\.[0-9]+\.[0-9]+)\s*/!#|
 | Buddy      | buddy %{VERSION} #!/\s*/!#|
-+------------+----------------------------------+
 ––– input –––
 curl -s "http://localhost:9308/cli_json" -d "show version"; echo
 ––– output –––


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 9.0.2 to 10.0.0 which includes:

[`88c182b`](https://github.com/manticoresoftware/columnar/commit/88c182b2505714fa570c1cebf39ed4b4d8fb32fc) Updated manticore commit hash
