### PR TITLE
ci: test installer changes with CLT

### DIFF
--- a/.github/workflows/clt_nightly.yml
+++ b/.github/workflows/clt_nightly.yml
@@ -9,7 +9,7 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/clt_nightly.yml'
-      - 'test/clt-tests/installation/**'
+      # Installer curl|sh checks stay on the nightly/manual run only; installer-source PRs use installer.yml.
       - 'test/clt-tests/data-manipulation/test-replace-into.rec'
       - 'test/clt-tests/data-manipulation/test-alter-rename-nightly.rec'
       - 'test/clt-tests/indexing-error/**'

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,234 @@
+name: Installer tests
+run-name: 📦 Installer tests ${{ github.sha }}
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/installer.yml'
+      - 'installer/**'
+      - 'test/clt-tests/installation/*'
+
+# cancels the previous workflow run when a new one appears in the same branch (e.g. main or a PR's branch)
+concurrency:
+  group: installer_${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate-installer:
+    name: Validate installer scripts
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Validate modular and standalone installer scripts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for script in installer/*.sh; do
+            if [[ "$script" == "installer/bootstrap-standalone.sh" ]]; then
+              sh -n "$script"
+            else
+              bash -n "$script"
+            fi
+          done
+
+          tmp_dir=$(mktemp -d)
+          trap 'rm -rf "$tmp_dir"' EXIT
+          generated_standalone="$tmp_dir/bootstrap-standalone.sh"
+          bash installer/build.sh "$generated_standalone"
+          sh -n "$generated_standalone"
+
+          if ! cmp -s installer/bootstrap-standalone.sh "$generated_standalone"; then
+            echo "installer/bootstrap-standalone.sh is not in sync with installer/*.sh" >&2
+            diff -u installer/bootstrap-standalone.sh "$generated_standalone" >&2
+            exit 1
+          fi
+
+  clt-installer:
+    name: CLT ${{ matrix.name }}
+    needs: [validate-installer]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Alma 8 release installer
+            runner: ubuntu-22.04
+            image: almalinux:8
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Alma 9 release installer
+            runner: ubuntu-22.04
+            image: almalinux:9
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Alma 10 release installer
+            runner: ubuntu-22.04
+            image: almalinux:10
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: OL 9 release installer
+            runner: ubuntu-22.04
+            image: oraclelinux:9
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Amazon release installer
+            runner: ubuntu-22.04
+            image: amazonlinux:latest
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Bionic release installer
+            runner: ubuntu-22.04
+            image: ubuntu:bionic
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Focal release installer
+            runner: ubuntu-22.04
+            image: ubuntu:focal
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Jammy release installer
+            runner: ubuntu-22.04
+            image: ubuntu:jammy
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Bullseye release installer
+            runner: ubuntu-22.04
+            image: debian:bullseye
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Bookworm release installer
+            runner: ubuntu-22.04
+            image: debian:bookworm
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Trixie release installer
+            runner: ubuntu-22.04
+            image: debian:trixie
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Noble release installer
+            runner: ubuntu-22.04
+            image: ubuntu:noble
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Alma 8 arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: almalinux:8
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Alma 9 arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: almalinux:9
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Alma 10 arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: almalinux:10
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: OL 9 arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: oraclelinux:9
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Amazon arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: amazonlinux:latest
+            test_prefix: |
+              test/clt-tests/installation/rhel-release-curl-bash-install
+              test/clt-tests/installation/rhel-release-curl-bash-list-versions
+          - name: Bionic arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: ubuntu:bionic
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Focal arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: ubuntu:focal
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Jammy arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: ubuntu:jammy
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Bullseye arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: debian:bullseye
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Bookworm arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: debian:bookworm
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Trixie arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: debian:trixie
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+          - name: Noble arm64 release installer
+            runner: ubuntu-24.04-arm
+            image: ubuntu:noble
+            test_prefix: |
+              test/clt-tests/installation/deb-release-curl-bash-install
+              test/clt-tests/installation/deb-release-curl-bash-list-versions
+              test/clt-tests/installation/deb-release-curl-bash-version-switch
+    steps:
+      - uses: manticoresoftware/clt@0.7.9
+        with:
+          image: ${{ matrix.image }}
+          test_prefix: ${{ matrix.test_prefix }}
+          comment_mode: failures
+          init_code: |
+            set -euo pipefail
+            mkdir -p "$RUNNER_TEMP/manticore-installer"
+            bash installer/build.sh "$RUNNER_TEMP/manticore-installer/bootstrap-standalone.sh"
+            chmod 755 "$RUNNER_TEMP/manticore-installer/bootstrap-standalone.sh"
+            sh -n "$RUNNER_TEMP/manticore-installer/bootstrap-standalone.sh"
+          run_args: "-v ${{ runner.temp }}/manticore-installer:/mnt/manticore-installer:ro -e MANTICORE_INSTALLER_SCRIPT=/mnt/manticore-installer/bootstrap-standalone.sh"
+          ui_host: "https://clt.manticoresearch.com"

--- a/test/clt-tests/installation/deb-release-curl-bash-install.rec
+++ b/test/clt-tests/installation/deb-release-curl-bash-install.rec
@@ -14,7 +14,7 @@ export TERM=xterm && export LC_ALL=C.UTF-8 && export LANG=C.UTF-8
 ––– output –––
 ––– block: installer-url –––
 ––– input –––
-set -o pipefail; (curl -sSL "$MANTICORE_INSTALLER_REPO_URL" | sh -s silent) > /dev/null 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_curl silent) > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––

--- a/test/clt-tests/installation/deb-release-curl-bash-list-versions.rec
+++ b/test/clt-tests/installation/deb-release-curl-bash-list-versions.rec
@@ -14,7 +14,7 @@ export TERM=xterm && export LC_ALL=C.UTF-8 && export LANG=C.UTF-8
 ––– output –––
 ––– block: installer-url –––
 ––– input –––
-set -o pipefail; (wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s list-versions-file /tmp/manticore-list-versions.txt) > /tmp/manticore-list-versions.out 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_wget list-versions-file /tmp/manticore-list-versions.txt) > /tmp/manticore-list-versions.out 2>&1; echo $?
 ––– output –––
 0
 ––– input –––

--- a/test/clt-tests/installation/deb-release-curl-bash-version-switch.rec
+++ b/test/clt-tests/installation/deb-release-curl-bash-version-switch.rec
@@ -14,7 +14,7 @@ export TERM=xterm && export LC_ALL=C.UTF-8 && export LANG=C.UTF-8
 ––– output –––
 ––– block: installer-url –––
 ––– input –––
-set -o pipefail; (wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s list-versions-file /tmp/manticore-versions.txt) > /tmp/manticore-versions.out 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_wget list-versions-file /tmp/manticore-versions.txt) > /tmp/manticore-versions.out 2>&1; echo $?
 ––– output –––
 0
 ––– input –––
@@ -32,7 +32,7 @@ export MANTICORE_PREVIOUS_VERSION="$(sed -n '1p' /tmp/manticore-switch-versions)
 #!/([0-9]+:)?[0-9]+[.][0-9]+[.][0-9]+([-_+~.][^[:space:]]+)?/!#
 0
 ––– input –––
-set -o pipefail; (wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s version "$MANTICORE_PREVIOUS_VERSION" no-start) > /tmp/manticore-install-previous.out 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_wget version "$MANTICORE_PREVIOUS_VERSION" no-start) > /tmp/manticore-install-previous.out 2>&1; echo $?
 ––– output –––
 0
 ––– input –––
@@ -50,7 +50,7 @@ apt-mark showmanual | grep -Fx manticore; echo $?
 manticore
 0
 ––– input –––
-set -o pipefail; (wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s upgrade no-start) > /tmp/manticore-version-switch.out 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_wget upgrade no-start) > /tmp/manticore-version-switch.out 2>&1; echo $?
 ––– output –––
 0
 ––– input –––

--- a/test/clt-tests/installation/installer-url.recb
+++ b/test/clt-tests/installation/installer-url.recb
@@ -1,3 +1,18 @@
 ––– input –––
 export MANTICORE_INSTALLER_REPO_URL="${MANTICORE_INSTALLER_REPO_URL:-https://manticoresearch.com}"
+export MANTICORE_INSTALLER_SCRIPT="${MANTICORE_INSTALLER_SCRIPT:-}"
+run_manticore_installer_curl() {
+    if [ -n "$MANTICORE_INSTALLER_SCRIPT" ]; then
+        sh "$MANTICORE_INSTALLER_SCRIPT" "$@"
+    else
+        curl -sSL "$MANTICORE_INSTALLER_REPO_URL" | sh -s "$@"
+    fi
+}
+run_manticore_installer_wget() {
+    if [ -n "$MANTICORE_INSTALLER_SCRIPT" ]; then
+        sh "$MANTICORE_INSTALLER_SCRIPT" "$@"
+    else
+        wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s "$@"
+    fi
+}
 ––– output –––

--- a/test/clt-tests/installation/installer-url.recb
+++ b/test/clt-tests/installation/installer-url.recb
@@ -3,14 +3,14 @@ export MANTICORE_INSTALLER_REPO_URL="${MANTICORE_INSTALLER_REPO_URL:-https://man
 export MANTICORE_INSTALLER_SCRIPT="${MANTICORE_INSTALLER_SCRIPT:-}"
 run_manticore_installer_curl() {
     if [ -n "$MANTICORE_INSTALLER_SCRIPT" ]; then
-        sh "$MANTICORE_INSTALLER_SCRIPT" "$@"
+        cat "$MANTICORE_INSTALLER_SCRIPT" | sh -s "$@"
     else
         curl -sSL "$MANTICORE_INSTALLER_REPO_URL" | sh -s "$@"
     fi
 }
 run_manticore_installer_wget() {
     if [ -n "$MANTICORE_INSTALLER_SCRIPT" ]; then
-        sh "$MANTICORE_INSTALLER_SCRIPT" "$@"
+        cat "$MANTICORE_INSTALLER_SCRIPT" | sh -s "$@"
     else
         wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s "$@"
     fi

--- a/test/clt-tests/installation/rhel-release-curl-bash-install.rec
+++ b/test/clt-tests/installation/rhel-release-curl-bash-install.rec
@@ -7,7 +7,7 @@ yum install -y -q --skip-broken curl mariadb mariadb105 which procps > /dev/null
 0
 ––– block: installer-url –––
 ––– input –––
-set -o pipefail; (curl -sSL "$MANTICORE_INSTALLER_REPO_URL" | sh -s silent) > /dev/null 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_curl silent) > /dev/null 2>&1; echo $?
 ––– output –––
 0
 ––– input –––

--- a/test/clt-tests/installation/rhel-release-curl-bash-list-versions.rec
+++ b/test/clt-tests/installation/rhel-release-curl-bash-list-versions.rec
@@ -7,7 +7,7 @@ yum install -y -q --skip-broken wget curl which procps diffutils > /dev/null 2>&
 0
 ––– block: installer-url –––
 ––– input –––
-set -o pipefail; (wget -qO- "$MANTICORE_INSTALLER_REPO_URL" | sh -s list-versions-file /tmp/manticore-list-versions.txt) > /tmp/manticore-list-versions.out 2>&1; echo $?
+set -o pipefail; (run_manticore_installer_wget list-versions-file /tmp/manticore-list-versions.txt) > /tmp/manticore-list-versions.out 2>&1; echo $?
 ––– output –––
 0
 ––– input –––


### PR DESCRIPTION
Add a focused installer workflow that builds the standalone installer from the current checkout and mounts it into CLT containers, while keeping nightly release installer checks on the published URL.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4709
Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4710