### PR TITLE
🆕 Update buddy version from 4.0.1 to 4.1.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.1+26061912-e2ca2bce-dev
-buddy 4.0.1+26062219-995c6b19-dev
+buddy 4.1.0+26062512-880f6cc2-dev
 mcl 13.7.1+26062315-a8e938f4-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 4.0.1 to 4.1.0 which includes:

[`880f6cc`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/880f6cc284122020e45fd57276a7d2121a0af0dc) Feat: Add support for JSON endpoints in Conversational Search (#685)
