### PR TITLE
Update DBeaver integration test for new session variables

### DIFF
--- a/test/clt-tests/integrations/dbeaver/test-integrations-dbeaver.rec
+++ b/test/clt-tests/integrations/dbeaver/test-integrations-dbeaver.rec
@@ -122,12 +122,18 @@ Variable_name: threads_ex_effective
 Variable_name: cluster_user
         Value: cluster
 *************************** 20. row ***************************
+Variable_name: wait_timeout
+        Value: 28800
+*************************** 21. row ***************************
+Variable_name: interactive_timeout
+        Value: 900
+*************************** 22. row ***************************
 Variable_name: thread_stack
         Value: 1048576
-*************************** 21. row ***************************
+*************************** 23. row ***************************
 Variable_name: threads_ex
         Value:
-*************************** 22. row ***************************
+*************************** 24. row ***************************
 Variable_name: user
         Value: root
 ––– input –––
@@ -222,7 +228,7 @@ mysql -h0 -P9306 -e "SELECT @@interactive_timeout"
 +-----------------------+
 | @@interactive_timeout |
 +-----------------------+
-| 28800                 |
+|                   900 |
 +-----------------------+
 ––– input –––
 mysql -h0 -P9306 -e "SELECT @@license"
@@ -283,7 +289,7 @@ mysql -h0 -P9306 -e "SELECT @@wait_timeout"
 +----------------+
 | @@wait_timeout |
 +----------------+
-| 28800          |
+|          28800 |
 +----------------+
 ––– input –––
 mysql -h0 -P9306 -e "SELECT @@GLOBAL.character_set_server"


### PR DESCRIPTION
## Summary
- Update expected output in DBeaver CLT test after `wait_timeout` and `interactive_timeout` variables were added in 5f1730b
- `SHOW VARIABLES\G` now returns 24 rows instead of 22 — added `wait_timeout` and `interactive_timeout` in correct order
- `SELECT @@interactive_timeout` returns `900` instead of `28800`
- `SELECT @@wait_timeout` — updated value alignment (left → right)

## Test plan
- [ ] Nightly integration test `Test DBeaver integration` passes