### PR TITLE
fix: serialize query stats percentile calculation

### DIFF
--- a/src/gtests/gtests_searchdaemon.cpp
+++ b/src/gtests/gtests_searchdaemon.cpp
@@ -20,13 +20,6 @@
 #include "replication/wsrep_cxx.h"
 #include "replication/cluster_binlog.h"
 
-#include <atomic>
-#include <chrono>
-#include <condition_variable>
-#include <mutex>
-#include <thread>
-#include <vector>
-
 
 // QueryStatElement_t uses default ctr with inline initializer;
 // this test is just to be sure it works correctly

--- a/src/gtests/gtests_searchdaemon.cpp
+++ b/src/gtests/gtests_searchdaemon.cpp
@@ -20,6 +20,13 @@
 #include "replication/wsrep_cxx.h"
 #include "replication/cluster_binlog.h"
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
 
 // QueryStatElement_t uses default ctr with inline initializer;
 // this test is just to be sure it works correctly
@@ -34,6 +41,75 @@ TEST ( functions, QueryStatElement_t_ctr )
 	ASSERT_EQ ( tElem.m_dData[TYPE_MAX], 0 );
 	ASSERT_EQ ( tElem.m_dData[TYPE_95], 0 );
 	ASSERT_EQ ( tElem.m_dData[TYPE_99], 0 );
+}
+
+TEST ( functions, ServedStatsConcurrentCalculations )
+{
+	// Default TDigest compression is 200, so BufferLimit() is 1600.
+	// Stop one sample before the automatic flush, then make many readers
+	// calculate percentiles at once. CalculateQueryStats() must serialize this
+	// because TDigest_c::Percentile() can flush/mutate buffered centroids.
+	constexpr int QUERY_STATS_BEFORE_FLUSH = 1599;
+	constexpr int CONCURRENT_READERS = 64;
+	constexpr int ROUNDS = 8;
+
+	ServedStats_c tStats;
+
+	for ( int iRound = 0; iRound < ROUNDS; ++iRound )
+	{
+		for ( int i = 0; i < QUERY_STATS_BEFORE_FLUSH; ++i )
+			tStats.AddQueryStat ( ( i + iRound ) % 31, ( i * 7 + iRound ) % 1000 );
+
+		std::atomic<int> iReady { 0 };
+		std::atomic<bool> bStart { false };
+		std::atomic<int> iDone { 0 };
+		std::atomic<bool> bBadStats { false };
+		std::mutex tDoneMutex;
+		std::condition_variable tDoneCv;
+		std::vector<std::thread> dThreads;
+		dThreads.reserve ( CONCURRENT_READERS );
+
+		for ( int i = 0; i < CONCURRENT_READERS; ++i )
+		{
+			dThreads.emplace_back ( [&] {
+				iReady.fetch_add ( 1, std::memory_order_release );
+				while ( !bStart.load ( std::memory_order_acquire ) )
+					std::this_thread::yield();
+
+				QueryStats_t tRowsFoundStats;
+				QueryStats_t tQueryTimeStats;
+				tStats.CalculateQueryStats ( tRowsFoundStats, tQueryTimeStats );
+
+				const uint64_t uExpectedQueries = uint64_t ( iRound + 1 ) * QUERY_STATS_BEFORE_FLUSH;
+				if ( tRowsFoundStats.m_dStats[QueryStats::INTERVAL_ALLTIME].m_uTotalQueries != uExpectedQueries ||
+					tQueryTimeStats.m_dStats[QueryStats::INTERVAL_ALLTIME].m_uTotalQueries != uExpectedQueries )
+					bBadStats.store ( true, std::memory_order_release );
+
+				{
+					std::lock_guard<std::mutex> tGuard ( tDoneMutex );
+					iDone.fetch_add ( 1, std::memory_order_release );
+				}
+				tDoneCv.notify_one();
+			} );
+		}
+
+		while ( iReady.load ( std::memory_order_acquire ) != CONCURRENT_READERS )
+			std::this_thread::yield();
+
+		bStart.store ( true, std::memory_order_release );
+
+		{
+			std::unique_lock<std::mutex> tLock ( tDoneMutex );
+			ASSERT_TRUE ( tDoneCv.wait_for ( tLock, std::chrono::seconds ( 30 ), [&] {
+				return iDone.load ( std::memory_order_acquire ) == CONCURRENT_READERS;
+			} ) );
+		}
+
+		for ( auto & tThread : dThreads )
+			tThread.join();
+
+		ASSERT_FALSE ( bBadStats.load ( std::memory_order_acquire ) );
+	}
 }
 
 TEST ( functions, SecretEqual )

--- a/src/searchdaemon.cpp
+++ b/src/searchdaemon.cpp
@@ -1101,7 +1101,7 @@ static const uint64_t g_dStatsIntervals[] =
 
 void ServedStats_c::CalculateQueryStats( QueryStats_t& tRowsFoundStats, QueryStats_t& tQueryTimeStats ) const
 {
-	ScRL_t rLock { m_tStatsLock };
+	ScWL_t wLock { m_tStatsLock };
 	DoStatCalcStats ( m_pQueryStatRecords.get(), tRowsFoundStats, tQueryTimeStats );
 }
 
@@ -1110,7 +1110,7 @@ void ServedStats_c::CalculateQueryStats( QueryStats_t& tRowsFoundStats, QuerySta
 
 void ServedStats_c::CalculateQueryStatsExact( QueryStats_t& tRowsFoundStats, QueryStats_t& tQueryTimeStats ) const
 {
-	ScRL_t rLock { m_tStatsLock };
+	ScWL_t wLock { m_tStatsLock };
 	DoStatCalcStats ( m_pQueryStatRecordsExact.get(), tRowsFoundStats, tQueryTimeStats );
 }
 
@@ -1196,7 +1196,7 @@ void ServedStats_c::DoStatCalcStats( const QueryStatContainer_i* pContainer, Que
 
 	auto uTimestamp = sphMicroTimer();
 
-	int iRecords = m_pQueryStatRecords->GetNumRecords();
+	int iRecords = pContainer->GetNumRecords();
 	for ( int i = INTERVAL_1MIN; i<=INTERVAL_15MIN; ++i )
 		CalcStatsForInterval( pContainer, tRowsFoundStats.m_dStats[i], tQueryTimeStats.m_dStats[i], uTimestamp, g_dStatsIntervals[i], iRecords );
 

--- a/src/searchdaemon.h
+++ b/src/searchdaemon.h
@@ -628,7 +628,7 @@ private:
 	uint64_t			m_uTotalQueries GUARDED_BY ( m_tStatsLock ) = 0;
 
 	void				DoStatCalcStats ( const QueryStatContainer_i * pContainer, QueryStats_t & tRowsFoundStats,
-							QueryStats_t & tQueryTimeStats ) const REQUIRES_SHARED ( m_tStatsLock );
+							QueryStats_t & tQueryTimeStats ) const REQUIRES ( m_tStatsLock );
 
 	CommandStats_t		m_tCommandsStats;
 };


### PR DESCRIPTION
SHOW INDEX ... STATUS calculates p95/p99 from TDigest instances. Percentile() is const in the public API, but it can flush buffered centroids internally, so concurrent status readers under a shared stats lock can corrupt TDigest vectors. Use the exclusive stats lock for stats calculation and cover the race with a focused ServedStats concurrency gtest.