### PR TITLE
fix: persist replication user in cluster config

### DIFF
--- a/src/searchdreplication.cpp
+++ b/src/searchdreplication.cpp
@@ -975,6 +975,7 @@ CSphVector<ClusterDesc_t> ReplicationCollectClusters ()  EXCLUDES ( g_tClustersL
 		ReplicationClusterRefPtr_c m_pCluster;
 		CSphString m_sName;
 		CSphString m_sPath;
+		CSphString m_sUser;
 		StrVec_t m_dClusterNodes;
 		bool m_bSelfBootstrapOnStartup = false;
 	};
@@ -994,6 +995,7 @@ CSphVector<ClusterDesc_t> ReplicationCollectClusters ()  EXCLUDES ( g_tClustersL
 			tSnapshot.m_pCluster = tCluster.second;
 			tSnapshot.m_sName = tCluster.second->m_sName;
 			tSnapshot.m_sPath = tCluster.second->m_sPath;
+			tSnapshot.m_sUser = tCluster.second->GetUserSnapshot();
 			tSnapshot.m_dClusterNodes = tCluster.second->m_dClusterNodes;
 			tSnapshot.m_bSelfBootstrapOnStartup = tCluster.second->m_bSelfBootstrapOnStartup && tCluster.second->m_dClusterNodes.GetLength()==1;
 		}
@@ -1013,6 +1015,7 @@ CSphVector<ClusterDesc_t> ReplicationCollectClusters ()  EXCLUDES ( g_tClustersL
 		ClusterDesc_t & tDesc = dClusters.Add();
 		tDesc.m_sName = tSnapshot.m_sName;
 		tDesc.m_sPath = tSnapshot.m_sPath;
+		tDesc.m_sUser = tSnapshot.m_sUser;
 		tDesc.m_dClusterNodes = tSnapshot.m_dClusterNodes;
 		tDesc.m_bSelfBootstrapOnStartup = tSnapshot.m_bSelfBootstrapOnStartup;
 		pCluster->WithRlockedIndexes ( [&tDesc,pCluster] ( const auto & hIndexes )

--- a/test/clt-tests/buddy-plugins/test-auth-cluster-delegated-flow.rec
+++ b/test/clt-tests/buddy-plugins/test-auth-cluster-delegated-flow.rec
@@ -70,6 +70,21 @@ MYSQL_PWD=noreplpass1 mysql -E -unorepluser -h0 -P2306 -e "SELECT id,title FROM 
 ––– output –––
 #!/1[[:space:]]+delegated replication works/!#
 ––– comment –––
+––– Cluster metadata must persist the effective replication user for restart/rejoin –––
+––– comment –––
+––– input –––
+bash -c 'for INSTANCE in 1 2; do json=$(tr -d " \n\t" < /var/log/manticore-${INSTANCE}/manticore.json); echo "$json" | grep -q "\"user\":\"repluser\"" || { echo "MISSING_USER_IN_CONFIG_NODE${INSTANCE}"; cat /var/log/manticore-${INSTANCE}/manticore.json; exit 1; }; done; echo "CLUSTER_USER_PERSISTED=yes"'
+––– output –––
+CLUSTER_USER_PERSISTED=yes
+––– input –––
+bash -c 'export INSTANCE=1; stdbuf -oL searchd --stopwait -c /tmp/searchd-with-flexible-ports-auth-${INSTANCE}.conf >/dev/null; : > /var/log/manticore-${INSTANCE}/searchd.log; stdbuf -oL searchd -c /tmp/searchd-with-flexible-ports-auth-${INSTANCE}.conf >/dev/null; if timeout 30 grep -qm1 "\[BUDDY\] started" <(tail -n 1000 -f /var/log/manticore-${INSTANCE}/searchd.log); then echo "NODE1_RESTARTED=yes"; else echo "NODE1_RESTARTED=no"; cat /var/log/manticore-${INSTANCE}/searchd.log; fi'
+––– output –––
+NODE1_RESTARTED=yes
+––– input –––
+bash -c 'ready=$(MYSQL_PWD=adminpass mysql -E -uadmin -h0 -P1306 -e "debug wait mycluster like '\''state'\'' option '\''timeout'\''=90;" 2>&1); status=$(MYSQL_PWD=adminpass mysql -E -uadmin -h0 -P1306 -e "SHOW STATUS LIKE '\''cluster_mycluster_status'\''" 2>&1); state=$(MYSQL_PWD=adminpass mysql -E -uadmin -h0 -P1306 -e "SHOW STATUS LIKE '\''cluster_mycluster_node_state'\''" 2>&1); if echo "$ready" | grep -q "Value: synced" && echo "$status" | grep -q "Value: primary" && echo "$state" | grep -q "Value: synced" && ! grep -q "missing effective replication user" /var/log/manticore-1/searchd.log; then echo "NODE1_REJOINED_WITH_USER=yes"; else echo "NODE1_REJOINED_WITH_USER=no"; echo "$ready"; echo "$status"; echo "$state"; tail -n 200 /var/log/manticore-1/searchd.log; exit 1; fi'
+––– output –––
+NODE1_REJOINED_WITH_USER=yes
+––– comment –––
 ––– Node1: delete cluster as norepluser (uses cluster user for replication auth) –––
 ––– comment –––
 ––– input –––


### PR DESCRIPTION
Copy the effective replication user into the saved cluster snapshot so authenticated clusters keep the user field in manticore.json and can restore after restart.

Add a delegated-auth cluster regression that verifies user persistence, restart, and automatic rejoin without the missing-user warning.

Ralated issue: https://github.com/manticoresoftware/manticoresearch/issues/4705