### PR TITLE
fix: load legacy auth clusters without stored user

### DIFF
--- a/src/searchdreplication.cpp
+++ b/src/searchdreplication.cpp
@@ -21,6 +21,7 @@
 #include "digest_sha1.h"
 #include "tracer.h"
 #include "auth/auth.h"
+#include "auth/auth_common.h"
 
 #include "replication/wsrep_cxx.h"
 #include "replication/common.h"
@@ -1822,6 +1823,78 @@ static bool AddAndStartCluster ( ReplicationClusterRefPtr_c pCluster )
 	return true;
 }
 
+static bool AuthPermitsLegacyClusterAction ( const UserPerms_t & dPerms, AuthAction_e eAction, const CSphString & sTarget )
+{
+	// Mirrors CheckPerms() resolution without producing auth-denied log entries while we
+	// only look for a best-effort startup compatibility user for pre-user-field clusters.
+	for ( const auto & tPerm : dPerms )
+	{
+		if ( tPerm.m_eAction!=eAction )
+			continue;
+
+		if ( !tPerm.m_bTargetWildcard && tPerm.m_sTarget==sTarget )
+			return tPerm.m_bAllow;
+
+		if ( tPerm.m_bTargetWildcard && !sTarget.IsEmpty() && ( tPerm.m_bTargetWildcardAll || sphWildcardMatch ( sTarget.cstr(), tPerm.m_sTarget.cstr() ) ) )
+			return tPerm.m_bAllow;
+	}
+
+	return false;
+}
+
+static bool PreferLegacyClusterUserCandidate ( const CSphString & sUser, bool bAdmin, const CSphString & sBestUser, bool bBestAdmin )
+{
+	if ( sBestUser.IsEmpty() )
+		return true;
+
+	// Prefer a dedicated replication user over a broader admin user when old metadata
+	// does not say which session user created the cluster. If that still leaves several
+	// candidates, use a deterministic name order so startup is stable.
+	if ( bAdmin!=bBestAdmin )
+		return !bAdmin;
+
+	return strcmp ( sUser.cstr(), sBestUser.cstr() ) < 0;
+}
+
+static bool TryAssignLegacyClusterUser ( ClusterDesc_t & tDesc )
+{
+	if ( !IsAuthEnabled() || !tDesc.m_sUser.IsEmpty() )
+		return true;
+
+	AuthUsersPtr_t pUsers = GetAuth();
+	if ( !pUsers )
+		return false;
+
+	CSphString sBestUser;
+	bool bBestAdmin = false;
+	for ( const auto & tUserPerms : pUsers->m_hUserPerms )
+	{
+		const CSphString & sUser = tUserPerms.first;
+		if ( sUser==GetAuthBuddyName() )
+			continue;
+
+		if ( !pUsers->m_hUserToken ( sUser ) )
+			continue;
+
+		if ( !AuthPermitsLegacyClusterAction ( tUserPerms.second, AuthAction_e::REPLICATION, tDesc.m_sName ) )
+			continue;
+
+		bool bAdmin = AuthPermitsLegacyClusterAction ( tUserPerms.second, AuthAction_e::ADMIN, "*" );
+		if ( PreferLegacyClusterUserCandidate ( sUser, bAdmin, sBestUser, bBestAdmin ) )
+		{
+			sBestUser = sUser;
+			bBestAdmin = bAdmin;
+		}
+	}
+
+	if ( sBestUser.IsEmpty() )
+		return false;
+
+	tDesc.m_sUser = sBestUser;
+	sphWarning ( "Cluster %s: missing effective replication user in stored metadata, using '%s' for legacy compatibility", tDesc.m_sName.cstr(), tDesc.m_sUser.cstr() );
+	return true;
+}
+
 static bool ClusterDescOk ( const ClusterDesc_t& tDesc, bool bForce ) noexcept
 {
 	if ( tDesc.m_dClusterNodes.IsEmpty() )
@@ -1996,8 +2069,9 @@ static void CoPrepareClustersOnStartup ( RplBootstrap_e eBs ) EXCLUDES ( g_tClus
 {
 	SmallStringHash_T<ReplicationClusterRefPtr_c> hClusters;
 	assert ( Threads::IsInsideCoroutine() );
-	for ( const ClusterDesc_t& tDesc : GetClustersInt() )
+	for ( ClusterDesc_t tDesc : GetClustersInt() )
 	{
+		TryAssignLegacyClusterUser ( tDesc );
 		if ( !ClusterDescOk ( tDesc, eBs==RplBootstrap_e::FORCED ) )
 			continue;
 

--- a/test/clt-tests/bugs/4720-auth-cluster-legacy-user-upgrade.rec
+++ b/test/clt-tests/bugs/4720-auth-cluster-legacy-user-upgrade.rec
@@ -1,0 +1,78 @@
+––– comment –––
+Regression for https://github.com/manticoresoftware/manticoresearch/issues/4720.
+Legacy cluster metadata created before effective replication user persistence has no
+`user` field in manticore.json. Auth-enabled startup must infer a compatible
+replication user instead of skipping the cluster and losing table membership.
+––– comment –––
+––– input –––
+export INSTANCE=1
+––– output –––
+––– block: ../base/replication/start-searchd-precach-with-auth –––
+––– input –––
+MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "CREATE USER 'repluser' IDENTIFIED BY 'replpass1234';" >/dev/null; MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "GRANT replication ON * TO 'repluser';" >/dev/null; MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "CREATE CLUSTER legacycluster 'repluser' AS user;" >/dev/null; MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "CREATE TABLE t1 (title text);" >/dev/null; MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "ALTER CLUSTER legacycluster ADD t1;" >/dev/null; MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "INSERT INTO legacycluster:t1(id,title) VALUES (1,'before restart');" >/dev/null; echo "legacy cluster ready"
+––– output –––
+legacy cluster ready
+––– input –––
+python3 - <<'PY'
+import json
+with open('/var/log/manticore-1/manticore.json') as f:
+    cfg = json.load(f)
+print(cfg['clusters']['legacycluster'].get('user'))
+PY
+––– output –––
+repluser
+––– input –––
+stdbuf -oL searchd --stopwait -c /tmp/searchd-with-flexible-ports-auth-${INSTANCE}.conf >/dev/null; echo "stopped before legacy metadata edit"
+––– output –––
+stopped before legacy metadata edit
+––– input –––
+python3 - <<'PY'
+import json
+path = '/var/log/manticore-1/manticore.json'
+with open(path) as f:
+    cfg = json.load(f)
+for cluster in cfg.get('clusters', {}).values():
+    cluster.pop('user', None)
+with open(path, 'w') as f:
+    json.dump(cfg, f, separators=(',', ':'))
+print('legacy metadata without user')
+PY
+––– output –––
+legacy metadata without user
+––– input –––
+python3 - <<'PY'
+import json
+with open('/var/log/manticore-1/manticore.json') as f:
+    cfg = json.load(f)
+print('user' in cfg['clusters']['legacycluster'])
+PY
+––– output –––
+False
+––– input –––
+bash -c 'export INSTANCE=1; : > /var/log/manticore-${INSTANCE}/searchd.log; stdbuf -oL searchd --new-cluster -c /tmp/searchd-with-flexible-ports-auth-${INSTANCE}.conf >/dev/null; if timeout 30 grep -qm1 "\[BUDDY\] started" <(tail -n 1000 -f /var/log/manticore-${INSTANCE}/searchd.log); then echo "restarted from legacy metadata"; else echo "restart failed"; cat /var/log/manticore-${INSTANCE}/searchd.log; exit 1; fi'
+––– output –––
+restarted from legacy metadata
+––– input –––
+grep -o "Cluster legacycluster: missing effective replication user in stored metadata, using 'repluser' for legacy compatibility" /var/log/manticore-1/searchd.log
+––– output –––
+Cluster legacycluster: missing effective replication user in stored metadata, using 'repluser' for legacy compatibility
+––– input –––
+MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "SHOW STATUS LIKE 'cluster_legacycluster_indexes_count';" | grep 'cluster_legacycluster_indexes_count' | grep -oE '[0-9]+' | tail -1
+––– output –––
+1
+––– input –––
+MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "SHOW STATUS LIKE 'cluster_legacycluster_indexes';" | grep 'cluster_legacycluster_indexes' | awk -F'|' '{gsub(/ /, "", $3); print $3}'
+––– output –––
+t1
+––– input –––
+MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "INSERT INTO legacycluster:t1(id,title) VALUES (2,'after restart'); SELECT COUNT(*) FROM t1;" | grep -oE '[0-9]+' | tail -1
+––– output –––
+2
+––– input –––
+MYSQL_PWD=adminpass mysql -uadmin -h0 -P1306 -e "INSERT INTO t1(id,title) VALUES (3,'local path rejected');" 2>&1 | grep -o "table 't1' is a part of cluster 'legacycluster', use 'legacycluster:t1'"
+––– output –––
+table 't1' is a part of cluster 'legacycluster', use 'legacycluster:t1'
+––– input –––
+stdbuf -oL searchd --stopwait -c /tmp/searchd-with-flexible-ports-auth-${INSTANCE}.conf >/dev/null; echo "stopped"
+––– output –––
+stopped


### PR DESCRIPTION
Infer a compatible replication user for legacy cluster metadata that predates persisted effective user tracking. This keeps upgraded auth-enabled clusters from being skipped on startup and preserves cluster table membership.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4720