### PR TITLE
🆕 Update mcl version from 13.7.0 to 13.7.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.10.1+26061912-e2ca2bce-dev
 buddy 4.0.1+26062219-995c6b19-dev
-mcl 13.7.0+26062219-dee8b294-dev
+mcl 13.7.1+26062315-a8e938f4-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.25.0+26050511-832198ca-dev


### PR DESCRIPTION
Update [mcl](https://github.com/manticoresoftware/columnar) version from 13.7.0 to 13.7.1 which includes:

[`a8e938f`](https://github.com/manticoresoftware/columnar/commit/a8e938f4e88f3d047d46f2d300102b7365db465b) updated manticore commit hash
