### PR TITLE
fix: MySQL auth client startup compatibility

### DIFF
--- a/src/auth/auth_proto_mysql.cpp
+++ b/src/auth/auth_proto_mysql.cpp
@@ -36,17 +36,12 @@ MySQLAuth_t GetMySQLAuth()
 {
 	MySQLAuth_t tAuth;
 
-	// fill scramble auth data (random)
-	DWORD i = 0;
-	DWORD uRand = sphRand() | 0x01010101;
-
-	for ( ; i<( tAuth.m_dScramble.GetLength() - sizeof ( DWORD ) ); i+=sizeof ( DWORD ) )
-	{
-		memcpy ( tAuth.m_dScramble.Begin() + i, &uRand, sizeof ( DWORD ) );
-		uRand = sphRand() | 0x01010101;
-	}
-	if ( i<tAuth.m_dScramble.GetLength() )
-		memcpy ( tAuth.m_dScramble.Begin() + i, &uRand, tAuth.m_dScramble.GetLength() - i );
+	// Fill scramble auth data with printable ASCII bytes.
+	// Connector/J treats mysql_native_password challenge data as a string internally;
+	// arbitrary high-bit bytes make it compute a token that does not match the server.
+	static constexpr char dChallengeAlphabet[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	for ( int i = 0; i < tAuth.m_dScramble.GetLength() - 1; ++i )
+		tAuth.m_dScramble[i] = dChallengeAlphabet [ sphRand() % ( sizeof(dChallengeAlphabet) - 1 ) ];
 	tAuth.m_dScramble.Last()  = 0;
 
 	return tAuth;
@@ -189,6 +184,7 @@ bool SqlCheckPerms ( const CSphString & sUser, const CSphVector<SqlStmt_t> & dSt
 	switch ( tStmt.m_eStmt )
 	{
 	case STMT_PARSE_ERROR: return true;
+	case STMT_DUMMY: return true; // harmless MySQL compatibility commands, e.g. SET NAMES
 
 	case STMT_SELECT:
 	case STMT_DESCRIBE:
@@ -246,8 +242,12 @@ bool SqlCheckPerms ( const CSphString & sUser, const CSphVector<SqlStmt_t> & dSt
 
 		return CheckPerms ( sUser, AuthAction_e::WRITE, tStmt.m_sIndex, false, sError );
 
-	// special write actions without index
 	case STMT_SET:
+		if ( tStmt.m_eSet==SET_LOCAL )
+			return true;
+		return CheckPerms ( sUser, AuthAction_e::WRITE, tStmt.m_sIndex, true, sError );
+
+	// special write actions without index
 	case STMT_BEGIN:
 	case STMT_COMMIT:
 	case STMT_ROLLBACK:
@@ -290,10 +290,12 @@ bool SqlCheckPerms ( const CSphString & sUser, const CSphVector<SqlStmt_t> & dSt
 	}
 
 
-	case STMT_SHOW_STATUS:
 	case STMT_SHOW_VARIABLES:
 	case STMT_SHOW_COLLATION:
 	case STMT_SHOW_CHARACTER_SET:
+		return true;
+
+	case STMT_SHOW_STATUS:
 	case STMT_SHOW_DATABASES:
 	case STMT_SHOW_PLUGINS:
 	case STMT_SHOW_THREADS:

--- a/src/auth/auth_proto_mysql.cpp
+++ b/src/auth/auth_proto_mysql.cpp
@@ -170,6 +170,22 @@ static bool DenyInternalAuthStorageTarget ( const CSphString & sUser, const CSph
 }
 
 
+static bool IsSessionOnlySetExtra ( const SqlStmt_t & tStmt )
+{
+	if ( tStmt.m_eSet!=SET_EXTRA )
+		return false;
+
+	if ( !tStmt.m_dInsertValues.GetLength() || tStmt.m_dInsertValues.GetLength()!=tStmt.m_dInsertSchema.GetLength() )
+		return false;
+
+	for ( const SqlInsert_t & tValue : tStmt.m_dInsertValues )
+		if ( !( tValue.m_iType & 1 ) )
+			return false;
+
+	return true;
+}
+
+
 bool SqlCheckPerms ( const CSphString & sUser, const CSphVector<SqlStmt_t> & dStmt, CSphString & sError )
 {
 	if ( !IsAuthEnabled() )
@@ -243,7 +259,7 @@ bool SqlCheckPerms ( const CSphString & sUser, const CSphVector<SqlStmt_t> & dSt
 		return CheckPerms ( sUser, AuthAction_e::WRITE, tStmt.m_sIndex, false, sError );
 
 	case STMT_SET:
-		if ( tStmt.m_eSet==SET_LOCAL )
+		if ( tStmt.m_eSet==SET_LOCAL || IsSessionOnlySetExtra ( tStmt ) )
 			return true;
 		return CheckPerms ( sUser, AuthAction_e::WRITE, tStmt.m_sIndex, true, sError );
 

--- a/test/clt-tests/buddy-plugins/test-auth-action-read.rec
+++ b/test/clt-tests/buddy-plugins/test-auth-action-read.rec
@@ -89,7 +89,40 @@ MYSQL_PWD=readerpass1 mysql -E -ureader -h0 -P9306 -e "SET AUTOCOMMIT = 0; SET N
 *************************** 1. row ***************************
 ok: 1
 ––– comment –––
-––– 4.1.6 MySQL client startup SHOW VARIABLES with READ — success –––
+––– 4.1.6 SET SESSION unknown variable with READ — SET handler error –––
+EXPECTED: Session-scoped SET_EXTRA must reach SET handling instead of auth denial.
+––– comment –––
+––– input –––
+MYSQL_PWD=readerpass1 mysql -ureader -h0 -P9306 -e "SET SESSION foo = 1;" 2>&1
+––– output –––
+ERROR 1064 (42000) at line 1: Unknown session variable 'foo' in SET statement
+––– comment –––
+––– 4.1.7 SET SESSION supported variable with READ — success –––
+EXPECTED: Session-scoped SET_EXTRA must not require WRITE/admin permissions.
+––– comment –––
+––– input –––
+MYSQL_PWD=readerpass1 mysql -E -ureader -h0 -P9306 -e "SET SESSION autocommit = 0; SELECT 1 AS ok;"
+––– output –––
+*************************** 1. row ***************************
+ok: 1
+––– comment –––
+––– 4.1.8 SET GLOBAL with READ — denied –––
+EXPECTED: Global SET_EXTRA still requires WRITE permission.
+––– comment –––
+––– input –––
+MYSQL_PWD=readerpass1 mysql -ureader -h0 -P9306 -e "SET GLOBAL foo = 1;" 2>&1
+––– output –––
+ERROR 1045 (42000) at line 1: Permission denied for user 'reader'
+––– comment –––
+––– 4.1.9 Mixed SESSION/GLOBAL SET with READ — denied –––
+EXPECTED: Mixed SET_EXTRA remains on the permission-checked path.
+––– comment –––
+––– input –––
+MYSQL_PWD=readerpass1 mysql -ureader -h0 -P9306 -e "SET SESSION autocommit = 0, GLOBAL foo = 1;" 2>&1
+––– output –––
+ERROR 1045 (42000) at line 1: Permission denied for user 'reader'
+––– comment –––
+––– 4.1.10 MySQL client startup SHOW VARIABLES with READ — success –––
 EXPECTED: MySQL compatibility metadata requests must not require SCHEMA/admin permissions.
 ––– comment –––
 ––– input –––

--- a/test/clt-tests/buddy-plugins/test-auth-action-read.rec
+++ b/test/clt-tests/buddy-plugins/test-auth-action-read.rec
@@ -79,3 +79,20 @@ EXPECTED: Success
 MYSQL_PWD=readerpass1 mysql -E -ureader -h0 -P9306 -e "SHOW TABLES;" | grep "Table:" | sort
 ––– output –––
 Table: readtest
+––– comment –––
+––– 4.1.5 MySQL client startup local SETs with READ — success –––
+EXPECTED: MySQL compatibility startup commands must not require WRITE/admin permissions.
+––– comment –––
+––– input –––
+MYSQL_PWD=readerpass1 mysql -E -ureader -h0 -P9306 -e "SET AUTOCOMMIT = 0; SET NAMES utf8; SELECT 1 AS ok;"
+––– output –––
+*************************** 1. row ***************************
+ok: 1
+––– comment –––
+––– 4.1.6 MySQL client startup SHOW VARIABLES with READ — success –––
+EXPECTED: MySQL compatibility metadata requests must not require SCHEMA/admin permissions.
+––– comment –––
+––– input –––
+MYSQL_PWD=readerpass1 mysql -N -ureader -h0 -P9306 -e "SHOW VARIABLES;" >/dev/null && echo "show_variables: OK"
+––– output –––
+show_variables: OK

--- a/test/clt-tests/buddy-plugins/test-auth-mysql.rec
+++ b/test/clt-tests/buddy-plugins/test-auth-mysql.rec
@@ -42,8 +42,9 @@ mysql -uadmin -h0 -P9306 -e "SELECT 1;" 2>&1
 ––– output –––
 ERROR 1045 (42000): Access denied for user 'admin' (using password: NO)
 ––– comment –––
-––– 1.1.5 Reject shortened mysql_native_password responses –––
-EXPECTED: Full 20-byte response succeeds; correct 1, 2, and 19-byte prefixes fail.
+––– 1.1.5 mysql_native_password auth response compatibility –––
+EXPECTED: Full 20-byte responses succeed; Connector/J-style seed handling succeeds;
+correct 1, 2, and 19-byte prefixes fail.
 ––– comment –––
 ––– input –––
 python3 - <<'PY'
@@ -60,6 +61,7 @@ CLIENT_PROTOCOL_41 = 0x00000200
 CLIENT_SECURE_CONNECTION = 0x00008000
 CLIENT_MULTI_RESULTS = 0x00020000
 CLIENT_PLUGIN_AUTH = 0x00080000
+COM_QUERY = 0x03
 
 
 def read_packet(sock):
@@ -75,6 +77,10 @@ def read_packet(sock):
             raise RuntimeError("unexpected EOF while reading MySQL packet")
         data.extend(chunk)
     return seq, bytes(data)
+
+
+def send_packet(sock, seq, payload):
+    sock.sendall(struct.pack("<I", len(payload))[:3] + bytes([seq]) + payload)
 
 
 def parse_scramble(data):
@@ -96,16 +102,31 @@ def parse_scramble(data):
 
 
 def native_password_token(password, scramble):
-    stage1 = hashlib.sha1(password.encode()).digest()
+    stage1 = hashlib.sha1(password).digest()
     stage2 = hashlib.sha1(stage1).digest()
     stage3 = hashlib.sha1(scramble + stage2).digest()
-    return bytes(a ^ b for a, b in zip(stage3, stage1))
+    return bytes(a ^ b for a, b in zip(stage1, stage3))
 
 
-def try_auth(prefix_len=None, mutate_first=False):
+def connectorj_style_seed(scramble):
+    # Connector/J passes the server seed through string handling before hashing.
+    # Printable ASCII seeds survive unchanged; arbitrary high-bit random bytes do not.
+    return scramble.decode("utf-8", "replace").encode("utf-8")
+
+
+def auth_result(reply):
+    if reply[0] == 0x00:
+        return "OK"
+    if reply[0] == 0xFF:
+        return "ERR %d" % struct.unpack("<H", reply[1:3])[0]
+    return "0x%02x" % reply[0]
+
+
+def try_auth(seed_filter=lambda seed: seed, prefix_len=None, mutate_first=False, run_query=False):
     with socket.create_connection((HOST, PORT), timeout=5) as sock:
         _, handshake = read_packet(sock)
-        token = native_password_token(PASSWORD, parse_scramble(handshake))
+        scramble = parse_scramble(handshake)
+        token = native_password_token(PASSWORD.encode(), seed_filter(scramble))
         response = token if prefix_len is None else token[:prefix_len]
         if mutate_first:
             response = bytes([response[0] ^ 0xFF]) + response[1:]
@@ -116,19 +137,21 @@ def try_auth(prefix_len=None, mutate_first=False):
         payload += USER.encode() + b"\0"
         payload += bytes([len(response)]) + response
         payload += b"mysql_native_password\0"
-        packet = struct.pack("<I", len(payload))[:3] + b"\x01" + payload
-        sock.sendall(packet)
-        _, reply = read_packet(sock)
+        send_packet(sock, 1, payload)
 
-    if reply[0] == 0x00:
-        return "OK"
-    if reply[0] == 0xFF:
-        return "ERR %d" % struct.unpack("<H", reply[1:3])[0]
-    return "0x%02x" % reply[0]
+        _, reply = read_packet(sock)
+        result = auth_result(reply)
+        if result != "OK" or not run_query:
+            return result
+
+        send_packet(sock, 2, bytes([COM_QUERY]) + b"SELECT 1")
+        _, first = read_packet(sock)
+        return "OK" if first and first[0] == 1 else auth_result(first)
 
 
 cases = [
-    ("full_expected", {}),
+    ("full_expected", {"run_query": True}),
+    ("connectorj_style", {"seed_filter": connectorj_style_seed, "run_query": True}),
     ("prefix_1_expected", {"prefix_len": 1}),
     ("prefix_2_expected", {"prefix_len": 2}),
     ("prefix_19_expected", {"prefix_len": 19}),
@@ -139,6 +162,7 @@ for label, kwargs in cases:
 PY
 ––– output –––
 full_expected: OK
+connectorj_style: OK
 prefix_1_expected: ERR 1045
 prefix_2_expected: ERR 1045
 prefix_19_expected: ERR 1045


### PR DESCRIPTION
Allow authenticated MySQL clients to complete native-password startup flows used by Connector/J and PyMySQL. Keep shortened native-password responses rejected and permit harmless MySQL compatibility startup statements for authenticated users.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4691