### PR TITLE
fix: validate secondary indexes in indextool check

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,6 +1,6 @@
 backup 1.10.1+26061912-e2ca2bce-dev
 buddy 4.2.0+26063013-dc2f8c9f-dev
-executor 1.4.3+26033010-390b6e66-dev
+executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.25.0+26050511-832198ca-dev
 galera 3.37

--- a/src/indexcheck.cpp
+++ b/src/indexcheck.cpp
@@ -1523,7 +1523,11 @@ void DiskIndexChecker_c::Impl_c::CheckSecondaryIndexes()
 
 	m_tReporter.Msg ( "checking secondary indexes..." );
 	CheckSecondaryIndexStorage ( GetFilename(SPH_EXT_SPIDX), (DWORD)m_iNumRows,
-		[this]( const char * szError ){ m_tReporter.Fail ( "\n%s", szError ); },
+		[this]( const char * szError )
+		{
+			m_tReporter.Fail ( szError ? "\n%s" : "%s", szError ? szError : "" );
+			return m_tReporter.GetNumFails()<FAILS_THRESH;
+		},
 		[this]( const char * szProgress ){ m_tReporter.Progress ( "%s", szProgress ); } );
 }
 

--- a/src/indexcheck.cpp
+++ b/src/indexcheck.cpp
@@ -19,6 +19,7 @@
 #include "docstore.h"
 #include "conversion.h"
 #include "columnarlib.h"
+#include "secondarylib.h"
 #include "indexfiles.h"
 #include "roaring/roaring64map.hh"
 
@@ -545,6 +546,7 @@ private:
 	void	CheckKillList() const;
 	void	CheckBlockIndex();
 	void	CheckColumnar();
+	void	CheckSecondaryIndexes();
 	void	CheckDocidLookup();
 	void	CheckDocids();
 	void	CheckDocstore();
@@ -880,6 +882,7 @@ void DiskIndexChecker_c::Impl_c::Check()
 	CheckAttributes();
 	CheckBlockIndex();
 	CheckColumnar();
+	CheckSecondaryIndexes();
 	CheckKillList();
 	CheckDocstore();
 
@@ -1507,6 +1510,19 @@ void DiskIndexChecker_c::Impl_c::CheckColumnar()
 	m_tReporter.Msg ( "checking columnar storage..." );
 
 	CheckColumnarStorage ( GetFilename(SPH_EXT_SPC), (DWORD)m_iNumRows,
+		[this]( const char * szError ){ m_tReporter.Fail ( "\n%s", szError ); },
+		[this]( const char * szProgress ){ m_tReporter.Progress ( "%s", szProgress ); } );
+}
+
+
+void DiskIndexChecker_c::Impl_c::CheckSecondaryIndexes()
+{
+	CSphString sError;
+	if ( !sphFileExists ( GetFilename(SPH_EXT_SPIDX), &sError ) )
+		return;
+
+	m_tReporter.Msg ( "checking secondary indexes..." );
+	CheckSecondaryIndexStorage ( GetFilename(SPH_EXT_SPIDX), (DWORD)m_iNumRows,
 		[this]( const char * szError ){ m_tReporter.Fail ( "\n%s", szError ); },
 		[this]( const char * szProgress ){ m_tReporter.Progress ( "%s", szProgress ); } );
 }

--- a/src/secondarylib.cpp
+++ b/src/secondarylib.cpp
@@ -26,6 +26,7 @@ using CreateBuilder_fn =		SI::Builder_i *	(*) ( const common::Schema_t & tSchema
 static void *					g_pSecondaryLib = nullptr;
 static sec::VersionStr_fn		g_fnVersionSecStr = nullptr;
 static sec::CreateSI_fn			g_fnCreateSI = nullptr;
+static sec::CheckStorage_fn		g_fnCheckSI = nullptr;
 static sec::CreateBuilder_fn	g_fnCreateBuilder = nullptr;
 
 static uint64_t					g_uBlockCacheSize = 8*1024*1024;
@@ -79,6 +80,7 @@ bool InitSecondary ( CSphString & sError )
 
 	if ( !LoadFunc ( g_fnVersionSecStr, tHandle.Get(), "GetSecondaryLibVersionStr", sLibfile, sError ) )				return false;
 	if ( !LoadFunc ( g_fnCreateSI, tHandle.Get(), "CreateSecondaryIndex", sLibfile, sError ) )						return false;
+	if ( !LoadFunc ( g_fnCheckSI, tHandle.Get(), "CheckSecondaryIndex", sLibfile, sError ) )						return false;
 	if ( !LoadFunc ( g_fnCreateBuilder, tHandle.Get(), "CreateBuilder", sLibfile, sError ) )						return false;
 
 	g_pSecondaryLib = tHandle.Leak();
@@ -153,6 +155,17 @@ SI::Index_i * CreateSecondaryIndex ( const char * szFile, CSphString & sError )
 		sError = sTmpError.c_str();
 
 	return pSIdx;
+}
+
+void CheckSecondaryIndexStorage ( const CSphString & sFile, uint32_t uNumRows, std::function<void (const char*)> && fnError, std::function<void (const char*)> && fnProgress )
+{
+	if ( !IsSecondaryLibLoaded() || !g_fnCheckSI )
+	{
+		fnError ( "secondary index library not loaded" );
+		return;
+	}
+
+	g_fnCheckSI ( sFile.cstr(), uNumRows, fnError, fnProgress );
 }
 
 std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int64_t iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError )

--- a/src/secondarylib.cpp
+++ b/src/secondarylib.cpp
@@ -16,7 +16,7 @@
 #include "std/sys.h"
 
 namespace sec {
-using CheckStorage_fn =			void (*) ( const std::string & sFilename, uint32_t uNumRows, std::function<void (const char*)> & fnError, std::function<void (const char*)> & fnProgress );
+using CheckStorage_fn =			bool (*) ( const std::string & sFilename, uint32_t uNumRows, SI::ErrorReporter_fn & fnError, SI::ProgressReporter_fn & fnProgress );
 using VersionStr_fn =			const char * (*)();
 using GetVersion_fn	=			int (*)();
 using CreateSI_fn =				SI::Index_i * (*) ( const char * sFile, const SI::IndexSettings_t & tSettings, std::string & sError );
@@ -157,15 +157,16 @@ SI::Index_i * CreateSecondaryIndex ( const char * szFile, CSphString & sError )
 	return pSIdx;
 }
 
-void CheckSecondaryIndexStorage ( const CSphString & sFile, uint32_t uNumRows, std::function<void (const char*)> && fnError, std::function<void (const char*)> && fnProgress )
+bool CheckSecondaryIndexStorage ( const CSphString & sFile, uint32_t uNumRows, SI::ErrorReporter_fn && fnError, SI::ProgressReporter_fn && fnProgress )
 {
 	if ( !IsSecondaryLibLoaded() || !g_fnCheckSI )
 	{
-		fnError ( "secondary index library not loaded" );
-		return;
+		if ( fnError )
+			fnError ( "secondary index library not loaded" );
+		return false;
 	}
 
-	g_fnCheckSI ( sFile.cstr(), uNumRows, fnError, fnProgress );
+	return g_fnCheckSI ( sFile.cstr(), uNumRows, fnError, fnProgress );
 }
 
 std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int64_t iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError )

--- a/src/secondarylib.h
+++ b/src/secondarylib.h
@@ -25,7 +25,7 @@ const char *	GetSecondaryVersionStr();
 bool			IsSecondaryLibLoaded();
 
 SI::Index_i *	CreateSecondaryIndex ( const char * szFile, CSphString & sError );
-void			CheckSecondaryIndexStorage ( const CSphString & sFile, uint32_t uNumRows, std::function<void (const char*)> && fnError, std::function<void (const char*)> && fnProgress );
+bool			CheckSecondaryIndexStorage ( const CSphString & sFile, uint32_t uNumRows, SI::ErrorReporter_fn && fnError, SI::ProgressReporter_fn && fnProgress );
 std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int64_t iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError );
 
 enum class SIDefault_e

--- a/src/secondarylib.h
+++ b/src/secondarylib.h
@@ -14,6 +14,8 @@
 #include "secondary/builder.h"
 #include "secondary/secondary.h"
 
+#include <functional>
+
 // FWD
 struct CSphString;
 
@@ -23,6 +25,7 @@ const char *	GetSecondaryVersionStr();
 bool			IsSecondaryLibLoaded();
 
 SI::Index_i *	CreateSecondaryIndex ( const char * szFile, CSphString & sError );
+void			CheckSecondaryIndexStorage ( const CSphString & sFile, uint32_t uNumRows, std::function<void (const char*)> && fnError, std::function<void (const char*)> && fnProgress );
 std::unique_ptr<SI::Builder_i> CreateSecondaryIndexBuilder ( const common::Schema_t & tSchema, int64_t iMemoryLimit, const CSphString & sFile, int iBufferSize, CSphString & sError );
 
 enum class SIDefault_e

--- a/test/clt-tests/bugs/check-corrupted-secondary-index-limit.rec
+++ b/test/clt-tests/bugs/check-corrupted-secondary-index-limit.rec
@@ -1,0 +1,22 @@
+––– comment –––
+indextool --check must suppress detailed secondary-index diagnostics after its limit while counting every independently corrupted block.
+––– block: ../base/start-searchd –––
+––– input –––
+perl -e 'my $q=chr 39; print "SET GLOBAL auto_optimize=0; DROP TABLE IF EXISTS si_check_limit; CREATE TABLE si_check_limit (id BIGINT, properties JSON secondary_index=\0471\047);\n"; for (my $first=1; $first<=13056; $first+=256) { my $last=$first+255; $last=13056 if $last>13056; print "INSERT INTO si_check_limit VALUES "; print join q{,}, map { "(".$_.",".$q."{\"v\":".$_."}".$q.")" } ($first..$last); print ";\n"; } print "FLUSH RAMCHUNK si_check_limit; SET GLOBAL secondary_indexes=1;\n";' >/tmp/si_check_limit.sql && mysql -h0 -P9306 </tmp/si_check_limit.sql && echo si_ready
+––– output –––
+si_ready
+––– input –––
+stdbuf -oL searchd --stopwait > /dev/null
+––– output –––
+––– input –––
+indextool --check si_check_limit >/tmp/si_check_limit_clean.out 2>&1; echo clean_rc=$?
+––– output –––
+clean_rc=0
+––– input –––
+spidx=$(find /var/lib/manticore/si_check_limit -maxdepth 1 -name '*.spidx' | head -1); blocks=102; if test -s "$spidx" && [ "$(wc -c < "$spidx")" -gt $((blocks*8)) ]; then size=$(wc -c < "$spidx"); table_start=$((size-blocks*8)); perl -e 'my ($file,$start,$count)=@ARGV; open my $fh,"<:raw",$file or die $!; seek $fh,$start,0 or die $!; my $got=read $fh,my $buf,$count*8; die "short read" unless defined $got && $got==$count*8; for (my $i=0;$i<$count;$i++) { print unpack("Q<",substr($buf,$i*8,8)),"\n"; }' "$spidx" "$table_start" "$blocks" | while read -r off; do dd if=/dev/zero of="$spidx" bs=1 seek="$off" count=1 conv=notrunc status=none; done; echo corrupted_all_block_headers; else echo failed_to_corrupt_block_headers; fi
+––– output –––
+corrupted_all_block_headers
+––– input –––
+set +e; out=$(indextool --check si_check_limit 2>&1); rc=$?; set -e; if [ "$rc" -ne 0 ] && echo "$out" | grep -Eq 'check FAILED, [0-9]+ of 102 failures reported'; then echo all_limited_errors_counted; else echo "unexpected rc=$rc"; echo "$out"; fi
+––– output –––
+all_limited_errors_counted

--- a/test/clt-tests/bugs/check-corrupted-secondary-index.rec
+++ b/test/clt-tests/bugs/check-corrupted-secondary-index.rec
@@ -2,10 +2,12 @@
 indextool --check must report a corrupted secondary-index payload as a check failure instead of crashing.
 ––– block: ../base/start-searchd –––
 ––– input –––
-mysql -h0 -P9306 -e "SET GLOBAL auto_optimize=0; DROP TABLE IF EXISTS si_check; CREATE TABLE si_check (id BIGINT, properties JSON secondary_index='1'); INSERT INTO si_check VALUES (1, '{\"channels\":[29],\"v\":10}'), (2, '{\"channels\":[30],\"v\":20}'), (3, '{\"channels\":[29],\"v\":30}'); FLUSH RAMCHUNK si_check; SET GLOBAL secondary_indexes=1; SELECT id, IN(properties.channels, 29) AS p2 FROM si_check WHERE p2=1 ORDER BY id ASC;" >/tmp/si_check_setup.out && tail -n +2 /tmp/si_check_setup.out
+mysql -h0 -P9306 -N -B -e "SET GLOBAL auto_optimize=0; DROP TABLE IF EXISTS si_check; CREATE TABLE si_check (id BIGINT, properties JSON secondary_index='1'); INSERT INTO si_check VALUES (1, '{\"channels\":[29],\"v\":10}'), (2, '{\"channels\":[30],\"v\":20}'), (3, '{\"channels\":[29],\"v\":30}'); FLUSH RAMCHUNK si_check; SET GLOBAL secondary_indexes=1; SELECT id, IN(properties.channels, 29) AS p2 FROM si_check WHERE p2=1 ORDER BY id ASC;"
 ––– output –––
-1	1
-3	1
++------+------+
+|    1 |    1 |
+|    3 |    1 |
++------+------+
 ––– input –––
 stdbuf -oL searchd --stopwait > /dev/null
 ––– output –––

--- a/test/clt-tests/bugs/check-corrupted-secondary-index.rec
+++ b/test/clt-tests/bugs/check-corrupted-secondary-index.rec
@@ -1,13 +1,10 @@
 ––– comment –––
-indextool --check must report a corrupted secondary-index payload as a check failure instead of crashing.
+indextool --check must report corrupted secondary-index files as controlled check failures instead of crashing.
 ––– block: ../base/start-searchd –––
 ––– input –––
-mysql -h0 -P9306 -N -B -e "SET GLOBAL auto_optimize=0; DROP TABLE IF EXISTS si_check; CREATE TABLE si_check (id BIGINT, properties JSON secondary_index='1'); INSERT INTO si_check VALUES (1, '{\"channels\":[29],\"v\":10}'), (2, '{\"channels\":[30],\"v\":20}'), (3, '{\"channels\":[29],\"v\":30}'); FLUSH RAMCHUNK si_check; SET GLOBAL secondary_indexes=1; SELECT id, IN(properties.channels, 29) AS p2 FROM si_check WHERE p2=1 ORDER BY id ASC;"
+mysql -h0 -P9306 -N -B -e "SET GLOBAL auto_optimize=0; DROP TABLE IF EXISTS si_check; CREATE TABLE si_check (id BIGINT, properties JSON secondary_index='1'); INSERT INTO si_check VALUES (1, '{\"channels\":[29],\"v\":10}'), (2, '{\"channels\":[30],\"v\":20}'), (3, '{\"channels\":[29],\"v\":30}'); FLUSH RAMCHUNK si_check; SET GLOBAL secondary_indexes=1;" && echo si_ready
 ––– output –––
-+------+------+
-|    1 |    1 |
-|    3 |    1 |
-+------+------+
+si_ready
 ––– input –––
 stdbuf -oL searchd --stopwait > /dev/null
 ––– output –––
@@ -15,11 +12,39 @@ stdbuf -oL searchd --stopwait > /dev/null
 indextool --check si_check >/tmp/si_check_clean.out 2>&1; echo clean_rc=$?
 ––– output –––
 clean_rc=0
+––– comment –––
+Save the clean file once and restore it before each independent corruption.
 ––– input –––
-spidx=$(find /var/lib/manticore/si_check -maxdepth 1 -name '*.spidx' | head -1); test -s "$spidx" && cp "$spidx" "$spidx.good" && size=$(wc -c < "$spidx") && keep=$((size/2)) && [ "$keep" -ge 1 ] || keep=1; dd if="$spidx.good" of="$spidx" bs=1 count="$keep" status=none; echo truncated_spidx
+spidx=$(find /var/lib/manticore/si_check -maxdepth 1 -name '*.spidx' | head -1); if test -s "$spidx" && cp "$spidx" "$spidx.good"; then echo saved_clean_spidx; else echo failed_to_save_clean_spidx; fi
 ––– output –––
-truncated_spidx
+saved_clean_spidx
+––– comment –––
+Half-file truncation must fail while loading the secondary-index metadata.
 ––– input –––
-set +e; out=$(indextool --check si_check 2>&1); rc=$?; set -e; if [ "$rc" -ne 0 ] && echo "$out" | grep -Eiq 'FAILED|unexpected EOF|Invalid secondary index'; then echo corrupted_check_failed_as_expected; else echo "unexpected rc=$rc"; echo "$out"; fi
+spidx=$(find /var/lib/manticore/si_check -maxdepth 1 -name '*.spidx' | head -1); if test -s "$spidx.good"; then size=$(wc -c < "$spidx.good"); keep=$((size/2)); [ "$keep" -ge 1 ] || keep=1; if dd if="$spidx.good" of="$spidx" bs=1 count="$keep" status=none && [ "$(wc -c < "$spidx")" -eq "$keep" ]; then echo truncated_spidx_half; else echo failed_to_truncate_spidx_half; fi; else echo failed_to_truncate_spidx_half; fi
+––– output –––
+truncated_spidx_half
+––– input –––
+set +e; out=$(indextool --check si_check 2>&1); rc=$?; set -e; if [ "$rc" -ne 0 ] && echo "$out" | grep -Eq 'check FAILED, [0-9]+( of [0-9]+)? failures reported'; then echo corrupted_check_failed_as_expected; else echo "unexpected rc=$rc"; echo "$out"; fi
 ––– output –––
 corrupted_check_failed_as_expected
+––– comment –––
+One missing byte at the tail makes the final block-offset entry incomplete.
+––– input –––
+spidx=$(find /var/lib/manticore/si_check -maxdepth 1 -name '*.spidx' | head -1); if test -s "$spidx.good" && cp "$spidx.good" "$spidx"; then size=$(wc -c < "$spidx"); keep=$((size-1)); if [ "$keep" -ge 1 ] && dd if="$spidx.good" of="$spidx" bs=1 count="$keep" status=none && [ "$(wc -c < "$spidx")" -eq "$keep" ]; then echo truncated_spidx_tail; else echo tail_truncation_failed; fi; else echo tail_truncation_failed; fi
+––– output –––
+truncated_spidx_tail
+––– input –––
+set +e; out=$(indextool --check si_check 2>&1); rc=$?; set -e; if [ "$rc" -ne 0 ] && echo "$out" | grep -Eq 'check FAILED, [0-9]+( of [0-9]+)? failures reported'; then echo tail_corruption_failed_as_expected; else echo "unexpected rc=$rc"; echo "$out"; fi
+––– output –––
+tail_corruption_failed_as_expected
+––– comment –––
+The final complete offset table entry must still point inside the raw-block area.
+––– input –––
+spidx=$(find /var/lib/manticore/si_check -maxdepth 1 -name '*.spidx' | head -1); if test -s "$spidx.good" && cp "$spidx.good" "$spidx"; then size=$(wc -c < "$spidx"); if [ "$size" -ge 8 ] && perl -e 'print pack("Q<", $ARGV[0])' "$size" | dd of="$spidx" bs=1 seek=$((size-8)) count=8 conv=notrunc status=none && [ "$(wc -c < "$spidx")" -eq "$size" ]; then echo corrupted_last_block_offset; else echo failed_to_corrupt_block_offset; fi; else echo failed_to_corrupt_block_offset; fi
+––– output –––
+corrupted_last_block_offset
+––– input –––
+set +e; out=$(indextool --check si_check 2>&1); rc=$?; set -e; if [ "$rc" -ne 0 ] && echo "$out" | grep -Eq 'check FAILED, [0-9]+( of [0-9]+)? failures reported'; then echo corrupt_offset_check_failed_as_expected; else echo "unexpected rc=$rc"; echo "$out"; fi
+––– output –––
+corrupt_offset_check_failed_as_expected

--- a/test/clt-tests/bugs/check-corrupted-secondary-index.rec
+++ b/test/clt-tests/bugs/check-corrupted-secondary-index.rec
@@ -1,0 +1,23 @@
+––– comment –––
+indextool --check must report a corrupted secondary-index payload as a check failure instead of crashing.
+––– block: ../base/start-searchd –––
+––– input –––
+mysql -h0 -P9306 -e "SET GLOBAL auto_optimize=0; DROP TABLE IF EXISTS si_check; CREATE TABLE si_check (id BIGINT, properties JSON secondary_index='1'); INSERT INTO si_check VALUES (1, '{\"channels\":[29],\"v\":10}'), (2, '{\"channels\":[30],\"v\":20}'), (3, '{\"channels\":[29],\"v\":30}'); FLUSH RAMCHUNK si_check; SET GLOBAL secondary_indexes=1; SELECT id, IN(properties.channels, 29) AS p2 FROM si_check WHERE p2=1 ORDER BY id ASC;" >/tmp/si_check_setup.out && tail -n +2 /tmp/si_check_setup.out
+––– output –––
+1	1
+3	1
+––– input –––
+stdbuf -oL searchd --stopwait > /dev/null
+––– output –––
+––– input –––
+indextool --check si_check >/tmp/si_check_clean.out 2>&1; echo clean_rc=$?
+––– output –––
+clean_rc=0
+––– input –––
+spidx=$(find /var/lib/manticore/si_check -maxdepth 1 -name '*.spidx' | head -1); test -s "$spidx" && cp "$spidx" "$spidx.good" && size=$(wc -c < "$spidx") && keep=$((size/2)) && [ "$keep" -ge 1 ] || keep=1; dd if="$spidx.good" of="$spidx" bs=1 count="$keep" status=none; echo truncated_spidx
+––– output –––
+truncated_spidx
+––– input –––
+set +e; out=$(indextool --check si_check 2>&1); rc=$?; set -e; if [ "$rc" -ne 0 ] && echo "$out" | grep -Eiq 'FAILED|unexpected EOF|Invalid secondary index'; then echo corrupted_check_failed_as_expected; else echo "unexpected rc=$rc"; echo "$out"; fi
+––– output –––
+corrupted_check_failed_as_expected


### PR DESCRIPTION
Wire the secondary-index check API into indextool --check and add CLT coverage that verifies a truncated .spidx is reported as a check failure instead of crashing.

Related PR in MCL: https://github.com/manticoresoftware/columnar/pull/195