### PR TITLE
🆕 Update load version from 1.24.0 to 1.25.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.44.5+26042317-cda7f1ff-dev
 mcl 13.2.6+26042820-0b375075-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
-load 1.24.0+25122422-e5db1c82-dev
+load 1.25.0+26050511-832198ca-dev
 galera 3.37
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.24.0 to 1.25.0 which includes:

[`832198c`](https://github.com/manticoresoftware/manticore-load/commit/832198ca2c23d5d2db19738c9f1fc61829a8e046) feat: multi query support
