### PR TITLE
CI probe: validate MCL pack publish flow

### DIFF
--- a/.github/ci-probes/mcl-pack-publish-validation.md
+++ b/.github/ci-probes/mcl-pack-publish-validation.md
@@ -1,0 +1,5 @@
+Temporary probe for validating the full pack-and-publish workflow after the
+MCL submodule migration.
+
+This branch is not intended for merge. It exists to run the package build,
+publish, and package installation smoke-test jobs on top of current main.


### PR DESCRIPTION
Temporary validation PR. Do not merge.\n\nPurpose: run the full pack-and-publish workflow on top of current main after the MCL runtime version fix, including the downstream DEB dev package installation jobs that failed in run 28266618332.\n\nThis PR only adds a CI probe note and should be closed after validation.