### PR TITLE
🆕 Update buddy version from 3.46.3 to 3.47.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.46.4+26060121-a9956af5-dev
+buddy 3.47.0+26060319-2f784a78-dev
 mcl 13.5.2+26052919-f7132f23-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.46.3+26051811-3109a9a2-dev
+buddy 3.46.4+26060121-a9956af5-dev
 mcl 13.5.2+26052919-f7132f23-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.46.3 to 3.47.0 which includes:

[`2f784a7`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/2f784a78f02e3559c78a5f94ceffc390fa368108) feature(sharding): sharding rollback, upgrades, tests, various fixes (#665)
