### PR TITLE
🆕 Update mcl version from 13.2.5 to 13.2.6

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.10.0+26032519-c42465e9-dev
 buddy 3.44.5+26042317-cda7f1ff-dev
-mcl 13.2.5+26042713-2291fd54-dev
+mcl 13.2.6+26042820-0b375075-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.24.0+25122422-e5db1c82-dev


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 13.2.5 to 13.2.6 which includes:

[`0b37507`](https://github.com/manticoresoftware/columnar/commit/0b375075dfd336a68aa14b08ebce64a19ae59ba0) fix: fixed a crash that could occur when running knn queries with 1-bit quantized vectors from multiple threads
