### PR TITLE
fix: handle negative SSL BIO reads

### DIFF
--- a/src/gtests/CMakeLists.txt
+++ b/src/gtests/CMakeLists.txt
@@ -6,6 +6,10 @@ if (NOT TARGET GTest::gmock_main)
 	return ()
 endif ()
 
+if (WITH_SSL)
+	target_compile_definitions ( searchd_ssl PRIVATE MANTICORE_SSL_TEST_HOOKS )
+endif ()
+
 set ( GTESTS_SRC
 		gtests_rtstuff.cpp
 		gtests_text.cpp
@@ -15,6 +19,7 @@ set ( GTESTS_SRC
 		gtests_searchd.cpp
 		gtests_filter.cpp
 		gtests_searchdaemon.cpp
+		gtests_ssl.cpp
 		gtests_stringbuilder.cpp
 		gtests_strfmt.cpp
 		gtests_pqstuff.cpp
@@ -33,6 +38,10 @@ target_link_libraries ( gmanticoretest PRIVATE
 		source_svpipe
 		daemon
 )
+
+if (WITH_SSL)
+	target_link_libraries ( gmanticoretest PRIVATE OpenSSL::SSL OpenSSL::Crypto )
+endif ()
 
 if (WITH_EXPAT)
 	target_link_libraries ( gmanticoretest PRIVATE source_xmlpipe2 )

--- a/src/gtests/CMakeLists.txt
+++ b/src/gtests/CMakeLists.txt
@@ -6,10 +6,6 @@ if (NOT TARGET GTest::gmock_main)
 	return ()
 endif ()
 
-if (WITH_SSL)
-	target_compile_definitions ( searchd_ssl PRIVATE MANTICORE_SSL_TEST_HOOKS )
-endif ()
-
 set ( GTESTS_SRC
 		gtests_rtstuff.cpp
 		gtests_text.cpp

--- a/src/gtests/gtests_ssl.cpp
+++ b/src/gtests/gtests_ssl.cpp
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2017-2026, Manticore Software LTD (https://manticoresearch.com)
+// Copyright (c) 2001-2016, Andrew Aksyonoff
+// Copyright (c) 2008-2016, Sphinx Technologies Inc
+// All rights reserved
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License. You should have
+// received a copy of the GPL license along with this program; if you
+// did not, you can find it at http://www.gnu.org/
+//
+
+#include <gtest/gtest.h>
+
+#include "searchdssl.h"
+
+#if WITH_SSL
+
+#include <openssl/bio.h>
+#include <openssl/opensslv.h>
+
+#include <algorithm>
+#include <cstring>
+#include <initializer_list>
+#include <memory>
+#include <utility>
+#include <vector>
+
+std::unique_ptr<AsyncNetBuffer_c> MakeSslTestBuffer ( BIO * pSslBackend );
+
+#if ( OPENSSL_VERSION_NUMBER < 0x1010000fL )
+#define BIO_set_shutdown(pBio,CODE) pBio->shutdown = CODE
+#define BIO_get_shutdown(pBio) pBio->shutdown
+#define BIO_set_init(pBio,CODE) pBio->init = CODE
+#define BIO_set_data(pBio,DATA) pBio->ptr = DATA
+#define BIO_get_data(pBio) pBio->ptr
+#define BIO_get_new_index() (24)
+#define BIO_meth_set_create(pMethod,pFn) pMethod->create = pFn
+#define BIO_meth_set_destroy(pMethod,pFn) pMethod->destroy = pFn
+#define BIO_meth_set_read(pMethod,pFn) pMethod->bread = pFn
+#define BIO_meth_set_write(pMethod,pFn) pMethod->bwrite = pFn
+#define BIO_meth_set_ctrl(pMethod,pFn) pMethod->ctrl = pFn
+
+inline static BIO_METHOD * BIO_meth_new ( int iType, const char * szName )
+{
+	auto pMethod = new BIO_METHOD;
+	memset ( pMethod, 0, sizeof ( BIO_METHOD ) );
+	pMethod->type = iType;
+	pMethod->name = szName;
+	return pMethod;
+}
+#endif
+
+struct ScriptedBioState_t
+{
+	std::vector<int> m_dReads;
+	int m_iReadCalls = 0;
+	int m_iCopiedBytes = 0;
+
+	explicit ScriptedBioState_t ( std::initializer_list<int> dReads )
+		: m_dReads ( dReads )
+	{}
+};
+
+static int ScriptedBioCreate ( BIO * pBio )
+{
+	BIO_set_shutdown ( pBio, BIO_CLOSE );
+	BIO_set_init ( pBio, 0 );
+	BIO_set_data ( pBio, nullptr );
+	BIO_clear_flags ( pBio, ~0 );
+	return 1;
+}
+
+static int ScriptedBioDestroy ( BIO * pBio )
+{
+	if ( !pBio )
+		return 0;
+
+	delete (std::shared_ptr<ScriptedBioState_t> *) BIO_get_data ( pBio );
+	BIO_set_data ( pBio, nullptr );
+	BIO_set_init ( pBio, 0 );
+	BIO_clear_flags ( pBio, ~0 );
+	return 1;
+}
+
+static int ScriptedBioRead ( BIO * pBio, char * pBuf, int iNum )
+{
+	auto ppState = (std::shared_ptr<ScriptedBioState_t> *) BIO_get_data ( pBio );
+	if ( !ppState || !pBuf || iNum<=0 )
+		return 0;
+
+	auto & tState = **ppState;
+	int iResult = 0;
+	if ( tState.m_iReadCalls<(int)tState.m_dReads.size() )
+		iResult = tState.m_dReads[tState.m_iReadCalls];
+	tState.m_iReadCalls++;
+
+	if ( iResult<=0 )
+		return iResult;
+
+	int iToCopy = std::min ( iResult, iNum );
+	memset ( pBuf, 'x', iToCopy );
+	tState.m_iCopiedBytes += iToCopy;
+	return iToCopy;
+}
+
+static int ScriptedBioWrite ( BIO *, const char *, int iNum )
+{
+	return iNum;
+}
+
+static long ScriptedBioCtrl ( BIO *, int iCmd, long, void * )
+{
+	switch ( iCmd )
+	{
+	case BIO_CTRL_FLUSH:
+		return 1;
+	case BIO_CTRL_PENDING:
+	case BIO_CTRL_WPENDING:
+	case BIO_CTRL_EOF:
+	default:
+		return 0;
+	}
+}
+
+static BIO_METHOD * ScriptedBioMethod ()
+{
+	static BIO_METHOD * pMethod = nullptr;
+	if ( !pMethod )
+	{
+		pMethod = BIO_meth_new ( BIO_get_new_index () | BIO_TYPE_SOURCE_SINK, "scripted test bio" );
+		BIO_meth_set_create ( pMethod, ScriptedBioCreate );
+		BIO_meth_set_destroy ( pMethod, ScriptedBioDestroy );
+		BIO_meth_set_read ( pMethod, ScriptedBioRead );
+		BIO_meth_set_write ( pMethod, ScriptedBioWrite );
+		BIO_meth_set_ctrl ( pMethod, ScriptedBioCtrl );
+	}
+
+	return pMethod;
+}
+
+static BIO * MakeScriptedBio ( std::shared_ptr<ScriptedBioState_t> pState )
+{
+	auto pBio = BIO_new ( ScriptedBioMethod() );
+	BIO_set_data ( pBio, new std::shared_ptr<ScriptedBioState_t> ( std::move ( pState ) ) );
+	BIO_set_init ( pBio, 1 );
+	return pBio;
+}
+
+TEST ( SslBioRead, NegativeReadDoesNotSpinOrAccountBytes )
+{
+	auto pState = std::make_shared<ScriptedBioState_t> ( std::initializer_list<int>{ -1, 0 } );
+	auto pBuf = MakeSslTestBuffer ( MakeScriptedBio ( pState ) );
+
+	EXPECT_FALSE ( pBuf->ReadFrom ( 1 ) );
+	EXPECT_EQ ( pState->m_iReadCalls, 1 );
+	EXPECT_EQ ( pState->m_iCopiedBytes, 0 );
+	EXPECT_EQ ( pBuf->GetTotalReceived(), 0 );
+}
+
+TEST ( SslBioRead, PartialReadBeforeNegativeReadKeepsAccounting )
+{
+	auto pState = std::make_shared<ScriptedBioState_t> ( std::initializer_list<int>{ 2, -1, 0 } );
+	auto pBuf = MakeSslTestBuffer ( MakeScriptedBio ( pState ) );
+
+	EXPECT_FALSE ( pBuf->ReadFrom ( 3 ) );
+	EXPECT_EQ ( pState->m_iReadCalls, 2 );
+	EXPECT_EQ ( pState->m_iCopiedBytes, 2 );
+	EXPECT_EQ ( pBuf->HasBytes(), 2 );
+	EXPECT_EQ ( pBuf->GetTotalReceived(), 2 );
+}
+
+#endif // WITH_SSL

--- a/src/gtests/gtests_ssl.cpp
+++ b/src/gtests/gtests_ssl.cpp
@@ -19,15 +19,6 @@
 #include <openssl/bio.h>
 #include <openssl/opensslv.h>
 
-#include <algorithm>
-#include <cstring>
-#include <initializer_list>
-#include <memory>
-#include <utility>
-#include <vector>
-
-std::unique_ptr<AsyncNetBuffer_c> MakeSslTestBuffer ( BIO * pSslBackend );
-
 #if ( OPENSSL_VERSION_NUMBER < 0x1010000fL )
 #define BIO_set_shutdown(pBio,CODE) pBio->shutdown = CODE
 #define BIO_get_shutdown(pBio) pBio->shutdown

--- a/src/searchdssl.cpp
+++ b/src/searchdssl.cpp
@@ -711,13 +711,11 @@ public:
 	}
 };
 
-#if defined(MANTICORE_SSL_TEST_HOOKS)
 std::unique_ptr<AsyncNetBuffer_c> MakeSslTestBuffer ( BIO * pSslBackend )
 {
 	assert ( pSslBackend );
 	return std::make_unique<AsyncSSBufferedSocket_c> ( BIOPtr_c ( pSslBackend, [] ( BIO * pBio ) { BIO_free_all ( pBio ); } ) );
 }
-#endif
 
 bool MakeSecureLayer ( std::unique_ptr<AsyncNetBuffer_c>& pSource )
 {

--- a/src/searchdssl.cpp
+++ b/src/searchdssl.cpp
@@ -657,16 +657,19 @@ class AsyncSSBufferedSocket_c final : public AsyncNetBuffer_c
 			int iGot = BIO_read ( m_pSslBackend, pBuf, iCanRead );
 			sphLogDebugv ( FRONT "<< BioReadFront (%p) done %d from %d..%d" NORM,
 					(BIO *) m_pSslBackend, iGot, iNeed, iHaveSpace );
+			if ( iGot<=0 )
+			{
+				sphLogDebugv ( FRONT "<< BioReadFront (%p) breaking on %d after %d" NORM,
+						(BIO *) m_pSslBackend, iGot, iGotTotal );
+				if ( iGot<0 && !iGotTotal )
+					return -1;
+				break;
+			}
+
 			pBuf += iGot;
 			iGotTotal += iGot;
 			iNeed -= iGot;
 			iHaveSpace -= iGot;
-			if ( !iGot )
-			{
-				sphLogDebugv ( FRONT "<< BioReadFront (%p) breaking on %d" NORM,
-						(BIO *) m_pSslBackend, iGotTotal );
-				break;
-			}
 		}
 		m_iReceivedTotal += iGotTotal;
 		return iGotTotal;
@@ -707,6 +710,14 @@ public:
 		return m_iReceivedTotal;
 	}
 };
+
+#if defined(MANTICORE_SSL_TEST_HOOKS)
+std::unique_ptr<AsyncNetBuffer_c> MakeSslTestBuffer ( BIO * pSslBackend )
+{
+	assert ( pSslBackend );
+	return std::make_unique<AsyncSSBufferedSocket_c> ( BIOPtr_c ( pSslBackend, [] ( BIO * pBio ) { BIO_free_all ( pBio ); } ) );
+}
+#endif
 
 bool MakeSecureLayer ( std::unique_ptr<AsyncNetBuffer_c>& pSource )
 {

--- a/src/searchdssl.h
+++ b/src/searchdssl.h
@@ -40,6 +40,9 @@ bool MakeRandBuf ( Str_t & sRes, CSphString & sError );
 bool SecretEqual ( const VecTraits_T<BYTE> & dA, const VecTraits_T<BYTE> & dB );
 
 #if WITH_SSL
+	// Kept forward-declared so SSL consumers do not need to include OpenSSL headers.
+	typedef struct bio_st BIO;
+
 	// set SSL key, certificate and ca-certificate to be used in SSL, if required.
 	// does NOT anyway initialize SSL library or call any of it's funcitons.
 	void SetServerSSLKeys ( const CSphString & sSslCert,  const CSphString & sSslKey,  const CSphString & sSslCa );
@@ -51,6 +54,9 @@ bool SecretEqual ( const VecTraits_T<BYTE> & dA, const VecTraits_T<BYTE> & dB );
 	// Replace pSource with it's SSL version.
 	// any data not consumed from original source will be considered as part of ssl handshake.
 	bool MakeSecureLayer ( std::unique_ptr<AsyncNetBuffer_c> & pSource );
+
+	// Creates the SSL input buffer around a supplied BIO; used by SSL tests.
+	std::unique_ptr<AsyncNetBuffer_c> MakeSslTestBuffer ( BIO * pSslBackend );
 
 #else
 	// these stubs work together with NOT including searchdsll.cpp into the final build


### PR DESCRIPTION
Avoid treating `BIO_read()` errors/retry states as bytes read in the SSL SphinxQL input buffer. A negative result used to move the buffer pointer backwards and increase the remaining byte count, which could spin a worker indefinitely under early SSL-upgrade/client-abort races. 

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4726