### PR TITLE
🆕 Update executor version from 1.4.0 to 1.4.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,7 +1,7 @@
 backup 1.9.6+25070510-5247d066
 buddy 3.43.0+26030216-12ae76e4-dev
 mcl 11.1.0+26022620-8b0838e3-dev
-executor 1.4.0+26012715-d7a66c60
+executor 1.4.1+26030421-9f457869-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.24.0+25122422-e5db1c82-dev
 ---


### PR DESCRIPTION
Update [executor](https://github.com/manticoresoftware/executor) version from 1.4.0 to 1.4.1 which includes:

[`9f45786`](https://github.com/manticoresoftware/executor/commit/9f457869d4bb65c64c9877f26b323acdeca05535) Fix/php source link (#81)
