### PR TITLE
fix: avoid false HTTP receive warnings on keep-alive teardown

### DIFF
--- a/src/netreceive_http.cpp
+++ b/src/netreceive_http.cpp
@@ -219,6 +219,11 @@ void HttpServe ( std::unique_ptr<AsyncNetBuffer_c> pBuf )
 
 			if ( !iChunk || tIn.GetError() )
 			{
+				// We already served at least one request on this keep-alive connection.
+				// If the client closes (or any read error happens) while waiting for the next header, just stop quietly.
+				if ( tSess.GetPersistent() )
+					return;
+
 				sError.SetSprintf ( "failed to receive HTTP request, %s", ( tIn.GetError() ? tIn.GetErrorMessage().cstr() : sphSockError() ) );
 				HttpReply ( EHTTP_STATUS::_400, FromStr ( sError ) );
 			}


### PR DESCRIPTION
This fixes a case where /bulk succeeds but searchd logs "failed to receive HTTP request" on the same connection right after sending the response.

Scenario:
- Client sends an HTTP/1.1 request (keep-alive by default).
- Server replies successfully.
- While waiting for the next request header, the client closes the socket or non-blocking poll/recv hits a transient would-block race.
- The old path treated this as a malformed request and logged a warning.

Changes:
- In SyncSockRead(), retry transient poll/recv errors instead of failing the read path on EAGAIN/EWOULDBLOCK (and poll errno==0 transient).
- In HttpServe(), if a persistent connection fails while reading the next header, stop the session quietly instead of sending HTTP 400/logging a request receive warning.

Related issue https://github.com/manticoresoftware/manticoresearch/issues/4264