### PR TITLE
fix: dedupe RT local_df keyword stats

### DIFF
--- a/src/queryfilter.cpp
+++ b/src/queryfilter.cpp
@@ -351,3 +351,18 @@ void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc )
 
 	sphSort ( dSrc.Begin(), dSrc.GetLength(), KeywordSorter_fn() );
 }
+
+
+void UniqKeywordStats ( CSphVector<CSphKeywordInfo> & dSrc )
+{
+	SmallStringHash_T<CSphKeywordInfo> hWords;
+	for ( const CSphKeywordInfo & tInfo : dSrc )
+		if ( !hWords.Exists ( tInfo.m_sNormalized ) )
+			hWords.Add ( tInfo, tInfo.m_sNormalized );
+
+	dSrc.Resize ( 0 );
+	for ( const auto & tWord : hWords )
+		dSrc.Add ( tWord.second );
+
+	sphSort ( dSrc.Begin(), dSrc.GetLength(), KeywordSorter_fn() );
+}

--- a/src/queryfilter.h
+++ b/src/queryfilter.h
@@ -56,3 +56,4 @@ struct KeywordSorter_fn
 };
 
 void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc );
+void UniqKeywordStats ( CSphVector<CSphKeywordInfo> & dSrc );

--- a/src/sphinxint.h
+++ b/src/sphinxint.h
@@ -1208,6 +1208,7 @@ struct ExpansionContext_t : public ExpansionTrait_t
 struct GetKeywordsSettings_t
 {
 	bool	m_bStats = true;
+	bool	m_bFoldStatsToUnique = false;	///< collect stats once per normalized keyword, used by internal local_df pre-pass
 	bool	m_bFoldLemmas = false;
 	bool	m_bFoldBlended = false;
 	bool	m_bFoldWildcards = false;

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -8757,6 +8757,7 @@ bool RtIndex_c::MultiQuery ( CSphQueryResult & tResult, const CSphQuery & tQuery
 		SwitchProfile ( pProfiler, SPH_QSTATE_LOCAL_DF );
 		GetKeywordsSettings_t tSettings;
 		tSettings.m_bStats = true;
+		tSettings.m_bFoldStatsToUnique = true;
 		// do not want to expand keywords and fold back its statistics as it could take too much time
 		tSettings.m_bAllowExpansion = false;
 
@@ -9073,6 +9074,8 @@ bool RtIndex_c::DoGetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, const c
 
 		tAotFilter.GetKeywords ( dKeywords, tExpCtx );
 		bHasWildcards = tExpCtx.m_bHasWildcards;
+		if ( tSettings.m_bFoldStatsToUnique )
+			UniqKeywordStats ( dKeywords );
 	} else
 	{
 		KeywordBuf_t dWord ( GetDictFormat() );
@@ -9109,7 +9112,7 @@ bool RtIndex_c::DoGetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, const c
 	if ( !tSettings.m_bStats && !bHasWildcards )
 		return true;
 
-	if ( bFillOnly )
+	if ( bFillOnly || tSettings.m_bFoldStatsToUnique )
 	{
 		for ( auto& pChunk : tGuard.m_dDiskChunks )
 			pChunk->Cidx().FillKeywords ( dKeywords );


### PR DESCRIPTION
For RT tables with multiple disk chunks, the local_df pre-pass reparsed the full raw query for every disk chunk. Large repeated OR/phrase queries could spend most of their time in keyword-stat collection before the actual search. Add an internal keyword-stat folding mode that keeps one entry per normalized term, then fills disk-chunk stats from that folded list instead of reparsing the raw query per chunk. Public CALL KEYWORDS behavior remains unchanged.