### PR TITLE
🆕 Update buddy version from 3.40.6 to 3.40.7

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.40.6+26011422-8ef265ee-dev
+buddy 3.40.7+26012816-f14021ce-dev
 mcl 10.0.0+26011116-88c182b2
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.40.6 to 3.40.7 which includes:

[`f14021c`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/f14021ce7f5233ac1b48f9244b73ceb21aa44533) Fixed handling of transaction variable
