### PR TITLE
fix: RT save kill capture to prevent duplicates

### DIFF
--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -442,7 +442,7 @@ int RtSegment_t::KillOnSaveHook_t::Kill ( DocID_t tDocID )
 
 int RtSegment_t::AddKillOnSave ( DocID_t tDocID ) const
 {
-	ScopedMutex_t tLock ( m_tKillOnSaveLock );
+	Threads::Coro::ScopedMutex_t tLock ( m_tKillOnSaveLock );
 	if ( !m_bKillOnSaveActive )
 		return 0;
 	m_dKillOnSave.Add ( tDocID );
@@ -451,13 +451,13 @@ int RtSegment_t::AddKillOnSave ( DocID_t tDocID ) const
 
 void RtSegment_t::SetKillOnSaveActive ( bool bActive ) const
 {
-	ScopedMutex_t tLock ( m_tKillOnSaveLock );
+	Threads::Coro::ScopedMutex_t tLock ( m_tKillOnSaveLock );
 	m_bKillOnSaveActive = bActive;
 }
 
 void RtSegment_t::DrainKillOnSave ( CSphVector<DocID_t> & dOut ) const
 {
-	ScopedMutex_t tLock ( m_tKillOnSaveLock );
+	Threads::Coro::ScopedMutex_t tLock ( m_tKillOnSaveLock );
 	dOut.SwapData ( m_dKillOnSave );
 	m_dKillOnSave.Reset();
 }

--- a/src/sphinxrt.h
+++ b/src/sphinxrt.h
@@ -18,6 +18,7 @@
 #include "sphinxint.h"
 #include "killlist.h"
 #include "attribute.h"
+#include "coroutine.h"
 #include "docstore.h"
 #include "columnarrt.h"
 #include "coroutine.h"
@@ -334,7 +335,7 @@ public:
 
 private:
 	mutable int64_t			m_iUsedRam = 0;			///< ram usage counter
-	mutable CSphMutex		m_tKillOnSaveLock;
+	mutable Threads::Coro::Mutex_c	m_tKillOnSaveLock;
 	mutable CSphVector<DocID_t>	m_dKillOnSave;
 	mutable bool			m_bKillOnSaveActive = false;
 


### PR DESCRIPTION
Related issue https://github.com/manticoresoftware/manticoresearch/issues/4207

The problem was that RT duplicates appeared after REPLACE because kills performed while RAM segments were locked for a save could be missed by the SaveDiskChunk kill buffer. This allowed an old copy to survive on disk while a new copy was saved, resulting in duplicates which could be easily verified by `COUNT(*) > COUNT(DISTINCT id)`.

## Root cause
SaveDiskChunk previously used a **per‑save, local** kill accumulator (`KillAccum_t dKillOnSave`).

During a save:
1. RAM segments were locked and their kill hook set to `dKillOnSave`.
2. The save flush completed and the code immediately consumed `dKillOnSave.m_dDocids`.
3. **Kills that occurred slightly later** (still while segments were locked) could hit the hook **after** that buffer was drained.

Those late kills were dropped, so the new disk chunk could include a docid whose old copy still existed elsewhere, producing duplicates.

## Fix
The fix suggested this PR makes kill capture **per‑segment and persistent** for the duration of the save, and adds a **late drain** after publish:

- Each `RtSegment_t` now owns its own kill‑on‑save buffer and hook.
- The hook stores docids in the segment buffer **as long as the segment is marked active**.
- SaveDiskChunk keeps hooks active until after the new chunk is published, then performs a **final drain** and applies those kills to existing disk chunks.
- Hooks are cleared only after that final drain, ensuring kills that arrive late (but still during the save window) are not lost.

This ensures every kill that happens while a segment is locked for save is either applied to the newly created disk chunk or to the existing disk chunks in the final drain, preventing duplicates.