### PR TITLE
Update DBeaver integration test after Buddy 3.40.7 update

### DIFF
--- a/test/clt-tests/integrations/dbeaver/test-integrations-dbeaver.rec
+++ b/test/clt-tests/integrations/dbeaver/test-integrations-dbeaver.rec
@@ -522,4 +522,8 @@ ERROR 1064 (42000) at line 1: unknown sysvar @@isolation
 ––– input –––
 mysql -h0 -P9306 -e "SELECT @@tx_isolation"
 ––– output –––
-ERROR 1064 (42000) at line 1: unknown sysvar @@tx_isolation
++-----------------+
+| @@tx_isolation  |
++-----------------+
+| REPEATABLE-READ |
++-----------------+


### PR DESCRIPTION
## Summary

  Fixes the DBeaver integration test that started failing after the Buddy version was bumped from 3.40.6 to 3.40.7.

  ## Changes

  - Updated test expectations in `test-integrations-dbeaver.rec` for `@@tx_isolation` system variable
  - Changed expected output from error to successful response with value `REPEATABLE-READ`

  ## Background

  Buddy 3.40.7 added support for the `@@tx_isolation` MySQL system variable to improve compatibility with DBeaver and other MySQL clients. The test was still expecting the old behavior (error response), causing CI
  failures.

  ## Test Changes

  **Before:**
  SELECT @@tx_isolation
  → ERROR 1064 (42000) at line 1: unknown sysvar @@tx_isolation

  **After:**
  SELECT @@tx_isolation
  → REPEATABLE-READ

  ## Testing

  - ✅ Test now expects the correct behavior after Buddy 3.40.7 update
  - ✅ Aligns with the fix implemented in #4193

  ## Related

  - Fixes #4196
  - Related to #1618 (DBeaver compatibility improvement)
  - Related PR: manticoresoftware/manticoresearch-buddy#636
  - Related commit: 570e10d0911887b25420447f0fe176aa6985686d