### PR TITLE
🆕 Update buddy version from 3.44.2 to 3.44.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.44.2+26040515-97dbd018-dev
+buddy 3.44.3+26041511-89a903a1-dev
 mcl 13.2.2+26041409-73bde7b8-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.44.2 to 3.44.3 which includes:

[`89a903a`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/89a903a1266cc50197820f9f420f66161da185d2) fix: volume metrics with empty binlog path
