### PR TITLE
🆕 Update buddy version from 3.44.3 to 3.44.4

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.44.3+26041511-89a903a1-dev
+buddy 3.44.4+26042112-354e9c36-dev
 mcl 13.2.2+26041409-73bde7b8-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.44.3 to 3.44.4 which includes:

[`354e9c3`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/354e9c36a47256a90c9e18ff2eb2d1c75fcf1cfa) fix: updated telemetry lib from 0.1.23 to 0.1.25 Related issue https://github.com/manticoresoftware/telemetry-lib/issues/2
