### PR TITLE
🆕 Update buddy version from 3.46.0 to 3.46.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.46.0+26050713-e852fe4c-dev
+buddy 3.46.1+26050811-1aa67cc7-dev
 mcl 13.2.6+26042820-0b375075-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.46.0 to 3.46.1 which includes:

[`1aa67cc`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/1aa67cc73b500c837415d20be037338b6e31ef12) fix: numeric COUNT(*) type for information_schema.tables
