### PR TITLE
🆕 Update mcl version from 13.2.2 to 13.2.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.10.0+26032519-c42465e9-dev
 buddy 3.44.3+26041511-89a903a1-dev
-mcl 13.2.2+26041409-73bde7b8-dev
+mcl 13.2.3+26042100-1e3cb2ea-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.24.0+25122422-e5db1c82-dev


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 13.2.2 to 13.2.3 which includes:

[`1e3cb2e`](https://github.com/manticoresoftware/columnar/commit/1e3cb2ea877c9f386398b26ea96d2884974f7ebd) fixed CI to work with embedding build in the previous stages (#160)
