### PR TITLE
🆕 Update buddy version from 3.47.0 to 3.47.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.47.0+26060319-2f784a78-dev
+buddy 3.47.1+26060513-a842ad49-dev
 mcl 13.5.2+26052919-f7132f23-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.47.0 to 3.47.1 which includes:

[`a842ad4`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/a842ad498fb705a58116459b5f94445137297df3) fix(knn): preserve offset and max_matches for doc_id HTTP search
