### PR TITLE
fix: dedupe RT local_df keyword stats

### DIFF
--- a/src/daemon/search_handler.cpp
+++ b/src/daemon/search_handler.cpp
@@ -1319,28 +1319,9 @@ void SearchHandler_c::SetupLocalDF ()
 		{
 			GetKeywordsSettings_t tSettings;
 			tSettings.m_bStats = true;
+			tSettings.m_bFoldStatsToUnique = true;
 			dKeywords.Resize ( 0 );
 			pIndex->GetKeywords ( dKeywords, dQuery.Begin(), tSettings, NULL );
-
-			// FIXME!!! move duplicate removal to GetKeywords to do less QWord setup and dict searching
-			// custom uniq - got rid of word duplicates
-			dKeywords.Sort ( bind ( &CSphKeywordInfo::m_sNormalized ) );
-			if ( dKeywords.GetLength()>1 )
-			{
-				int iSrc = 1, iDst = 1;
-				while ( iSrc<dKeywords.GetLength() )
-				{
-					if ( dKeywords[iDst-1].m_sNormalized==dKeywords[iSrc].m_sNormalized )
-						iSrc++;
-					else
-					{
-						Swap ( dKeywords[iDst], dKeywords[iSrc] );
-						iDst++;
-						iSrc++;
-					}
-				}
-				dKeywords.Resize ( iDst );
-			}
 		}
 
 		for ( auto& tKw: dKeywords )

--- a/src/queryfilter.cpp
+++ b/src/queryfilter.cpp
@@ -52,6 +52,14 @@ static void ReportSkippedOverLimitTokens ( ISphTokenizer * pTokenizer, CSphStrin
 
 void ISphQueryFilter::GetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, ExpansionContext_t & tCtx )
 {
+	CollectKeywords ( dKeywords, tCtx );
+	if ( m_tFoldSettings.m_bFoldStatsToUnique )
+		UniqKeywords ( dKeywords, KeywordUniq_e::BY_NORMALIZED );
+}
+
+
+void ISphQueryFilter::CollectKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, ExpansionContext_t & tCtx )
+{
 	assert ( m_pTokenizer && m_pDict && m_pSettings );
 
 	DictFormat_e eDictFormat = m_pDict->GetSettings().GetDictFormat();
@@ -325,24 +333,44 @@ void CSphPlainQueryFilter::AddKeywordStats ( BYTE * sWord, const BYTE * sTokeniz
 	RemoveDictSpecials ( tInfo.m_sNormalized, ( m_pSettings->m_eBigramIndex!=SPH_BIGRAM_NONE ) );
 }
 
-void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc )
+template<bool KEEP_QPOS, typename HASH, typename KEY>
+static void AddUniqueKeyword_T ( HASH & hWords, const KEY & tKey, const CSphKeywordInfo & tInfo )
 {
-	CSphOrderedHash < CSphKeywordInfo, uint64_t, IdentityHash_fn, 256 > hWords;
+	if constexpr ( !KEEP_QPOS )
+	{
+		if ( hWords.Exists ( tKey ) )
+			return;
+	}
+
+	CSphKeywordInfo & tVal = hWords.AddUnique ( tKey );
+	if ( !tVal.m_iQpos )
+		tVal = tInfo;
+	else if constexpr ( KEEP_QPOS )
+	{
+		tVal.m_iDocs += tInfo.m_iDocs;
+		tVal.m_iHits += tInfo.m_iHits;
+	}
+}
+
+
+template<KeywordUniq_e MODE>
+static void UniqKeywords_T ( CSphVector<CSphKeywordInfo> & dSrc )
+{
+	constexpr bool KEEP_QPOS = MODE==KeywordUniq_e::BY_NORMALIZED_AND_QPOS;
+	using Key_t = std::conditional_t<KEEP_QPOS,uint64_t,CSphString>;
+	using Hash_fn = std::conditional_t<KEEP_QPOS,IdentityHash_fn,CSphStrHashFunc>;
+	CSphOrderedHash<CSphKeywordInfo,Key_t,Hash_fn,256> hWords;
+
 	ARRAY_FOREACH ( i, dSrc )
 	{
 		const CSphKeywordInfo & tInfo = dSrc[i];
-		uint64_t uKey = sphFNV64 ( tInfo.m_iQpos );
-		uKey = sphFNV64 ( tInfo.m_sNormalized.cstr(), tInfo.m_sNormalized.Length(), uKey );
-
-		CSphKeywordInfo & tVal = hWords.AddUnique ( uKey );
-		if ( !tVal.m_iQpos )
+		if constexpr ( KEEP_QPOS )
 		{
-			tVal = tInfo;
+			uint64_t uKey = sphFNV64 ( tInfo.m_iQpos );
+			uKey = sphFNV64 ( tInfo.m_sNormalized.cstr(), tInfo.m_sNormalized.Length(), uKey );
+			AddUniqueKeyword_T<KEEP_QPOS> ( hWords, uKey, tInfo );
 		} else
-		{
-			tVal.m_iDocs += tInfo.m_iDocs;
-			tVal.m_iHits += tInfo.m_iHits;
-		}
+			AddUniqueKeyword_T<KEEP_QPOS> ( hWords, tInfo.m_sNormalized, tInfo );
 	}
 
 	dSrc.Resize ( 0 );
@@ -353,16 +381,10 @@ void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc )
 }
 
 
-void UniqKeywordStats ( CSphVector<CSphKeywordInfo> & dSrc )
+void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc, KeywordUniq_e eMode )
 {
-	SmallStringHash_T<CSphKeywordInfo> hWords;
-	for ( const CSphKeywordInfo & tInfo : dSrc )
-		if ( !hWords.Exists ( tInfo.m_sNormalized ) )
-			hWords.Add ( tInfo, tInfo.m_sNormalized );
-
-	dSrc.Resize ( 0 );
-	for ( const auto & tWord : hWords )
-		dSrc.Add ( tWord.second );
-
-	sphSort ( dSrc.Begin(), dSrc.GetLength(), KeywordSorter_fn() );
+	if ( eMode==KeywordUniq_e::BY_NORMALIZED_AND_QPOS )
+		UniqKeywords_T<KeywordUniq_e::BY_NORMALIZED_AND_QPOS> ( dSrc );
+	else
+		UniqKeywords_T<KeywordUniq_e::BY_NORMALIZED> ( dSrc );
 }

--- a/src/queryfilter.cpp
+++ b/src/queryfilter.cpp
@@ -351,3 +351,18 @@ void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc )
 
 	sphSort ( dSrc.Begin(), dSrc.GetLength(), KeywordSorter_fn() );
 }
+
+
+void UniqKeywordStats ( CSphVector<CSphKeywordInfo> & dSrc )
+{
+	SmallStringHash_T<CSphKeywordInfo> hWords;
+	for ( const CSphKeywordInfo & tInfo : dSrc )
+		if ( !hWords.Exists ( tInfo.m_sNormalized ) )
+			hWords.Add ( tInfo, tInfo.m_sNormalized );
+
+	dSrc.Resize ( 0 );
+	for ( const auto & tWord : hWords )
+		dSrc.Add ( tWord.second );
+
+	sphSort ( dSrc.Begin(), dSrc.GetLength(), KeywordSorter_fn() );
+}

--- a/src/queryfilter.h
+++ b/src/queryfilter.h
@@ -27,6 +27,9 @@ struct ISphQueryFilter
 
 	void GetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, ExpansionContext_t & tCtx );
 	virtual void AddKeywordStats ( BYTE* sWord, const BYTE* sTokenized, int iQpos, CSphVector<CSphKeywordInfo>& dKeywords ) = 0;
+
+private:
+	void CollectKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, ExpansionContext_t & tCtx );
 };
 
 struct CSphTemplateQueryFilter: public ISphQueryFilter
@@ -55,5 +58,10 @@ struct KeywordSorter_fn
 	}
 };
 
-void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc );
-void UniqKeywordStats ( CSphVector<CSphKeywordInfo> & dSrc );
+enum class KeywordUniq_e
+{
+	BY_NORMALIZED,				///< retain the first entry for each normalized keyword
+	BY_NORMALIZED_AND_QPOS		///< merge stats for the same query position and normalized keyword
+};
+
+void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc, KeywordUniq_e eMode );

--- a/src/queryfilter.h
+++ b/src/queryfilter.h
@@ -56,3 +56,4 @@ struct KeywordSorter_fn
 };
 
 void UniqKeywords ( CSphVector<CSphKeywordInfo> & dSrc );
+void UniqKeywordStats ( CSphVector<CSphKeywordInfo> & dSrc );

--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -5383,7 +5383,7 @@ bool DoGetKeywords ( const CSphString & sIndex, const CSphString & sQuery, const
 
 		// process result sets
 		if ( dLocals.GetLength() + iAgentsReply>1 )
-			UniqKeywords ( dKeywords );
+			UniqKeywords ( dKeywords, KeywordUniq_e::BY_NORMALIZED_AND_QPOS );
 
 		bOk = true;
 	}

--- a/src/sphinxint.h
+++ b/src/sphinxint.h
@@ -1208,6 +1208,7 @@ struct ExpansionContext_t : public ExpansionTrait_t
 struct GetKeywordsSettings_t
 {
 	bool	m_bStats = true;
+	bool	m_bFoldStatsToUnique = false;	///< collect stats once per normalized keyword, used by internal local_df pre-pass
 	bool	m_bFoldLemmas = false;
 	bool	m_bFoldBlended = false;
 	bool	m_bFoldWildcards = false;

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -9074,8 +9074,6 @@ bool RtIndex_c::DoGetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, const c
 
 		tAotFilter.GetKeywords ( dKeywords, tExpCtx );
 		bHasWildcards = tExpCtx.m_bHasWildcards;
-		if ( tSettings.m_bFoldStatsToUnique )
-			UniqKeywordStats ( dKeywords );
 	} else
 	{
 		KeywordBuf_t dWord ( GetDictFormat() );
@@ -9130,7 +9128,7 @@ bool RtIndex_c::DoGetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, const c
 
 		// merge keywords from RAM parts with disk keywords
 		if ( iWasKeywords!=dKeywords.GetLength() )
-			UniqKeywords ( dKeywords );
+			UniqKeywords ( dKeywords, KeywordUniq_e::BY_NORMALIZED_AND_QPOS );
 	}
 
 	return true;

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -8757,6 +8757,7 @@ bool RtIndex_c::MultiQuery ( CSphQueryResult & tResult, const CSphQuery & tQuery
 		SwitchProfile ( pProfiler, SPH_QSTATE_LOCAL_DF );
 		GetKeywordsSettings_t tSettings;
 		tSettings.m_bStats = true;
+		tSettings.m_bFoldStatsToUnique = true;
 		// do not want to expand keywords and fold back its statistics as it could take too much time
 		tSettings.m_bAllowExpansion = false;
 
@@ -9073,6 +9074,8 @@ bool RtIndex_c::DoGetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, const c
 
 		tAotFilter.GetKeywords ( dKeywords, tExpCtx );
 		bHasWildcards = tExpCtx.m_bHasWildcards;
+		if ( tSettings.m_bFoldStatsToUnique )
+			UniqKeywordStats ( dKeywords );
 	} else
 	{
 		KeywordBuf_t dWord ( GetDictFormat() );
@@ -9109,7 +9112,7 @@ bool RtIndex_c::DoGetKeywords ( CSphVector<CSphKeywordInfo> & dKeywords, const c
 	if ( !tSettings.m_bStats && !bHasWildcards )
 		return true;
 
-	if ( bFillOnly )
+	if ( bFillOnly || tSettings.m_bFoldStatsToUnique )
 	{
 		for ( auto& pChunk : tGuard.m_dDiskChunks )
 			pChunk->Cidx().FillKeywords ( dKeywords );


### PR DESCRIPTION
For RT tables with multiple disk chunks, the local_df pre-pass reparsed the full raw query for every disk chunk. Large repeated OR/phrase queries could spend most of their time in keyword-stat collection before the actual search. Add an internal keyword-stat folding mode that keeps one entry per normalized term, then fills disk-chunk stats from that folded list instead of reparsing the raw query per chunk. Public CALL KEYWORDS behavior remains unchanged.