### PR TITLE
🆕 Update buddy version from 3.47.2 to 4.0.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.0+26032519-c42465e9-dev
-buddy 3.47.2+26060516-4ce387ef-dev
+buddy 4.0.0+26061611-459f89dc-dev
 mcl 13.5.3+26060817-4277f4a1-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 3.47.2 to 4.0.0 which includes:

[`459f89d`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/459f89dc01635c50db7db4661a74c4d4a9bc708c) feat!: authentication
