### PR TITLE
fix: protect Buddy SQL conversion from type mismatches

### DIFF
--- a/src/searchdhttp.cpp
+++ b/src/searchdhttp.cpp
@@ -1684,7 +1684,13 @@ void ConvertJsonDataset ( const JsonObj_c & tRoot, const char * sStmt, RowBuffer
 					case MYSQL_COL_LONGLONG : assert ( tDataCol.IsInt() ); tOut.PutInt64 (tDataCol.IntVal()); break;
 					case MYSQL_COL_FLOAT : assert ( tDataCol.IsDbl() ); tOut.PutFloat (tDataCol.DblVal()); break;
 					case MYSQL_COL_DOUBLE : assert ( tDataCol.IsDbl() ); tOut.PutDouble (tDataCol.DblVal()); break;
-					default: tOut.PutString ( tDataCol.StrVal() );
+					default:
+						if ( tDataCol.IsInt() )
+							tOut.PutNumAsString ( tDataCol.IntVal() );
+						else if ( tDataCol.IsDbl() )
+							tOut.PutDoubleAsString ( tDataCol.DblVal() );
+						else
+							tOut.PutString ( tDataCol.StrVal() );
 				}
 				++iCol;
 			}


### PR DESCRIPTION
Keep the daemon-side Buddy reply conversion tolerant of inconsistent /sql?mode=raw payloads.

Before this protection, when Buddy declared a column as string but emitted a numeric JSON scalar in data, ConvertJsonDataset() used StrVal() unconditionally in the default branch. For integer/double JSON nodes that produced an empty string, so the MySQL client could receive a blank value instead of the numeric payload.

This change keeps the declared-column default branch but preserves numeric JSON values when they appear:
- int -> PutNumAsString()
- double -> PutDoubleAsString()
- otherwise -> PutString()