### PR TITLE
ci: force-push test-kit-latest regardless of branch/test result

### DIFF
--- a/dist/test_kit_docker_push.sh
+++ b/dist/test_kit_docker_push.sh
@@ -27,16 +27,14 @@ else
 	current_branch="$GITHUB_REF_NAME"
 fi
 
-should_push_main=0
-if [ "$TEST_RESULT" != "failure" ]; then
-	should_push_main=1
-fi
+# FORCE OVERRIDE (temporary): always push test-kit-latest, ignoring the test result.
+# Used to refresh test-kit-latest while main's CLT is red. Revert before merging to main.
+should_push_main=1
 
 hub_repo="ghcr.io/${REPO_OWNER}/manticoresearch"
 img_url="${hub_repo}:test-kit-${BUILD_COMMIT}"
-[[ $current_branch == "main" ]] \
-  && img_url_latest="${hub_repo}:test-kit-latest" \
-  || img_url_latest=""
+# FORCE OVERRIDE (temporary): always tag latest regardless of branch, so this PR branch can refresh it.
+img_url_latest="${hub_repo}:test-kit-latest"
 
 # Get the latest tag from the git references
 # Check if any tag exists


### PR DESCRIPTION
Temporary override of dist/test_kit_docker_push.sh so a PR branch refreshes the test-kit-latest image while main's CLT is red. Removes the branch==main gate and the "skip latest on test failure" gate. Revert before/after merging.