### PR TITLE
🆕 Update buddy version from 3.44.4 to 3.44.5

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.44.4+26042112-354e9c36-dev
+buddy 3.44.5+26042317-cda7f1ff-dev
 mcl 13.2.4+26042221-0e87abac-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.44.4 to 3.44.5 which includes:

[`cda7f1f`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/cda7f1ff1b49c5a60b8aa836efe2399f95d6ca8c) Fix: Composer vulnerability (#662)
