### PR TITLE
fix: ORDER BY ASC/DESC reversed in sort comparators

### DIFF
--- a/src/columnarsort.cpp
+++ b/src/columnarsort.cpp
@@ -180,7 +180,7 @@ FORCE_INLINE bool CompareFloat_fn<5>::IsLess ( const CSphMatch & tMatchA, SphAtt
 
 #define TEST_PAIR(_aa,_bb,_idx ) \
 	if ( (_aa)!=(_bb) ) \
-		return ( (tState.m_uAttrDesc >> (_idx)) & 1 ) ^ ( (_aa) > (_bb) );
+		return ( 1 - ( (tState.m_uAttrDesc >> (_idx)) & 1 ) ) ^ ( (_aa) > (_bb) );
 
 #define TEST_KEYPART(_idx) \
 	switch ( tState.m_eKeypart[_idx] ) \

--- a/src/sortcomp.h
+++ b/src/sortcomp.h
@@ -104,7 +104,7 @@ public:
 
 #define SPH_TEST_PAIR(_aa,_bb,_idx ) \
 	if ( (_aa)!=(_bb) ) \
-		return ( (t.m_uAttrDesc >> (_idx)) & 1 ) ^ ( (_aa) > (_bb) );
+		return ( 1 - ( (t.m_uAttrDesc >> (_idx)) & 1 ) ) ^ ( (_aa) > (_bb) );
 
 
 #define SPH_TEST_KEYPART(_idx) \
@@ -138,7 +138,7 @@ public:
 		{ \
 			int iCmp = t.CmpStrings ( a, b, _idx ); \
 			if ( iCmp!=0 ) \
-				return ( ( t.m_uAttrDesc >> (_idx) ) & 1 ) ^ ( iCmp>0 ); \
+				return ( 1 - ( ( t.m_uAttrDesc >> (_idx) ) & 1 ) ) ^ ( iCmp>0 ); \
 			break; \
 		} \
 	}


### PR DESCRIPTION
Related issue https://github.com/manticoresoftware/manticoresearch/issues/4320