### PR TITLE
ci: update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/build_template.yml
+++ b/.github/workflows/build_template.yml
@@ -114,7 +114,7 @@ jobs:
         BUILD_TAG: ${{ inputs.build_tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.ref != '' && inputs.ref || github.sha }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Download built MCL package artifact
         if: ${{ inputs.MCL_PACKAGE_ARTIFACT_NAME != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.MCL_PACKAGE_ARTIFACT_NAME }}
           path: ./mcl-package
@@ -159,7 +159,7 @@ jobs:
           echo "MCL_REPO_TYPE=${{ inputs.MCL_REPO_TYPE }}" >> "$GITHUB_ENV"
 
       - name: Check out cache before building
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cache
           enableCrossOsArchive: true
@@ -171,14 +171,14 @@ jobs:
 
       - name: Upload Windows build cache artifact
         if: success() && inputs.DISTR == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cache_${{ inputs.cache_key }}
           path: cache
 
       - name: Upload build artifacts
         if: success()
-        uses: manticoresoftware/upload_artifact_with_retries@v4
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: ${{ steps.artifact_name.outputs.value }}
           path: ${{ inputs.artifact_list }}

--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -95,7 +95,7 @@ jobs:
           fi
       - name: Upload artifact
         if: steps.docs-artifact.outputs.exists == 'true'
-        uses: manticoresoftware/upload_artifact_with_retries@v4
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: Docs error artifact
           path: $DOCS_ERRORS_DIR

--- a/.github/workflows/clt_nightly.yml
+++ b/.github/workflows/clt_nightly.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - run: |
           echo "# Nightly tests of latest release" >> $GITHUB_STEP_SUMMARY
           echo "* Attempt: ${{ github.run_attempt }}" >> $GITHUB_STEP_SUMMARY
@@ -138,8 +138,8 @@ jobs:
             test_prefix: test/clt-tests/performance-nightly/test-performance-for-queries-with-multiple-disk-chunks
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: ${{ matrix.test_prefix }}
           image: ${{ matrix.image }}
@@ -228,8 +228,8 @@ jobs:
             test_prefix: test/clt-tests/installation/deb-dev-update
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: ${{ matrix.test_prefix }}
           image: ${{ matrix.image }}

--- a/.github/workflows/clt_tests.yml
+++ b/.github/workflows/clt_tests.yml
@@ -45,7 +45,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.ref }}
@@ -150,7 +150,7 @@ jobs:
       # itself — wipe its contents instead (`rm -rf /var/lib/manticore/*` leaves .cache alone).
       - id: model_cache
         name: Restore model cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/clt-model-cache
           key: clt-models-v1-chunk-${{ matrix.chunk.id }}
@@ -159,7 +159,7 @@ jobs:
         shell: bash
         run: mkdir -p "${{ runner.temp }}/clt-model-cache" && chmod 777 "${{ runner.temp }}/clt-model-cache"
 
-      - uses: manticoresoftware/clt@0.7.8
+      - uses: manticoresoftware/clt@0.7.9
         with:
           artifact: ${{ inputs.artifact_name }}
           image: ${{ inputs.docker_image }}
@@ -180,7 +180,7 @@ jobs:
       - name: Save model cache
         if: ${{ always() && steps.model_cache.outputs.cache-hit != 'true' }}
         continue-on-error: true
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}/clt-model-cache
           key: clt-models-v1-chunk-${{ matrix.chunk.id }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -78,7 +78,7 @@ jobs:
           apt-get install -y git
     
       - name: Checkout
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           set-safe-directory: true
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload artifact
         if: always()
-        uses: manticoresoftware/upload_artifact_with_retries@v4
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: Docs deploy error artifact
           path: $DOCS_ERRORS_DIR

--- a/.github/workflows/mcl_embeddings_core.yml
+++ b/.github/workflows/mcl_embeddings_core.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
           fetch-depth: 0
@@ -76,20 +76,35 @@ jobs:
           git config --global --add safe.directory "$PWD"
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: clippy, rustfmt
-          override: true
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: '29.3'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="29.3"
+          case "${{ runner.os }}-${{ runner.arch }}" in
+            Linux-X64) platform="linux-x86_64" ;;
+            Linux-ARM64) platform="linux-aarch_64" ;;
+            macOS-X64) platform="osx-x86_64" ;;
+            macOS-ARM64) platform="osx-aarch_64" ;;
+            Windows-X64) platform="win64" ;;
+            *)
+              echo "Unsupported protoc runner: ${{ runner.os }}-${{ runner.arch }}" >&2
+              exit 1
+              ;;
+          esac
+          url="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-${platform}.zip"
+          dest="${RUNNER_TEMP}/protoc"
+          rm -rf "${dest}"
+          mkdir -p "${dest}"
+          curl --fail --show-error --location --retry 5 --retry-all-errors --retry-delay 2 "${url}" -o "${RUNNER_TEMP}/protoc.zip"
+          unzip -q "${RUNNER_TEMP}/protoc.zip" -d "${dest}"
+          echo "${dest}/bin" >> "${GITHUB_PATH}"
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -98,7 +113,7 @@ jobs:
           restore-keys: cargo-registry-${{ runner.os }}-
 
       - name: Cache cargo build target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./embeddings/target
           key: cargo-target-${{ runner.os }}-${{ hashFiles('embeddings/Cargo.lock') }}-${{ hashFiles('embeddings/src/**/*.rs') }}
@@ -107,7 +122,7 @@ jobs:
             cargo-target-${{ runner.os }}-
 
       - name: Cache ML test models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ./embeddings/.cache/manticore
           key: ml-models-${{ runner.os }}-${{ hashFiles('embeddings/src/model/local_test.rs') }}
@@ -233,7 +248,7 @@ jobs:
           lib_dir="./embeddings/target/${target}/release"
           echo "lib_dir=${lib_dir}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
           fetch-depth: 0
@@ -270,18 +285,33 @@ jobs:
           git config --global --add safe.directory "$PWD"
 
       - name: Setup Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           target: ${{ steps.vars.outputs.target }}
-          override: true
 
       - name: Install protoc
         if: ${{ inputs.distr != 'linux' }}
-        uses: arduino/setup-protoc@v3
-        with:
-          version: '29.3'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="29.3"
+          case "${{ runner.os }}-${{ runner.arch }}" in
+            Linux-X64) platform="linux-x86_64" ;;
+            Linux-ARM64) platform="linux-aarch_64" ;;
+            macOS-X64) platform="osx-x86_64" ;;
+            macOS-ARM64) platform="osx-aarch_64" ;;
+            Windows-X64) platform="win64" ;;
+            *)
+              echo "Unsupported protoc runner: ${{ runner.os }}-${{ runner.arch }}" >&2
+              exit 1
+              ;;
+          esac
+          url="https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-${platform}.zip"
+          dest="${RUNNER_TEMP}/protoc"
+          rm -rf "${dest}"
+          mkdir -p "${dest}"
+          curl --fail --show-error --location --retry 5 --retry-all-errors --retry-delay 2 "${url}" -o "${RUNNER_TEMP}/protoc.zip"
+          unzip -q "${RUNNER_TEMP}/protoc.zip" -d "${dest}"
+          echo "${dest}/bin" >> "${GITHUB_PATH}"
 
       - name: Extract git metadata
         id: git_meta
@@ -326,7 +356,7 @@ jobs:
 
       - name: Cache cargo registry for native build
         if: ${{ inputs.distr != 'linux' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -335,7 +365,7 @@ jobs:
           restore-keys: emb-build-cargo-${{ runner.os }}-${{ inputs.arch }}-
 
       - name: Cache cargo build target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: embeddings/target
           key: emb-build-target-${{ runner.os }}-${{ inputs.distr }}-${{ inputs.arch }}-${{ inputs.mcl_full_sha }}-${{ hashFiles('embeddings/Cargo.lock', 'embeddings/Cargo.toml', 'embeddings/src/**/*.rs') }}
@@ -345,7 +375,7 @@ jobs:
 
       - name: Cache cargo registry for Docker build
         if: ${{ inputs.distr == 'linux' }}
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .cargo-cache/registry
@@ -558,7 +588,7 @@ jobs:
 
       - name: Upload build artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: embeddings_${{ inputs.distr }}_${{ inputs.arch }}
           path: ./build/*

--- a/.github/workflows/mcl_pack_publish.yml
+++ b/.github/workflows/mcl_pack_publish.yml
@@ -24,7 +24,7 @@ jobs:
       version_full: ${{ steps.package_version.outputs.version_full }}
       version_rpm: ${{ steps.package_version.outputs.version_rpm }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
           fetch-depth: 0

--- a/.github/workflows/mcl_package_build.yml
+++ b/.github/workflows/mcl_package_build.yml
@@ -105,7 +105,7 @@ jobs:
         RPM_PACKAGE_VERSION: ${{ inputs.rpm_package_version }}
     steps:
       - name: Checkout daemon repository with MCL submodule
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
           fetch-depth: 0
@@ -185,7 +185,7 @@ jobs:
 
       - name: Download embeddings lib
         if: ${{ inputs.embeddings_artifact != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: ${{ inputs.embeddings_artifact }}
@@ -222,7 +222,7 @@ jobs:
           fi
 
       - name: Check out main cache before building
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cache
           enableCrossOsArchive: true
@@ -231,7 +231,7 @@ jobs:
             ${{ inputs.cache_key }}_master
 
       - name: Check out deps cache before building
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/_deps/cache
           enableCrossOsArchive: true
@@ -295,7 +295,7 @@ jobs:
 
       - name: Save MCL package to exact-SHA cache
         if: success() && inputs.package_cache_key != ''
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .mcl-package-cache
           key: ${{ inputs.package_cache_key }}
@@ -314,7 +314,7 @@ jobs:
 
       - name: Upload build artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ steps.artifact_paths.outputs.value }}

--- a/.github/workflows/mcl_runtime_build.yml
+++ b/.github/workflows/mcl_runtime_build.yml
@@ -74,7 +74,7 @@ jobs:
         SYSROOT_URL: https://repo.manticoresearch.com/repository/sysroots
     steps:
       - name: Checkout daemon repository with MCL submodule
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Restore exact MCL runtime cache
         id: runtime_cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .mcl-runtime-cache
           key: ${{ inputs.cache_key }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Download embeddings artifact
         if: ${{ steps.restored.outputs.ok != 'true' && inputs.embeddings_artifact != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.embeddings_artifact }}
           path: ./embeddings-lib
@@ -265,13 +265,13 @@ jobs:
 
       - name: Save exact MCL runtime cache
         if: ${{ steps.restored.outputs.ok != 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .mcl-runtime-cache
           key: ${{ inputs.cache_key }}
 
       - name: Upload MCL runtime artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_name }}
           path: mcl-runtime

--- a/.github/workflows/nightly_dumps.yml
+++ b/.github/workflows/nightly_dumps.yml
@@ -31,8 +31,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/mysqldump/versions/mariadb/
@@ -45,8 +45,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/mysqldump/versions/mysql/
@@ -59,8 +59,8 @@ jobs:
     timeout-minutes: 60  
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: manticoresearch/dind:v1
           test_prefix: test/clt-tests/migration-es-ms/
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload .rep File
         if: always()  
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-migration-es-ms-rep
           path: test/clt-tests/migration-es-ms/test-migration-es-ms.rep

--- a/.github/workflows/nightly_fuzzer.yml
+++ b/.github/workflows/nightly_fuzzer.yml
@@ -27,17 +27,17 @@ jobs:
         cache-hit: ${{ steps.check-cache.outputs.cache-hit }}
     steps:
         - name: 📥 Checkout repo
-          uses: actions/checkout@v3        
+          uses: actions/checkout@v5
         - name: 💾 Attempt to restore build cache
           id: check-cache
-          uses: actions/cache@v4
+          uses: actions/cache@v5
           with:
             path: build
             key: build-linux-fuzz-${{ github.sha }}
 #            key: build-linux-fuzz
         - name: 📦 Upload restored build (if cache was found)
           if: steps.check-cache.outputs.cache-hit == 'true'
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v6
           with:
               name: fuzz-build
               path: build
@@ -66,12 +66,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
         - name: 📥 Download built artifact
-          uses: actions/download-artifact@v4
+          uses: actions/download-artifact@v7
           with:
               name: fuzz-build
               path: build
         - name: 💾 Save build to cache
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v5
           with:
               path: build
               key: build-linux-fuzz-${{ github.sha }}
@@ -91,18 +91,18 @@ jobs:
       image: ubuntu:jammy
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           set-safe-directory: true
       - name: 📦 Download built artifact with retry logic
-        uses: manticoresoftware/download_artifact_with_retries@v3
+        uses: manticoresoftware/download_artifact_with_retries@v5
         continue-on-error: true
         with:
           name: fuzz-build
           path: .
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/src/fuzzer/corpus
           key: fuzz-corpus-cache-to-delete
@@ -134,13 +134,13 @@ jobs:
             exit $qfuzzer_exit_code
       - name: Save cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: build/src/fuzzer/corpus
           key: fuzz-corpus-${{ steps.run.outputs.corpus_size || 'unknown' }}
       - name: 📦 Upload fuzzer directory
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fuzzer-dir
           path: |
@@ -152,7 +152,7 @@ jobs:
             !build/src/fuzzer/CTest*
       - name: 📦 Upload updated fuzzer corpus
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fuzzer-corpus
           path: build/src/fuzzer/corpus
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 📥 Download fuzzer-corpus artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fuzzer-corpus
           path: corpus

--- a/.github/workflows/nightly_integration.yml
+++ b/.github/workflows/nightly_integration.yml
@@ -33,8 +33,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/filebeat/test-integrations-check-filebeat-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -48,8 +48,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/logstash/test-integrations-check-logstash-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -63,8 +63,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/grafana/test-integrations-check-grafana-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -81,8 +81,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/dbeaver/test-integrations-dbeaver
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -96,8 +96,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/filebeat/test-integrations-filebeat
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -111,8 +111,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/fluentbit/test-integrations-fluentbit
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -125,8 +125,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/grafana/test-integrations-grafana
           image: manticoresearch/dind:v1
@@ -140,8 +140,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/kafka/test-integration-
           image: manticoresearch/dind:v1
@@ -155,8 +155,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/logstash/test-integrations-logstash
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -170,8 +170,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/vector/test-integrations-vector
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -188,8 +188,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/filebeat/test-integrations-support-filebeat-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -203,8 +203,8 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/logstash/test-integrations-test-logstash-versions
           image: ghcr.io/manticoresoftware/manticoresearch:test-kit-latest
@@ -218,8 +218,8 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: manticoresoftware/clt@0.7.8
+        uses: actions/checkout@v5
+      - uses: manticoresoftware/clt@0.7.9
         with:
           test_prefix: test/clt-tests/integrations/grafana/test-integrations-test-grafana-versions
           image: manticoresearch/dind:v1

--- a/.github/workflows/nightly_memleaks.yml
+++ b/.github/workflows/nightly_memleaks.yml
@@ -35,12 +35,12 @@ jobs:
         CACHEB: "../cache"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           set-safe-directory: true
       - name: Check out cache before building
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: cache
           key: build_linux_debug_x86_64
@@ -51,7 +51,7 @@ jobs:
       - name: Upload build artifacts
         if: always()
         continue-on-error: true
-        uses: manticoresoftware/upload_artifact_with_retries@v4
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: memleaks_${{ github.sha }}
           path: build/Testing

--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -45,7 +45,7 @@ jobs:
       mcl_full_sha: ${{ steps.mcl.outputs.mcl_full_sha }}
       mcl_changed: ${{ steps.detect.outputs.mcl_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           fetch-depth: 0
@@ -140,7 +140,7 @@ jobs:
       )
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           submodules: recursive
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
       # We have to checkout to access .github/workflows/ in further steps
@@ -358,14 +358,14 @@ jobs:
       CI_COMMIT_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Download local Windows MCL package artifact
         if: ${{ needs.check_branch.outputs.mcl_changed == 'true' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mcl_pkg_windows_x64
           path: ./mcl-package
@@ -400,7 +400,7 @@ jobs:
         shell: bash
       - run: mv /builds/manticoresearch/dev/build build
       - name: Upload artifact
-        uses: manticoresoftware/upload_artifact_with_retries@main
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: win_installer
           path: build/manticore-*.exe
@@ -503,7 +503,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Download Windows installer artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: win_installer
         path: ./installer
@@ -711,7 +711,7 @@ jobs:
       GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
           submodules: recursive
@@ -723,7 +723,7 @@ jobs:
         id: sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Building docker
@@ -738,7 +738,7 @@ jobs:
         image: [ "almalinux:8", "almalinux:9", "almalinux:10", "oraclelinux:9", "amazonlinux:latest" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.7.8
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/rhel-dev-
@@ -753,7 +753,7 @@ jobs:
         image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.7.8
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/deb-dev-

--- a/.github/workflows/pack_publish_galera.yml
+++ b/.github/workflows/pack_publish_galera.yml
@@ -205,7 +205,7 @@ jobs:
         image: [ "almalinux:8", "almalinux:9", "almalinux:10", "oraclelinux:9", "amazonlinux:latest" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.7.8
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/rhel-dev-
@@ -220,7 +220,7 @@ jobs:
         image: [ "ubuntu:bionic", "ubuntu:focal", "ubuntu:jammy", "debian:bullseye", "debian:bookworm" ]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/clt@0.7.8
+      - uses: manticoresoftware/clt@0.7.9
         with:
           image: ${{ matrix.image }}
           test_prefix: test/clt-tests/installation/deb-dev-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       run_image_push: ${{ steps.calc.outputs.run_image_push }} # push test-kit image tags
       skip_clt_reason: ${{ steps.related_prs.outputs.skip_clt_reason }} # explanation for CLT skip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           submodules: recursive
@@ -333,7 +333,7 @@ jobs:
     steps:
       - name: Check out cache
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             bundle
@@ -352,7 +352,7 @@ jobs:
           wget https://repo.manticoresearch.com/repository/ci/boost_1_75_0.tgz
           tar -xf boost_1_75_0.tgz
       - name: Upload Windows bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows_bundle
           path: |
@@ -474,7 +474,7 @@ jobs:
       - name: Restore exact-SHA MCL package cache
         id: probe
         if: ${{ needs.meta.outputs.mcl_full_sha != '' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .mcl-package-cache
           key: mcl-test-pkg-jammy-amd64-${{ needs.meta.outputs.mcl_full_sha }}
@@ -505,7 +505,7 @@ jobs:
       image: manticoresearch/external_toolchain:clang16_cmake3263
     steps:
       - name: Restore exact-SHA MCL package cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .mcl-package-cache
           key: ${{ needs.mcl_test_package_cache_probe.outputs.cache_key }}
@@ -523,7 +523,7 @@ jobs:
             exit 1
           fi
       - name: Upload cached MCL package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mcl_package_jammy_x86_64
           path: mcl-package
@@ -543,7 +543,7 @@ jobs:
         run: mkdir -p .mcl-runtime-cache
       - name: Restore exact MCL Linux Release runtime cache
         id: restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .mcl-runtime-cache
           key: ${{ needs.meta.outputs.mcl_runtime_linux_release_cache_key }}
@@ -573,7 +573,7 @@ jobs:
           echo "cache_hit=${ok}" >> "$GITHUB_OUTPUT"
       - name: Upload cached MCL Linux Release runtime artifact
         if: steps.validate.outputs.cache_hit == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mcl_runtime_linux_release_x86_64
           path: mcl-runtime
@@ -593,7 +593,7 @@ jobs:
         run: mkdir -p .mcl-runtime-cache
       - name: Restore exact MCL Linux Debug runtime cache
         id: restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .mcl-runtime-cache
           key: ${{ needs.meta.outputs.mcl_runtime_linux_debug_cache_key }}
@@ -623,7 +623,7 @@ jobs:
           echo "cache_hit=${ok}" >> "$GITHUB_OUTPUT"
       - name: Upload cached MCL Linux Debug runtime artifact
         if: steps.validate.outputs.cache_hit == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mcl_runtime_linux_debug_x86_64
           path: mcl-runtime
@@ -643,7 +643,7 @@ jobs:
         run: mkdir -p .mcl-runtime-cache
       - name: Restore exact MCL Windows Debug runtime cache
         id: restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .mcl-runtime-cache
           key: ${{ needs.meta.outputs.mcl_runtime_windows_debug_cache_key }}
@@ -673,7 +673,7 @@ jobs:
           echo "cache_hit=${ok}" >> "$GITHUB_OUTPUT"
       - name: Upload cached MCL Windows Debug runtime artifact
         if: steps.validate.outputs.cache_hit == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: mcl_runtime_windows_debug_x64
           path: mcl-runtime
@@ -843,7 +843,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository # We have to checkout to access .github/workflows/ in further steps
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -862,7 +862,7 @@ jobs:
       - name: Pack docker image artifact
         run: tar -cf artifact.tar manticore_test_kit.img
       - name: Upload docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: manticore_test_kit.img
           path: artifact.tar
@@ -881,18 +881,18 @@ jobs:
       out-build: ${{ steps.build.outputs.build_image }}
     steps:
       - name: Checkout repository # We have to checkout to access .github/workflows/ in further steps
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Download built x86_64 Ubuntu Jammy packages
-        uses: manticoresoftware/download_artifact_with_retries@v3
+        uses: manticoresoftware/download_artifact_with_retries@v5
         with:
           name: release_build
           path: .
       - name: Restore exact-SHA MCL package cache
         if: ${{ needs.mcl_test_package_cache_probe.outputs.cache_hit == 'true' }}
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ./.mcl-package-cache
           key: ${{ needs.mcl_test_package_cache_probe.outputs.cache_key }}
@@ -900,7 +900,7 @@ jobs:
       - name: Download local MCL package artifact (best effort)
         if: ${{ always() }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mcl_package_jammy_x86_64
           path: ./mcl-package
@@ -920,7 +920,7 @@ jobs:
       - name: Pack docker image artifact
         run: tar -cf artifact.tar manticore_test_kit.img
       - name: Upload docker image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: manticore_test_kit.img
           path: artifact.tar
@@ -968,9 +968,9 @@ jobs:
       IMAGE_BUILD_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout repository # We have to checkout to access .github/workflows/ in further steps
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: manticore_test_kit.img
           path: .

--- a/.github/workflows/test_template.yml
+++ b/.github/workflows/test_template.yml
@@ -106,7 +106,7 @@ jobs:
         FLOAT_TOLERANCE: ${{ inputs.FLOAT_TOLERANCE }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
@@ -124,14 +124,14 @@ jobs:
           test -f /work/aot/uk.pak
 
       - name: Check out cache before building
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cache
           enableCrossOsArchive: true
           key: build_linux_debug_x86_64
 
       - name: Download build artifacts
-        uses: manticoresoftware/download_artifact_with_retries@v3
+        uses: manticoresoftware/download_artifact_with_retries@v5
         with:
           name: ${{ inputs.build_artifact_name }}
           path: .
@@ -153,7 +153,7 @@ jobs:
 
       - name: Download MCL runtime artifact
         if: ${{ inputs.MCL_RUNTIME_ARTIFACT_NAME != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.MCL_RUNTIME_ARTIFACT_NAME }}
           path: ./mcl-runtime
@@ -185,7 +185,7 @@ jobs:
       - name: Download built MCL package artifact (best effort)
         if: ${{ inputs.MCL_PACKAGE_ARTIFACT_NAME != '' }}
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.MCL_PACKAGE_ARTIFACT_NAME }}
           path: ./.mcl-package-cache
@@ -259,7 +259,7 @@ jobs:
       - name: Upload test artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ inputs.artifact_name }}
           path: |

--- a/.github/workflows/win_test_template.yml
+++ b/.github/workflows/win_test_template.yml
@@ -56,18 +56,18 @@ jobs:
       test_outcome: ${{ steps.test.outcome }}
     steps:
       - name: Checkout repository # We have to checkout to access .github/workflows/ in further steps
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Download build artifacts
-        uses: manticoresoftware/download_artifact_with_retries@v3
+        uses: manticoresoftware/download_artifact_with_retries@v5
         with:
           name: build_windows_Debug_x64
           path: .
       - name: Download MCL runtime artifact
         if: ${{ inputs.MCL_RUNTIME_ARTIFACT_NAME != '' }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.MCL_RUNTIME_ARTIFACT_NAME }}
           path: mcl-runtime
@@ -100,7 +100,7 @@ jobs:
           Get-ChildItem "mcl-runtime" | Select-Object -ExpandProperty FullName
       - name: Check out Windows bundle cache
         id: windows_bundle_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             bundle
@@ -109,7 +109,7 @@ jobs:
           key: win_bundle
       - name: Download Windows bundle artifact on cache miss
         if: steps.windows_bundle_cache.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows_bundle
           path: .
@@ -121,14 +121,14 @@ jobs:
           }
       - name: Check out cache
         id: build_cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: cache
           enableCrossOsArchive: true
           key: build_windows_x64
       - name: Download Windows build cache artifact on cache miss
         if: steps.build_cache.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: cache_build_windows_x64
           path: cache
@@ -170,14 +170,14 @@ jobs:
         continue-on-error: true
       - name: Upload CTest XML artifact
         if: always()
-        uses: manticoresoftware/upload_artifact_with_retries@v4
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: ${{ inputs.artifact_name }}_ctest_xml
           path: "build/test*/Test.xml"
       - name: Upload test artifacts
         if: always()
         continue-on-error: true
-        uses: manticoresoftware/upload_artifact_with_retries@v4
+        uses: manticoresoftware/upload_artifact_with_retries@v5
         with:
           name: ${{ inputs.artifact_name }}
           path: "build/test*/Test.xml build/test_*/test/**/report* build/test_*/test/**/error*.txt build/test_*/test/**/*.log build/test_*/test/**/*log build/test_*/test/**/*.txt build/test/*.mdmp build/test/*.dmp build/test/**/*.mdmp build/test/**/*.dmp build/test_*/test/**/*.mdmp build/test_*/test/**/*.dmp"
@@ -193,18 +193,18 @@ jobs:
       image: manticoresearch/ubertests_public:332_aot
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Download test report artifacts
-        uses: manticoresoftware/download_artifact_with_retries@v3
+        uses: manticoresoftware/download_artifact_with_retries@v5
         continue-on-error: true
         with:
           name: ${{ inputs.artifact_name }}
           path: .
       - name: Download CTest XML artifact
-        uses: manticoresoftware/download_artifact_with_retries@v3
+        uses: manticoresoftware/download_artifact_with_retries@v5
         with:
           name: ${{ inputs.artifact_name }}_ctest_xml
           path: .

--- a/actions/checklist-validator/action.yml
+++ b/actions/checklist-validator/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: 🔁 Reopen issue if checklist is incomplete
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const issueBody = context.payload.issue.body;

--- a/actions/update-deps/action.yml
+++ b/actions/update-deps/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout the calling repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       env:
         GH_REPOSITORY_REF: ${{ github.head_ref || github.ref }}
       with:
@@ -29,7 +29,7 @@ runs:
         path: repository
 
     - name: Checkout manticoreseach
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       env:
         GH_ACTION_REPOSITORY: ${{ github.action_repository }}
         GH_ACTION_REF: ${{ github.action_ref }}


### PR DESCRIPTION
Updates GitHub Actions and internal wrapper action references to avoid Node.js 20 deprecation warnings.

Changes include:
- actions/checkout -> v5
- actions/cache/restore/save -> v5
- actions/upload-artifact -> v6
- actions/download-artifact -> v7
- actions/github-script -> v8
- docker/setup-qemu-action -> v4
- actions-rs/toolchain replaced with dtolnay/rust-toolchain
- arduino/setup-protoc replaced with pinned protoc 29.3 shell install
- internal wrappers updated to:
  - download_artifact_with_retries@v5
  - upload_artifact_with_retries@v5
  - clt@0.7.9

Prerequisites:
- upload-artifact-verify-action@v0.1.14 exists
- download_artifact_with_retries@v5 exists
- upload_artifact_with_retries@v5 exists
- clt@0.7.9 exists
- publish_to_repo@main uses download_artifact_with_retries@v5