### PR TITLE
🆕 Update executor version from 1.4.1 to 1.4.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,7 +1,6 @@
 backup 1.10.0+26032519-c42465e9-dev
 buddy 3.44.1+26031916-d0ff5bfe-dev
 mcl 13.0.0+26032715-e60b0836
-backup 1.10.0+26032519-c42465e9-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.24.0+25122422-e5db1c82-dev


### PR DESCRIPTION
Update [executor](https://github.com/manticoresoftware/executor) version from 1.4.1 to 1.4.3 which includes:

[`390b6e6`](https://github.com/manticoresoftware/executor/commit/390b6e66833749753afc6a43d4244a1110c6de83) fix(docker): return docker build and make it simpler
