### PR TITLE
🆕 Update buddy version from 3.40.7 to 3.40.8

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.9.6+25070510-5247d066
-buddy 3.40.7+26012816-f14021ce-dev
+buddy 3.40.8+26012920-0020464e
 mcl 10.1.0+26012815-974bd517-dev
 executor 1.3.6+25102902-defbddd7-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.40.7 to 3.40.8 which includes:

[`0020464`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/0020464e5b42aaf45dc31d35db1fc7c43d5ef52c) Feat/autoschema replace support (#639)
