### PR TITLE
fix(stack): increase default stack size to 1MiB

### DIFF
--- a/src/coro_stack.h
+++ b/src/coro_stack.h
@@ -31,7 +31,17 @@ namespace Threads
 #endif
 
 static constexpr size_t STACK_ALIGN = 16;					  // stack align - let it be 16 bytes for convenience
-static constexpr size_t DEFAULT_CORO_STACK_SIZE = 1024 * 128; // stack size - 128K
+// Coroutine stack size. Previously 128 KiB, which is too small to safely run
+// any non-trivial C dependency in *debug* builds — Rust's debug codegen and
+// C++'s un-optimised debug frames cumulatively exceed 128 KiB when the
+// daemon calls into the embeddings library's BERT forward pass. The overflow
+// silently corrupts adjacent memory and manifests later as a glibc heap
+// abort in unrelated code paths (test_481/490/508). Bumped to 1 MiB to give
+// the call chain comfortable headroom. Release builds were unaffected by
+// the smaller value; the bigger budget is "free" on 64-bit systems because
+// page mappings are committed on first touch, so unused tail of the stack
+// costs nothing.
+static constexpr size_t DEFAULT_CORO_STACK_SIZE = 1024 * 1024; // stack size - 1 MiB
 
 enum class StackFlavour_E { fixedsize, protected_fixedsize, mocked_prealloc }; // what allocator is in game
 using CoroStack_t = std::pair<boost::context::stack_context, StackFlavour_E>;

--- a/src/threadutils.h
+++ b/src/threadutils.h
@@ -205,7 +205,11 @@ public:
 };
 
 /// stack of a thread (that is NOT stack of the coroutine!)
-static const DWORD STACK_SIZE = 128 * 1024;
+/// Bumped from 128 KiB to 1 MiB to match DEFAULT_CORO_STACK_SIZE — debug
+/// builds have fat frames and any C dep (e.g. embeddings BERT forward via
+/// dlopen) blows the smaller budget. 64-bit page-on-touch makes the extra
+/// VA range free in practice.
+static const DWORD STACK_SIZE = 1024 * 1024;
 
 /// get the pointer to my thread's stack
 const void * TopOfStack ();


### PR DESCRIPTION
- Prevent memory corruption in debug builds caused by stack overflow
- Resolve glibc heap aborts during BERT forward pass calls
- Align thread and coroutine stack sizes to avoid frame overflows