### PR TITLE
ci: publish standalone MCL packages by submodule SHA

### DIFF
--- a/.github/workflows/mcl_pack_publish.yml
+++ b/.github/workflows/mcl_pack_publish.yml
@@ -16,6 +16,12 @@ on:
         default: ""
 
 jobs:
+  noop:
+    if: ${{ inputs.enabled != true }}
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "MCL package build is not needed for this run"
+
   metadata:
     if: ${{ inputs.enabled }}
     runs-on: ubuntu-22.04
@@ -23,6 +29,7 @@ jobs:
       version_base: ${{ steps.package_version.outputs.version_base }}
       version_full: ${{ steps.package_version.outputs.version_full }}
       version_rpm: ${{ steps.package_version.outputs.version_rpm }}
+      version_tagged: ${{ steps.package_version.outputs.version_tagged }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -63,14 +70,23 @@ jobs:
         id: package_version
         run: |
           set -euo pipefail
-          base_version="$(git tag --merged HEAD --list '[0-9]*' --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)"
+          # MCL semver tags are owned by manticoresoftware/columnar's Auto version workflow.
+          # The daemon workflow only consumes those tags to package the checked-out submodule SHA.
+          tagged_version="$(git tag --points-at HEAD --list '[0-9]*' --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1 || true)"
+          if [[ -n "${tagged_version}" ]]; then
+            base_version="${tagged_version}"
+            version_tagged=true
+          else
+            base_version="$(git tag --merged HEAD --list '[0-9]*' --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)"
+            version_tagged=false
+          fi
           if [[ -z "${base_version}" ]]; then
             echo "Unable to determine MCL base version from reachable semver tags" >&2
             exit 1
           fi
           commit_hash="$(git rev-parse --short=8 HEAD)"
           timestamp="$(git log -1 --format='%cd' --date=format:'%y%m%d%H' HEAD)"
-          if git tag --points-at HEAD | grep -Eq "^(${base_version}|release-${base_version})$"; then
+          if [[ "${version_tagged}" == true ]] || git tag --points-at HEAD | grep -Eq "^release-${base_version}$"; then
             version_full="${base_version}+${timestamp}-${commit_hash}"
           else
             version_full="${base_version}+${timestamp}-${commit_hash}-dev"
@@ -79,6 +95,7 @@ jobs:
           echo "version_base=${base_version}" >> "$GITHUB_OUTPUT"
           echo "version_full=${version_full}" >> "$GITHUB_OUTPUT"
           echo "version_rpm=${version_rpm}" >> "$GITHUB_OUTPUT"
+          echo "version_tagged=${version_tagged}" >> "$GITHUB_OUTPUT"
 
   embeddings_builds:
     if: ${{ inputs.enabled }}

--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -517,16 +517,18 @@ jobs:
 
   publish_debian_ubuntu:
     needs: [publish, pack]
-    if: needs.pack.outputs.should_continue == 'true'
+    if: needs.pack.outputs.should_continue == 'true' || needs.pack.outputs.mcl_package_needed == 'true'
     strategy:
       fail-fast: true
       matrix:
-        DISTR: [bionic, focal, jammy, bullseye, bookworm]
+        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
         arch: [x86_64, aarch64]
     runs-on: ubuntu-22.04
     name: ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
     steps:
-      - uses: manticoresoftware/publish_to_repo@main
+      - name: Publish daemon DEB package
+        if: needs.pack.outputs.should_continue == 'true' && matrix.DISTR != 'buster'
+        uses: manticoresoftware/publish_to_repo@main
         with:
           ssh_key: ${{ secrets.REPO_SSH_KEY }}
           distr: ${{ matrix.DISTR }}
@@ -535,76 +537,9 @@ jobs:
           type: deb
           delimiter: "-"
           target: ${{ needs.pack.outputs.target }}
-
-  publish_rhel:
-    needs: [publish, pack]
-    if: needs.pack.outputs.should_continue == 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        DISTR: [8, 9, 10]
-        arch: [x86_64, aarch64]
-    runs-on: ubuntu-22.04
-    name: RHEL ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
-    steps:
-      - uses: manticoresoftware/publish_to_repo@main
-        with:
-          ssh_key: ${{ secrets.REPO_SSH_KEY }}
-          distr: ${{ matrix.DISTR }}
-          arch: ${{ matrix.arch }}
-          artifact: build_rhel${{ matrix.DISTR }}_RelWithDebInfo_${{ matrix.arch }}
-          type: rpm
-          delimiter: "_"
-          target: ${{ needs.pack.outputs.target }}
-
-  publish_macos:
-    name: Publishing MacOS
-    needs: [publish, pack]
-    if: needs.pack.outputs.should_continue == 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        arch: [x86_64, arm64]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: manticoresoftware/publish_to_repo@main
-        with:
-          ssh_key: ${{ secrets.REPO_SSH_KEY }}
-          distr: macos
-          arch: ${{ matrix.arch }}
-          artifact: build_macos_RelWithDebInfo_${{ matrix.arch }}
-          type: arc
-          delimiter: "-"
-          target: ${{ needs.pack.outputs.target }}
-
-  publish_windows:
-    name: Publishing Windows packages to repo.manticoresearch.com
-    needs: [publish, pack]
-    if: needs.pack.outputs.should_continue == 'true'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: manticoresoftware/publish_to_repo@main
-        with:
-          ssh_key: ${{ secrets.REPO_SSH_KEY }}
-          distr: windows
-          arch: x64
-          artifact: build_windows_RelWithDebInfo_x64
-          type: arc
-          delimiter: "-"
-          target: ${{ needs.pack.outputs.target }}
-
-  publish_mcl_debian_ubuntu:
-    name: MCL ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
-    needs: [publish, pack]
-    if: needs.pack.outputs.mcl_package_needed == 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
-        arch: [x86_64, aarch64]
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: manticoresoftware/publish_to_repo@main
+      - name: Publish standalone MCL DEB package
+        if: needs.pack.outputs.mcl_package_needed == 'true'
+        uses: manticoresoftware/publish_to_repo@main
         with:
           ssh_key: ${{ secrets.REPO_SSH_KEY }}
           distr: ${{ matrix.DISTR }}
@@ -614,18 +549,31 @@ jobs:
           delimiter: "-"
           target: ${{ needs.pack.outputs.target }}
 
-  publish_mcl_rhel:
-    name: MCL RHEL ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
+  publish_rhel:
     needs: [publish, pack]
-    if: needs.pack.outputs.mcl_package_needed == 'true'
+    if: needs.pack.outputs.should_continue == 'true' || needs.pack.outputs.mcl_package_needed == 'true'
     strategy:
       fail-fast: true
       matrix:
         DISTR: [7, 8, 9, 10]
         arch: [x86_64, aarch64]
     runs-on: ubuntu-22.04
+    name: RHEL ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
     steps:
-      - uses: manticoresoftware/publish_to_repo@main
+      - name: Publish daemon RPM package
+        if: needs.pack.outputs.should_continue == 'true' && matrix.DISTR != 7
+        uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: ${{ matrix.DISTR }}
+          arch: ${{ matrix.arch }}
+          artifact: build_rhel${{ matrix.DISTR }}_RelWithDebInfo_${{ matrix.arch }}
+          type: rpm
+          delimiter: "_"
+          target: ${{ needs.pack.outputs.target }}
+      - name: Publish standalone MCL RPM package
+        if: needs.pack.outputs.mcl_package_needed == 'true'
+        uses: manticoresoftware/publish_to_repo@main
         with:
           ssh_key: ${{ secrets.REPO_SSH_KEY }}
           distr: ${{ matrix.DISTR }}
@@ -635,17 +583,30 @@ jobs:
           delimiter: "_"
           target: ${{ needs.pack.outputs.target }}
 
-  publish_mcl_macos:
-    name: MCL MacOS ${{ matrix.arch }} publishing
+  publish_macos:
+    name: Publishing MacOS
     needs: [publish, pack]
-    if: needs.pack.outputs.mcl_package_needed == 'true'
+    if: needs.pack.outputs.should_continue == 'true' || needs.pack.outputs.mcl_package_needed == 'true'
     strategy:
       fail-fast: true
       matrix:
         arch: [x86_64, arm64]
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/publish_to_repo@main
+      - name: Publish daemon macOS package
+        if: needs.pack.outputs.should_continue == 'true'
+        uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: macos
+          arch: ${{ matrix.arch }}
+          artifact: build_macos_RelWithDebInfo_${{ matrix.arch }}
+          type: arc
+          delimiter: "-"
+          target: ${{ needs.pack.outputs.target }}
+      - name: Publish standalone MCL macOS package
+        if: needs.pack.outputs.mcl_package_needed == 'true'
+        uses: manticoresoftware/publish_to_repo@main
         with:
           ssh_key: ${{ secrets.REPO_SSH_KEY }}
           distr: macos
@@ -655,13 +616,26 @@ jobs:
           delimiter: "-"
           target: ${{ needs.pack.outputs.target }}
 
-  publish_mcl_windows:
-    name: MCL Windows x64 publishing
+  publish_windows:
+    name: Publishing Windows packages to repo.manticoresearch.com
     needs: [publish, pack]
-    if: needs.pack.outputs.mcl_package_needed == 'true'
+    if: needs.pack.outputs.should_continue == 'true' || needs.pack.outputs.mcl_package_needed == 'true'
     runs-on: ubuntu-22.04
     steps:
-      - uses: manticoresoftware/publish_to_repo@main
+      - name: Publish daemon Windows package
+        if: needs.pack.outputs.should_continue == 'true'
+        uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: windows
+          arch: x64
+          artifact: build_windows_RelWithDebInfo_x64
+          type: arc
+          delimiter: "-"
+          target: ${{ needs.pack.outputs.target }}
+      - name: Publish standalone MCL Windows package
+        if: needs.pack.outputs.mcl_package_needed == 'true'
+        uses: manticoresoftware/publish_to_repo@main
         with:
           ssh_key: ${{ secrets.REPO_SSH_KEY }}
           distr: windows
@@ -675,6 +649,7 @@ jobs:
   test_windows_installer:
     name: Test Windows NSIS installer
     needs: [publish_windows, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     runs-on: windows-latest
     steps:
     - name: Download Windows installer artifact
@@ -863,6 +838,7 @@ jobs:
   publish_nsis:
     name: Publishing Windows NSIS installer
     needs: [test_windows_installer, publish, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: manticoresoftware/publish_to_repo@main
@@ -878,6 +854,7 @@ jobs:
   build_docker:
     name: Building and pushing docker
     needs: [publish_debian_ubuntu, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     runs-on: ubuntu-22.04
     env:
       DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -906,7 +883,8 @@ jobs:
 
   clt_rhel_dev_installation:
     name: Testing RHEL dev packages installation
-    needs: publish_rhel
+    needs: [publish_rhel, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -921,7 +899,8 @@ jobs:
 
   clt_deb_dev_installation:
     name: Testing DEB dev packages installation
-    needs: publish_debian_ubuntu
+    needs: [publish_debian_ubuntu, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pack_publish.yml
+++ b/.github/workflows/pack_publish.yml
@@ -37,13 +37,49 @@ permissions:
 jobs:
   check_branch:
     name: Resolve MCL metadata
-    needs: [pack]
-    if: needs.pack.outputs.should_continue == 'true'
     runs-on: ubuntu-22.04
+    if: |
+      (
+        github.event_name == 'pull_request'
+        &&
+        (
+          contains(
+            github.event.pull_request.labels.*.name, 'pack'
+          )
+          ||
+          contains(
+            github.event.pull_request.labels.*.name, 'publish'
+          )
+        )
+      )
+      ||
+      (
+        github.event_name == 'workflow_run'
+        &&
+        github.event.workflow_run.conclusion == 'success'
+        &&
+        github.ref == 'refs/heads/main'
+      )
+      ||
+      (
+        github.event_name == 'push'
+        &&
+        (
+          startsWith(
+            github.ref, 'refs/heads/manticore-'
+          )
+          ||
+          contains(
+            github.ref, 'refs/tags/pack_publish'
+          )
+        )
+      )
     outputs:
       mcl_sha: ${{ steps.mcl.outputs.mcl_sha }}
       mcl_full_sha: ${{ steps.mcl.outputs.mcl_full_sha }}
-      mcl_changed: ${{ steps.detect.outputs.mcl_changed }}
+      mcl_submodule_changed: ${{ steps.detect.outputs.mcl_submodule_changed }}
+      mcl_missing_dev: ${{ steps.detect.outputs.mcl_missing_dev }}
+      mcl_missing_release_candidate: ${{ steps.detect.outputs.mcl_missing_release_candidate }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -79,21 +115,33 @@ jobs:
           else
             files=$(git ls-tree -r --name-only "$head")
           fi
-          repo_has_mcl_pkg=false
-          if bash dist/resolve_repo_artifact.sh --repo-type dev --distr jammy --arch amd64 --sha "${{ steps.mcl.outputs.mcl_sha }}" --extension .deb >/dev/null 2>&1; then
-            repo_has_mcl_pkg=true
+          mcl_submodule_changed=false
+          if echo "$files" | grep -Eq '^(mcl|mcl/|\.gitmodules$)'; then
+            mcl_submodule_changed=true
           fi
 
-          if echo "$files" | grep -Eq '^(mcl|mcl/|\.gitmodules$)'; then
-            echo "mcl_changed=true" >> $GITHUB_OUTPUT
-          elif [[ "$repo_has_mcl_pkg" != true ]]; then
-            echo "mcl_changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "mcl_changed=false" >> $GITHUB_OUTPUT
+          repo_has_mcl_dev=false
+          if bash dist/resolve_repo_artifact.sh --repo-type dev --distr jammy --arch amd64 --sha "${{ steps.mcl.outputs.mcl_sha }}" --extension .deb >/dev/null 2>&1; then
+            repo_has_mcl_dev=true
           fi
+
+          repo_has_mcl_release_candidate=false
+          if bash dist/resolve_repo_artifact.sh --repo-type release_candidate --distr jammy --arch amd64 --sha "${{ steps.mcl.outputs.mcl_sha }}" --extension .deb >/dev/null 2>&1; then
+            repo_has_mcl_release_candidate=true
+          fi
+
+          mcl_missing_dev=false
+          mcl_missing_release_candidate=false
+          [[ "$repo_has_mcl_dev" == true ]] || mcl_missing_dev=true
+          [[ "$repo_has_mcl_release_candidate" == true ]] || mcl_missing_release_candidate=true
+
+          echo "mcl_submodule_changed=${mcl_submodule_changed}" >> "$GITHUB_OUTPUT"
+          echo "mcl_missing_dev=${mcl_missing_dev}" >> "$GITHUB_OUTPUT"
+          echo "mcl_missing_release_candidate=${mcl_missing_release_candidate}" >> "$GITHUB_OUTPUT"
 
   pack:
     name: OK to pack?
+    needs: check_branch
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.semver-tagger.outputs.version }}
@@ -102,6 +150,7 @@ jobs:
       version_deb: ${{ steps.semver-tagger.outputs.version_deb }}
       target: ${{ steps.semver-tagger.outputs.target }}
       should_continue: ${{ steps.check-should-continue.outputs.should_continue }}
+      mcl_package_needed: ${{ steps.mcl-package-needed.outputs.mcl_package_needed }}
     if: |
       (
         github.event_name == 'pull_request'
@@ -153,6 +202,26 @@ jobs:
           github_token: ${{ secrets.GH_ACCESS_TOKEN != '' && secrets.GH_ACCESS_TOKEN || secrets.GITHUB_TOKEN }}
           conventional_commits_authors: alexey@manticoresearch.com
           ignore_patterns: '\.md$|^test/|^manual/|\.clt|\.github|\.patterns|\.yml|\.gitignore'
+      - name: Check if MCL package should be built
+        id: mcl-package-needed
+        run: |
+          set -euo pipefail
+          target="${{ steps.semver-tagger.outputs.target }}"
+          mcl_package_needed=false
+
+          if [[ "$target" == "release" && "${{ needs.check_branch.outputs.mcl_missing_release_candidate }}" == "true" ]]; then
+            echo "MCL package is needed because it is missing from release_candidate for this submodule SHA"
+            mcl_package_needed=true
+          elif [[ "$target" != "release" && "${{ needs.check_branch.outputs.mcl_missing_dev }}" == "true" ]]; then
+            echo "MCL package is needed because it is missing from dev for this submodule SHA"
+            mcl_package_needed=true
+          elif [[ "${{ needs.check_branch.outputs.mcl_submodule_changed }}" == "true" ]]; then
+            echo "MCL submodule changed, but a package for this SHA is already available for target $target"
+          else
+            echo "MCL package is already available for target $target"
+          fi
+
+          echo "mcl_package_needed=${mcl_package_needed}" >> "$GITHUB_OUTPUT"
       - name: Check if we should continue packing
         id: check-should-continue
         run: |
@@ -180,7 +249,11 @@ jobs:
           echo "* Ref: ${{ github.ref_type }} \"${{ github.ref_name }}\"" >> $GITHUB_STEP_SUMMARY
           echo "* Attempt: ${{ github.run_attempt }}" >> $GITHUB_STEP_SUMMARY
           echo "* Version updated: ${{ steps.semver-tagger.outputs.version_updated }}" >> $GITHUB_STEP_SUMMARY
-          echo "* Should continue packing: ${{ steps.check-should-continue.outputs.should_continue }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Should continue packing daemon packages: ${{ steps.check-should-continue.outputs.should_continue }}" >> $GITHUB_STEP_SUMMARY
+          echo "* MCL submodule changed: ${{ needs.check_branch.outputs.mcl_submodule_changed }}" >> $GITHUB_STEP_SUMMARY
+          echo "* MCL package missing from dev: ${{ needs.check_branch.outputs.mcl_missing_dev }}" >> $GITHUB_STEP_SUMMARY
+          echo "* MCL package missing from release_candidate: ${{ needs.check_branch.outputs.mcl_missing_release_candidate }}" >> $GITHUB_STEP_SUMMARY
+          echo "* Should build standalone MCL package: ${{ steps.mcl-package-needed.outputs.mcl_package_needed }}" >> $GITHUB_STEP_SUMMARY
 
 #  debug_info:
 #    name: Debug GitHub Event Info
@@ -203,11 +276,11 @@ jobs:
 
   mcl_pack_matrix:
     needs: [check_branch, pack]
-    if: needs.pack.outputs.should_continue == 'true'
+    if: needs.pack.outputs.should_continue == 'true' || needs.pack.outputs.mcl_package_needed == 'true'
     uses: ./.github/workflows/mcl_pack_publish.yml
     secrets: inherit
     with:
-      enabled: ${{ needs.check_branch.outputs.mcl_changed == 'true' && needs.pack.outputs.should_continue == 'true' }}
+      enabled: ${{ needs.pack.outputs.mcl_package_needed == 'true' }}
       mcl_full_sha: ${{ needs.check_branch.outputs.mcl_full_sha }}
       source_ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
@@ -240,8 +313,8 @@ jobs:
         DISTR: [bionic, focal, jammy, bullseye, bookworm]
         arch: [x86_64, aarch64]
     with:
-      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.check_branch.outputs.mcl_changed == 'true' && format('mcl_pkg_{0}_{1}', matrix.DISTR, matrix.arch) || '' }}
-      MCL_PACKAGE_SHA: ${{ needs.check_branch.outputs.mcl_changed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
+      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.pack.outputs.mcl_package_needed == 'true' && format('mcl_pkg_{0}_{1}', matrix.DISTR, matrix.arch) || '' }}
+      MCL_PACKAGE_SHA: ${{ needs.pack.outputs.mcl_package_needed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
       MCL_REPO_TYPE: ${{ needs.pack.outputs.target == 'release' && 'release_candidate' || 'dev' }}
       DISTR: ${{ matrix.DISTR }}
       arch: ${{ matrix.arch }}
@@ -269,8 +342,8 @@ jobs:
         DISTR: [rhel8, rhel9, rhel10]
         arch: [x86_64, aarch64]
     with:
-      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.check_branch.outputs.mcl_changed == 'true' && format('mcl_pkg_{0}_{1}', matrix.DISTR, matrix.arch) || '' }}
-      MCL_PACKAGE_SHA: ${{ needs.check_branch.outputs.mcl_changed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
+      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.pack.outputs.mcl_package_needed == 'true' && format('mcl_pkg_{0}_{1}', matrix.DISTR, matrix.arch) || '' }}
+      MCL_PACKAGE_SHA: ${{ needs.pack.outputs.mcl_package_needed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
       MCL_REPO_TYPE: ${{ needs.pack.outputs.target == 'release' && 'release_candidate' || 'dev' }}
       DISTR: ${{ matrix.DISTR }}
       arch: ${{ matrix.arch }}
@@ -301,8 +374,8 @@ jobs:
         DISTR: [macos]
         arch: [x86_64, arm64]
     with:
-      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.check_branch.outputs.mcl_changed == 'true' && format('mcl_pkg_{0}_{1}', matrix.DISTR, matrix.arch) || '' }}
-      MCL_PACKAGE_SHA: ${{ needs.check_branch.outputs.mcl_changed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
+      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.pack.outputs.mcl_package_needed == 'true' && format('mcl_pkg_{0}_{1}', matrix.DISTR, matrix.arch) || '' }}
+      MCL_PACKAGE_SHA: ${{ needs.pack.outputs.mcl_package_needed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
       MCL_REPO_TYPE: ${{ needs.pack.outputs.target == 'release' && 'release_candidate' || 'dev' }}
       DISTR: ${{ matrix.DISTR }}
       arch: ${{ matrix.arch }}
@@ -328,8 +401,8 @@ jobs:
     needs: [pack, check_branch, check_deps, mcl_pack_matrix]
     if: needs.pack.outputs.should_continue == 'true'
     with:
-      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.check_branch.outputs.mcl_changed == 'true' && 'mcl_pkg_windows_x64' || '' }}
-      MCL_PACKAGE_SHA: ${{ needs.check_branch.outputs.mcl_changed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
+      MCL_PACKAGE_ARTIFACT_NAME: ${{ needs.pack.outputs.mcl_package_needed == 'true' && 'mcl_pkg_windows_x64' || '' }}
+      MCL_PACKAGE_SHA: ${{ needs.pack.outputs.mcl_package_needed != 'true' && needs.check_branch.outputs.mcl_sha || '' }}
       MCL_REPO_TYPE: ${{ needs.pack.outputs.target == 'release' && 'release_candidate' || 'dev' }}
       DISTR: windows
       arch: x64
@@ -364,13 +437,13 @@ jobs:
           submodules: recursive
           token: ${{ secrets.MCL_SUBMODULE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: Download local Windows MCL package artifact
-        if: ${{ needs.check_branch.outputs.mcl_changed == 'true' }}
+        if: ${{ needs.pack.outputs.mcl_package_needed == 'true' }}
         uses: actions/download-artifact@v7
         with:
           name: mcl_pkg_windows_x64
           path: ./mcl-package
       - name: Preflight local Windows MCL package artifact
-        if: ${{ needs.check_branch.outputs.mcl_changed == 'true' }}
+        if: ${{ needs.pack.outputs.mcl_package_needed == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -409,21 +482,42 @@ jobs:
   publish:
     name: OK to publish?
     runs-on: ubuntu-22.04
-    # This job depends on all the package preparation jobs that have to pass before we can start publishing packages
-    needs: [pack_debian_ubuntu, pack_rhel, pack_macos, build_nsis]
+    # This job depends on both daemon and MCL package preparation jobs. Some of
+    # them may be intentionally skipped, so the if condition below checks the
+    # relevant artifact family explicitly.
+    needs: [pack, pack_debian_ubuntu, pack_rhel, pack_macos, build_nsis, mcl_pack_matrix]
     if: |
-      (github.repository == 'manticoresoftware/manticoresearch')
+      always()
+      && (github.repository == 'manticoresoftware/manticoresearch')
       && (
         (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'publish')))
         || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
         || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/manticore-'))
         || (github.event_name == 'push' && contains(github.ref, 'refs/tags/pack_publish'))
       )
+      && (
+        (
+          needs.pack.outputs.should_continue == 'true'
+          && needs.pack_debian_ubuntu.result == 'success'
+          && needs.pack_rhel.result == 'success'
+          && needs.pack_macos.result == 'success'
+          && needs.build_nsis.result == 'success'
+        )
+        ||
+        (
+          needs.pack.outputs.mcl_package_needed == 'true'
+          && needs.mcl_pack_matrix.result == 'success'
+        )
+      )
     steps:
-      - run: echo "Ready to publish"
+      - run: |
+          echo "Ready to publish"
+          echo "Daemon packages needed: ${{ needs.pack.outputs.should_continue }}"
+          echo "Standalone MCL packages needed: ${{ needs.pack.outputs.mcl_package_needed }}"
 
   publish_debian_ubuntu:
     needs: [publish, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -444,6 +538,7 @@ jobs:
 
   publish_rhel:
     needs: [publish, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -465,6 +560,7 @@ jobs:
   publish_macos:
     name: Publishing MacOS
     needs: [publish, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -484,6 +580,7 @@ jobs:
   publish_windows:
     name: Publishing Windows packages to repo.manticoresearch.com
     needs: [publish, pack]
+    if: needs.pack.outputs.should_continue == 'true'
     runs-on: ubuntu-22.04
     steps:
       - uses: manticoresoftware/publish_to_repo@main
@@ -492,6 +589,84 @@ jobs:
           distr: windows
           arch: x64
           artifact: build_windows_RelWithDebInfo_x64
+          type: arc
+          delimiter: "-"
+          target: ${{ needs.pack.outputs.target }}
+
+  publish_mcl_debian_ubuntu:
+    name: MCL ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
+    needs: [publish, pack]
+    if: needs.pack.outputs.mcl_package_needed == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        DISTR: [bionic, focal, jammy, buster, bullseye, bookworm]
+        arch: [x86_64, aarch64]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: ${{ matrix.DISTR }}
+          arch: ${{ matrix.arch }}
+          artifact: mcl_pkg_${{ matrix.DISTR }}_${{ matrix.arch }}
+          type: deb
+          delimiter: "-"
+          target: ${{ needs.pack.outputs.target }}
+
+  publish_mcl_rhel:
+    name: MCL RHEL ${{ matrix.DISTR }} ${{ matrix.arch }} publishing
+    needs: [publish, pack]
+    if: needs.pack.outputs.mcl_package_needed == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        DISTR: [7, 8, 9, 10]
+        arch: [x86_64, aarch64]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: ${{ matrix.DISTR }}
+          arch: ${{ matrix.arch }}
+          artifact: mcl_pkg_rhel${{ matrix.DISTR }}_${{ matrix.arch }}
+          type: rpm
+          delimiter: "_"
+          target: ${{ needs.pack.outputs.target }}
+
+  publish_mcl_macos:
+    name: MCL MacOS ${{ matrix.arch }} publishing
+    needs: [publish, pack]
+    if: needs.pack.outputs.mcl_package_needed == 'true'
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [x86_64, arm64]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: macos
+          arch: ${{ matrix.arch }}
+          artifact: mcl_pkg_macos_${{ matrix.arch }}
+          type: arc
+          delimiter: "-"
+          target: ${{ needs.pack.outputs.target }}
+
+  publish_mcl_windows:
+    name: MCL Windows x64 publishing
+    needs: [publish, pack]
+    if: needs.pack.outputs.mcl_package_needed == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: manticoresoftware/publish_to_repo@main
+        with:
+          ssh_key: ${{ secrets.REPO_SSH_KEY }}
+          distr: windows
+          arch: x64
+          artifact: mcl_pkg_windows_x64
           type: arc
           delimiter: "-"
           target: ${{ needs.pack.outputs.target }}
@@ -693,8 +868,8 @@ jobs:
       - uses: manticoresoftware/publish_to_repo@main
         with:
           ssh_key: ${{ secrets.REPO_SSH_KEY }}
-          distr:
-          arch:
+          distr: windows
+          arch: x64
           artifact: win_installer
           type: arc
           delimiter: "-"


### PR DESCRIPTION
Use columnar semver tags as the source of truth for MCL package versions.

Build and publish standalone manticore-columnar-lib packages when the selected submodule SHA is missing from the target repository, independent of daemon package versioning.