### PR TITLE
fix: clean merge temp file components on interrupt

### DIFF
--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -2965,6 +2965,13 @@ bool CSphIndex_VLN::Alter_IsMinMax ( const CSphRowitem * pDocinfo, int iStride )
 
 bool CSphIndex_VLN::AddRemoveColumnarAttr ( bool bAddAttr, const CSphString & sAttrName, ESphAttr eAttrType, const ISphSchema & tOldSchema, const ISphSchema & tNewSchema, CSphString & sError )
 {
+	bool bHaveColumnar = false;
+	for ( int i = 0; i < tNewSchema.GetAttrsCount(); i++ )
+		bHaveColumnar |= tNewSchema.GetAttr(i).IsColumnar();
+
+	if ( !bHaveColumnar )
+		return true;
+
 	BuildBufferSettings_t tSettings; // use default buffer settings
 	CSphString sTmpSPC = GetTmpFilename ( SPH_EXT_SPC );
 	bool bKeepTmp = false;

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -155,6 +155,27 @@ int64_t		g_iIndexerPoolStartHit		= 0;
 
 static bool IndexBuildDone ( const BuildHeader_t & tBuildHeader, const WriteHeader_t & tWriteHeader, const CSphString & sFileName, CSphString & sError );
 
+static void DeleteMergeTmpFiles ( const StrVec_t & dFiles )
+{
+	dFiles.for_each ( [] ( const auto & sFile )
+	{
+		if ( sFile.IsEmpty() )
+			return;
+
+		CSphString sMask;
+		sMask.SetSprintf ( "%s*", sFile.cstr() );
+		StrVec_t dMatches = FindFiles ( sMask.cstr(), false );
+		if ( dMatches.IsEmpty() && sphFileExists ( sFile.cstr() ) )
+			dMatches.Add ( sFile );
+
+		dMatches.for_each ( [] ( const auto & sTmpFile )
+		{
+			if ( !sTmpFile.IsEmpty() )
+				::unlink ( sTmpFile.cstr() );
+		} );
+	} );
+}
+
 /////////////////////////////////////////////////////////////////////////////
 // COMPILE-TIME CHECKS
 /////////////////////////////////////////////////////////////////////////////
@@ -7333,11 +7354,7 @@ bool CSphIndex_VLN::DoMerge ( const CSphIndex_VLN * pDstIndex, const CSphIndex_V
 	// unlink prepared attribute files on exit, if any
 	AT_SCOPE_EXIT ( [&dDeleteOnInterrupt]
 	{
-		dDeleteOnInterrupt.for_each ( [] ( const auto & sFile )
-		{
-			if ( !sFile.IsEmpty() && sphFileExists ( sFile.cstr() ) )
-				::unlink ( sFile.cstr() );
-		} ); 
+		DeleteMergeTmpFiles ( dDeleteOnInterrupt );
 	});
 
 	// merging attributes
@@ -7514,11 +7531,7 @@ bool CSphIndex_VLN::DoMergeN ( VecTraits_T<const CSphIndex_VLN *> dIndexes, CSph
 	StrVec_t dDeleteOnInterrupt;
 	AT_SCOPE_EXIT ( [&dDeleteOnInterrupt]
 	{
-		dDeleteOnInterrupt.for_each ( [] ( const auto & sFile )
-		{
-			if ( !sFile.IsEmpty() && sphFileExists ( sFile.cstr() ) )
-				::unlink ( sFile.cstr() );
-		} );
+		DeleteMergeTmpFiles ( dDeleteOnInterrupt );
 	} );
 
 	{

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -155,25 +155,28 @@ int64_t		g_iIndexerPoolStartHit		= 0;
 
 static bool IndexBuildDone ( const BuildHeader_t & tBuildHeader, const WriteHeader_t & tWriteHeader, const CSphString & sFileName, CSphString & sError );
 
-static void DeleteMergeTmpFiles ( const StrVec_t & dFiles )
+static void DeleteTmpFilesWithPrefix ( const CSphString & sFile )
 {
-	dFiles.for_each ( [] ( const auto & sFile )
+	if ( sFile.IsEmpty() )
+		return;
+
+	CSphString sMask;
+	sMask.SetSprintf ( "%s*", sFile.cstr() );
+	StrVec_t dMatches = FindFiles ( sMask.cstr(), false );
+	if ( dMatches.IsEmpty() && sphFileExists ( sFile.cstr() ) )
+		dMatches.Add ( sFile );
+
+	dMatches.for_each ( [] ( const auto & sTmpFile )
 	{
-		if ( sFile.IsEmpty() )
-			return;
-
-		CSphString sMask;
-		sMask.SetSprintf ( "%s*", sFile.cstr() );
-		StrVec_t dMatches = FindFiles ( sMask.cstr(), false );
-		if ( dMatches.IsEmpty() && sphFileExists ( sFile.cstr() ) )
-			dMatches.Add ( sFile );
-
-		dMatches.for_each ( [] ( const auto & sTmpFile )
-		{
-			if ( !sTmpFile.IsEmpty() )
-				::unlink ( sTmpFile.cstr() );
-		} );
+		if ( !sTmpFile.IsEmpty() )
+			::unlink ( sTmpFile.cstr() );
 	} );
+}
+
+
+static void DeleteTmpFilesWithPrefix ( const StrVec_t & dFiles )
+{
+	dFiles.for_each ( [] ( const auto & sFile ) { DeleteTmpFilesWithPrefix ( sFile ); } );
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2963,11 +2966,23 @@ bool CSphIndex_VLN::Alter_IsMinMax ( const CSphRowitem * pDocinfo, int iStride )
 bool CSphIndex_VLN::AddRemoveColumnarAttr ( bool bAddAttr, const CSphString & sAttrName, ESphAttr eAttrType, const ISphSchema & tOldSchema, const ISphSchema & tNewSchema, CSphString & sError )
 {
 	BuildBufferSettings_t tSettings; // use default buffer settings
-	auto pBuilder = CreateColumnarBuilder ( tNewSchema, GetTmpFilename ( SPH_EXT_SPC ), tSettings.m_iBufferColumnar, sError );
+	CSphString sTmpSPC = GetTmpFilename ( SPH_EXT_SPC );
+	bool bKeepTmp = false;
+	AT_SCOPE_EXIT ( [&sTmpSPC, &bKeepTmp]
+	{
+		if ( !bKeepTmp )
+			DeleteTmpFilesWithPrefix ( sTmpSPC );
+	} );
+
+	auto pBuilder = CreateColumnarBuilder ( tNewSchema, sTmpSPC, tSettings.m_iBufferColumnar, sError );
 	if ( !pBuilder )
 		return false;
 
-	return Alter_AddRemoveColumnar ( bAddAttr, m_tSchema, tNewSchema, m_pColumnar.get(), pBuilder.get(), (DWORD)m_iDocinfo, GetName(), sError );
+	if ( !Alter_AddRemoveColumnar ( bAddAttr, tOldSchema, tNewSchema, m_pColumnar.get(), pBuilder.get(), (DWORD)m_iDocinfo, GetName(), sError ) )
+		return false;
+
+	bKeepTmp = true;
+	return true;
 }
 
 
@@ -3050,8 +3065,10 @@ bool CSphIndex_VLN::AddRemoveAttribute ( bool bAddAttr, const AttrAddRemoveCtx_t
 	}
 
 	if ( bColumnar )
-		AddRemoveColumnarAttr ( bAddAttr, tCtx.m_sName, tCtx.m_eType, m_tSchema, tNewSchema, sError );
-	else
+	{
+		if ( !AddRemoveColumnarAttr ( bAddAttr, tCtx.m_sName, tCtx.m_eType, m_tSchema, tNewSchema, sError ) )
+			return false;
+	} else
 	{
 		int64_t iTotalRows = m_iDocinfo + (m_iDocinfoIndex+1)*2;
 		Alter_AddRemoveRowwiseAttr ( m_tSchema, tNewSchema, m_tAttr.GetReadPtr(), (DWORD)iTotalRows, m_tBlobAttrs.GetReadPtr(), *pSPAWriteWrapper, *pSPBWriteWrapper, bAddAttr, tCtx.m_sName );
@@ -7354,7 +7371,7 @@ bool CSphIndex_VLN::DoMerge ( const CSphIndex_VLN * pDstIndex, const CSphIndex_V
 	// unlink prepared attribute files on exit, if any
 	AT_SCOPE_EXIT ( [&dDeleteOnInterrupt]
 	{
-		DeleteMergeTmpFiles ( dDeleteOnInterrupt );
+		DeleteTmpFilesWithPrefix ( dDeleteOnInterrupt );
 	});
 
 	// merging attributes
@@ -7531,7 +7548,7 @@ bool CSphIndex_VLN::DoMergeN ( VecTraits_T<const CSphIndex_VLN *> dIndexes, CSph
 	StrVec_t dDeleteOnInterrupt;
 	AT_SCOPE_EXIT ( [&dDeleteOnInterrupt]
 	{
-		DeleteMergeTmpFiles ( dDeleteOnInterrupt );
+		DeleteTmpFilesWithPrefix ( dDeleteOnInterrupt );
 	} );
 
 	{

--- a/test/clt-tests/bugs/4697-columnar-alter-temp-cleanup.rec
+++ b/test/clt-tests/bugs/4697-columnar-alter-temp-cleanup.rec
@@ -1,0 +1,47 @@
+––– comment –––
+Disk-columnar ALTER should clean columnar builder sidecars when the final .tmp.spc write fails.
+––– block: ../base/start-searchd –––
+––– input –––
+cat > /tmp/issue-4697-columnar-alter-temp-cleanup.sh <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+mysqlq() { mysql -h0 -P9306 --batch --raw --skip-column-names -e "$1"; }
+
+mysqlq "SET GLOBAL auto_optimize=0"
+mysqlq "DROP TABLE IF EXISTS t" >/dev/null 2>&1 || true
+rm -rf /var/lib/manticore/t
+
+mysqlq "CREATE TABLE t (a int) engine='columnar'"
+mysqlq "INSERT INTO t VALUES (1,10), (2,20), (3,30)"
+mysqlq "FLUSH RAMCHUNK t"
+
+spc_file=$(find /var/lib/manticore/t -maxdepth 1 -name '*.spc' -print | sort | head -n1)
+if [ -z "$spc_file" ]; then
+  echo "ERROR: no disk columnar file"
+  exit 1
+fi
+
+tmp_prefix="${spc_file%.spc}.tmp.spc"
+rm -rf "$tmp_prefix" "$tmp_prefix".*
+mkdir "$tmp_prefix"
+
+set +e
+mysql -h0 -P9306 --batch --raw --skip-column-names -e "ALTER TABLE t ADD COLUMN b int" >/tmp/issue-4697-alter.out 2>&1
+set -e
+
+leftovers=$(find /var/lib/manticore/t -maxdepth 1 -name "$(basename "$tmp_prefix").*" -print | sort || true)
+rm -rf "$tmp_prefix"
+mysqlq "DROP TABLE IF EXISTS t" >/dev/null 2>&1 || true
+
+if [ -n "$leftovers" ]; then
+  echo "ERROR: temp columnar alter sidecars left"
+  printf '%s\n' "$leftovers" | sed 's#.*/##'
+  exit 1
+fi
+
+echo "alter temp sidecars cleaned"
+BASH
+bash /tmp/issue-4697-columnar-alter-temp-cleanup.sh
+––– output –––
+alter temp sidecars cleaned

--- a/test/clt-tests/vector-knn/test-issue-4697-columnar-knn-temp-cleanup.rec
+++ b/test/clt-tests/vector-knn/test-issue-4697-columnar-knn-temp-cleanup.rec
@@ -1,0 +1,71 @@
+––– input –––
+searchd --stopwait >/dev/null 2>&1 || true; rm -rf /var/lib/manticore/*; mkdir -p /var/lib/manticore /var/log/manticore /run/manticore; : > /var/log/manticore/searchd.log; stdbuf -oL searchd ${SEARCHD_ARGS:-} >/tmp/issue-4697-searchd-start.out 2>&1; for i in $(seq 1 60); do mysql -h0 -P9306 -e "SELECT 1" >/dev/null 2>&1 && { echo "Accepting connections!"; break; }; sleep 0.5; if [ "$i" -eq 60 ]; then echo "Timeout or failed!"; cat /tmp/issue-4697-searchd-start.out /var/log/manticore/searchd.log 2>/dev/null | tail -100; fi; done
+––– output –––
+Accepting connections!
+––– input –––
+cat > /tmp/issue-4697-columnar-knn-temp-cleanup.sh <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+ROWS_PER_FLUSH=${ROWS_PER_FLUSH:-4000}
+FLUSHES=${FLUSHES:-10}
+DIMS=${DIMS:-128}
+SCHEMA="id bigint, c text, e float_vector knn_type='hnsw' knn_dims='$DIMS' hnsw_similarity='cosine' quantization='8bit'"
+VEC="("
+sep=""
+for _ in $(seq 1 "$DIMS"); do
+  VEC="${VEC}${sep}0.1"
+  sep=","
+done
+VEC="${VEC})"
+mysqlq() { mysql -h0 -P9306 --batch --raw --skip-column-names -e "$1"; }
+mysqlq "DROP TABLE IF EXISTS t__old"
+mysqlq "DROP TABLE IF EXISTS t"
+mysqlq "CREATE TABLE t ($SCHEMA) engine='columnar'"
+for f in $(seq 1 "$FLUSHES"); do
+  sql="/tmp/issue-4697-insert-$f.sql"
+  : > "$sql"
+  for i in $(seq 1 "$ROWS_PER_FLUSH"); do
+    id=$((f*ROWS_PER_FLUSH+i))
+    printf "INSERT INTO t (id,c,e) VALUES (%d,'x',%s);\n" "$id" "$VEC" >> "$sql"
+  done
+  mysql -h0 -P9306 --batch --raw --skip-column-names < "$sql" >/dev/null
+  mysqlq "FLUSH RAMCHUNK t" >/dev/null
+done
+
+end=$((SECONDS+30))
+while [ $SECONDS -lt $end ]; do
+  if find /var/lib/manticore/t -maxdepth 1 -name '*.tmp.spc.*' | grep -q .; then
+    echo "merge window observed"
+    break
+  fi
+  sleep 0.1
+done
+if ! find /var/lib/manticore/t -maxdepth 1 -name '*.tmp.spc.*' | grep -q .; then
+  echo "ERROR: merge temp-file window was not observed"
+  exit 1
+fi
+
+mysqlq "CREATE TABLE t__old LIKE t" >/dev/null
+mysqlq "ATTACH TABLE t TO TABLE t__old" >/dev/null
+mysqlq "DROP TABLE t" >/dev/null
+
+leftovers=$(find /var/lib/manticore/t -maxdepth 1 -name '*.tmp*' -print 2>/dev/null | sort || true)
+if [ -n "$leftovers" ]; then
+  echo "ERROR: temp files left after DROP TABLE t"
+  printf '%s\n' "$leftovers" | sed 's#.*/##'
+  exit 1
+fi
+if ! out=$(mysql -h0 -P9306 --batch --raw --skip-column-names -e "CREATE TABLE t ($SCHEMA) engine='columnar'" 2>&1); then
+  echo "ERROR: recreate failed"
+  printf '%s\n' "$out" | sed -E 's#/var/lib/manticore/t#TABLEDIR#g'
+  exit 1
+fi
+
+echo "cleanup ok"
+echo "recreate ok"
+BASH
+bash /tmp/issue-4697-columnar-knn-temp-cleanup.sh
+––– output –––
+merge window observed
+cleanup ok
+recreate ok


### PR DESCRIPTION
Interrupted disk-chunk merges only removed exact tracked temp filenames, but columnar/KNN builders can create component files under the same temp prefix such as .tmp.spc.0 and .tmp.spc.1. Remove all files matching the tracked temp prefix during merge cleanup so ATTACH/DROP does not leave the table directory non-empty.

Related issue http://github.com/manticoresoftware/manticoresearch/issues/4697