### PR TITLE
fix: prefer Homebrew libcurl automatically at runtime on macOS

### DIFF
--- a/src/netfetch.cpp
+++ b/src/netfetch.cpp
@@ -92,6 +92,10 @@ static decltype ( &curl_slist_free_all ) sph_curl_slist_free_all = nullptr;
 
 static bool InitDynamicCurl()
 {
+#if __APPLE__
+	static constexpr const char * sHomebrewCurlLibArm = "/opt/homebrew/opt/curl/lib/libcurl.4.dylib";
+	static constexpr const char * sHomebrewCurlLibX64 = "/usr/local/opt/curl/lib/libcurl.4.dylib";
+#endif
 	const char* sFuncs[] = {
 		"curl_global_init",
 		"curl_global_cleanup",
@@ -131,9 +135,19 @@ static bool InitDynamicCurl()
 
 	const char * szCurlLib = getenv ( "MANTICORE_CURL_LIB" );
 	static const bool bHasOverride = szCurlLib && *szCurlLib;
-	static CSphDynamicLibrary dLib ( bHasOverride ? szCurlLib : CURL_LIB );
+	static CSphDynamicLibrary dLib (
+#if __APPLE__
+		bHasOverride ? szCurlLib : sHomebrewCurlLibArm
+#else
+		bHasOverride ? szCurlLib : CURL_LIB
+#endif
+	);
+#if __APPLE__
 	if ( bHasOverride )
-		dLib.CSphDynamicLibraryAlternative ( CURL_LIB );
+		dLib.CSphDynamicLibraryAlternative ( sHomebrewCurlLibArm );
+	dLib.CSphDynamicLibraryAlternative ( sHomebrewCurlLibX64 );
+#endif
+	dLib.CSphDynamicLibraryAlternative ( CURL_LIB );
 	return dLib.LoadSymbols ( sFuncs, pFuncs, sizeof ( pFuncs ) / sizeof ( void** ) );
 }
 


### PR DESCRIPTION
Starting searchd manually on macOS could still pick the wrong libcurl even after the package build was switched to `DL_CURL=1`, because the Homebrew curl preference was only being injected through the Homebrew service environment.

That meant `brew services` could be forced onto the newer Homebrew curl, but a plain manual startup such as `searchd` could still fall back to an older curl and reproduce Buddy connection failures.

Change the runtime lookup order on macOS so searchd prefers curl in this order:
- `MANTICORE_CURL_LIB` if explicitly set
- `/opt/homebrew/opt/curl/lib/libcurl.4.dylib`
- `/usr/local/opt/curl/lib/libcurl.4.dylib`
- compiled `CURL_LIB`

This keeps the explicit override for debugging, automatically prefers the newer Homebrew curl for both Apple Silicon and Intel, and still falls back safely if Homebrew curl is unavailable.

With this handled in searchd itself, the Homebrew tap formulas no longer need to inject `MANTICORE_CURL_LIB` into the service environment.