### PR TITLE
ci: resolved issue with handling PR-s from fork repos

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -19,16 +19,27 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Download an artifact with PR repo name
+        if: github.event_name == 'workflow_run'
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: pr_repo
+          path: .
       - name: Check origin repository
         id: repo-check
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            repo="${{ github.event.pull_request.head.repo.full_name }}"
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            PR_REPO=$(cat ./pr_repo.txt)
+            repo=$(head -n 1 <<< "$PR_REPO")
+            ref=$(tail -n 1 <<< "$PR_REPO")
           else
             repo="${{ github.repository }}"
+            ref="${{ github.head_ref }}"
           fi
           echo "repo=$repo" >> $GITHUB_OUTPUT
-
+          echo "ref=$ref" >> $GITHUB_OUTPUT
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -36,7 +47,7 @@ jobs:
           repository: ${{ steps.repo-check.outputs.repo }}
           token: ${{ secrets.GITHUB_TOKEN }}
           submodules: true
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.repo-check.outputs.ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/trigger_docs_check.yml
+++ b/.github/workflows/trigger_docs_check.yml
@@ -18,6 +18,18 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Save PR repo
+        env:
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          echo $PR_REPO > pr_repo.txt
+          echo $PR_REF >> pr_repo.txt
+      - name: Upload PR repo name
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_repo
+          path: ./pr_repo.txt
       - name: Trigger doc check
         run: |
           echo "Doc check triggered"


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure you've read the Contributing guide located at CONTRIBUTING.md in the root directory.
-->

**Type of Change (select one):**
- Bug fix 

**Description of the Change:**
The `trigger_docs_check `workflow now persists the source repo and ref of every manual PR into an artifact, so forked contributions no longer lose that context when using `worklow_run`.
The `check_docs` workflow consumes that artifact whenever it runs via `workflow_run`, feeding the recorded repo/ref into the checkout step so the translate job can fetch them later.

**Related Issue (provide the link):**
https://github.com/manticoresoftware/manticoresearch/pull/4075
