### PR TITLE
fix: use-after-free (ASAN)

### DIFF
--- a/src/gtests/gtests_tokenizer.cpp
+++ b/src/gtests/gtests_tokenizer.cpp
@@ -1454,6 +1454,16 @@ TEST_F ( QueryParser, transform_common_and_not_factor_with_mixed_phrases_1 )
 	);
 }
 
+// use-after-free error
+TEST_F ( QueryParser, transform_common_subphrases_fail_asan )
+{
+	Transform (
+		"\"00-00\"|\"00@00-00\"|\"00@00-00\"~5",
+		"( \"00 00\" | \"00 00 00\" | \"00 00 00\"~5 )",
+		"( \"00 00 00\"~5 | ( \"00 \"00 00\"\" ) )"
+	);
+}
+
 // COMMON | NOT
 TEST_F ( QueryParser, transform_common_or_not )
 {

--- a/src/sphinxquery/transform_commonkeywords.cpp
+++ b/src/sphinxquery/transform_commonkeywords.cpp
@@ -589,7 +589,7 @@ bool CSphTransformation::TransformCommonPhrase () const noexcept
 
 void CSphTransformation::MakeTransformCommonPhrase ( const CSphVector<XQNode_t *> & dCommonNodes, int iCommonLen, bool bHeadIsCommon )
 {
-	const XQLimitSpec_t & tSpec = dCommonNodes[0]->m_dSpec;
+	const XQLimitSpec_t tSpec = dCommonNodes[0]->m_dSpec;
 	auto * pCommonPhrase = new XQNode_t ( tSpec );
 	pCommonPhrase->SetOp ( SPH_QUERY_PHRASE );
 


### PR DESCRIPTION
test case provided.
ref: https://github.com/manticoresoftware/manticoresearch/issues/4198
