### PR TITLE
test: retry remote embedding table creation

### DIFF
--- a/test/clt-tests/mcl/auto-embeddings-alter-table.rec
+++ b/test/clt-tests/mcl/auto-embeddings-alter-table.rec
@@ -14,6 +14,7 @@ API Key Validation: All keys are valid except "wrong" (returns 401 error)
 ––– comment –––
 Start Manticore Search
 ––– block: ../base/start-searchd –––
+––– block: ./base –––
 ––– comment –––
 MOCK SERVER STARTUP
 ––– comment –––
@@ -43,7 +44,7 @@ Setup: Requires mock server running: php test/clt-tests/mcl/mock-embeddings-serv
 ––– comment –––
 Create table without API_URL
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_add_api_url (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_add_api_url (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -102,7 +103,7 @@ Expected: ALTER succeeds (reverts to default endpoint), default endpoint used, S
 ––– comment –––
 Create table with API_URL
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_remove_api_url (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_URL='http://localhost:8080/v1/embeddings')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_remove_api_url (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_URL='http://localhost:8080/v1/embeddings')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -184,7 +185,7 @@ Expected: ALTER succeeds, new timeout used for subsequent requests, SHOW CREATE 
 ––– comment –––
 Create table without API_TIMEOUT
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_add_api_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_add_api_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -213,7 +214,7 @@ Expected: ALTER succeeds, new timeout used for subsequent requests, SHOW CREATE 
 ––– comment –––
 Create table with API_TIMEOUT='30'
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_change_api_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_TIMEOUT='30')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_change_api_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_TIMEOUT='30')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -242,7 +243,7 @@ Expected: ALTER succeeds (reverts to default timeout), default timeout (10s) use
 ––– comment –––
 Create table with API_TIMEOUT='30'
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_remove_api_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_TIMEOUT='30')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_remove_api_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_TIMEOUT='30')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -272,7 +273,7 @@ Verify: Error message: "API_TIMEOUT must be a non-negative integer"
 ––– comment –––
 First create table
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_negative_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_negative_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -290,7 +291,7 @@ Verify: Error message: "API_TIMEOUT must be a non-negative integer"
 ––– comment –––
 First create table
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_alter_nonint_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_alter_nonint_timeout (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––

--- a/test/clt-tests/mcl/auto-embeddings-api-key-validation.rec
+++ b/test/clt-tests/mcl/auto-embeddings-api-key-validation.rec
@@ -16,6 +16,7 @@ Removed Format Validation: The previous format-based validation (e.g., "sk-" pre
 ––– comment –––
 Start Manticore Search
 ––– block: ../base/start-searchd –––
+––– block: ./base –––
 ––– comment –––
 MOCK SERVER STARTUP
 ––– comment –––
@@ -82,7 +83,7 @@ Expected: Table creation succeeds, SHOW CREATE TABLE does NOT display api_key (s
 Verify: Full workflow works correctly
 Note: Using real OpenAI API key and default endpoint
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_valid_api_key (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_valid_api_key (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––

--- a/test/clt-tests/mcl/auto-embeddings-api-timeout.rec
+++ b/test/clt-tests/mcl/auto-embeddings-api-timeout.rec
@@ -15,6 +15,7 @@ API Key Validation: All keys are valid except "wrong" (returns 401 error)
 ––– comment –––
 Start Manticore Search
 ––– block: ../base/start-searchd –––
+––– block: ./base –––
 ––– comment –––
 MOCK SERVER STARTUP
 ––– comment –––
@@ -41,7 +42,7 @@ Test: Create table without API_TIMEOUT parameter
 Expected: Uses default timeout (10 seconds)
 Verify: Table creation succeeds, SHOW CREATE TABLE does NOT display api_timeout
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_api_timeout_not_specified (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_api_timeout_not_specified (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -62,7 +63,7 @@ Test: CREATE TABLE ... API_TIMEOUT='0'
 Expected: Treated as not specified, uses default timeout (10 seconds)
 Verify: Table creation succeeds, SHOW CREATE TABLE does NOT display api_timeout
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_api_timeout_zero (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_TIMEOUT='0')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_api_timeout_zero (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_TIMEOUT='0')"; echo $?
 ––– output –––
 0
 ––– comment –––

--- a/test/clt-tests/mcl/auto-embeddings-api-url.rec
+++ b/test/clt-tests/mcl/auto-embeddings-api-url.rec
@@ -16,6 +16,7 @@ Response Type Override: Use "response-type=TYPE" in input text to test invalid r
 ––– comment –––
 Start Manticore Search
 ––– block: ../base/start-searchd –––
+––– block: ./base –––
 ––– comment –––
 MOCK SERVER STARTUP
 ––– comment –––
@@ -34,7 +35,7 @@ Test: Create table without API_URL parameter
 Expected: Uses default provider endpoint (e.g., https://api.openai.com/v1/embeddings for OpenAI)
 Verify: Table creation succeeds, embeddings generated successfully, SHOW CREATE TABLE does NOT display api_url
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_api_url_not_specified (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_api_url_not_specified (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -56,7 +57,7 @@ Test: CREATE TABLE ... API_URL=''
 Expected: Treated as not specified, uses default endpoint
 Verify: Same as API_URL Not Specified test
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_api_url_empty (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_URL='')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_api_url_empty (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_URL='')"; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -161,7 +162,7 @@ Test: API_URL='https://api.openai.com/v1/embeddings' with valid OpenAI key
 Expected: Table creation succeeds, embeddings generated successfully, SHOW CREATE TABLE displays api_url
 Note: This requires a valid OpenAI API key
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_api_url_default_endpoint (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_URL='https://api.openai.com/v1/embeddings')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_api_url_default_endpoint (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}' API_URL='https://api.openai.com/v1/embeddings')"; echo $?
 ––– output –––
 0
 ––– comment –––

--- a/test/clt-tests/mcl/auto-embeddings-jina-remote.rec
+++ b/test/clt-tests/mcl/auto-embeddings-jina-remote.rec
@@ -19,7 +19,7 @@ ERROR 1064 (42000) at line 1: error adding table 'test_valid_model_no_api_key': 
 ––– comment –––
 Test table creation with valid JinaAI model and KEY
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_jina_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'jina/jina-embeddings-v4' FROM = 'title, content' API_KEY='${JINA_API_KEY}') "; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_jina_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'jina/jina-embeddings-v4' FROM = 'title, content' API_KEY='${JINA_API_KEY}') "; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -89,7 +89,7 @@ SUCCESS: Same FROM fields produce similar vectors (similarity: #!/(1|0\.[0-9]+)/
 ––– comment –––
 Test different FROM field combinations produce different vectors
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_jina_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'jina/jina-embeddings-v4' FROM = 'title' API_KEY='${JINA_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_jina_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_jina_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_jina_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
+retry_remote_embedding_create_table "CREATE TABLE test_jina_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'jina/jina-embeddings-v4' FROM = 'title' API_KEY='${JINA_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_jina_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_jina_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_jina_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
 ––– output –––
 multi_field_md5: #!/[0-9a-f]{32}/!#
 single_field_md5: #!/[0-9a-f]{32}/!#

--- a/test/clt-tests/mcl/auto-embeddings-openai-remote.rec
+++ b/test/clt-tests/mcl/auto-embeddings-openai-remote.rec
@@ -19,7 +19,7 @@ ERROR 1064 (42000) at line 1: error adding table 'test_valid_model_no_api_key': 
 ––– comment –––
 Test table creation with valid OpenAI model and KEY
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_openai_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'openai/text-embedding-ada-002' FROM = 'title, content' API_KEY='${OPENAI_API_KEY}') "; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_openai_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'openai/text-embedding-ada-002' FROM = 'title, content' API_KEY='${OPENAI_API_KEY}') "; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -91,7 +91,7 @@ SUCCESS: Same FROM fields produce similar vectors (similarity: #!/(1|0\.[0-9]+)/
 ––– comment –––
 Test different FROM field combinations produce different vectors
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_openai_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'openai/text-embedding-ada-002' FROM = 'title' API_KEY='${OPENAI_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_openai_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_openai_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_openai_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
+retry_remote_embedding_create_table "CREATE TABLE test_openai_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'openai/text-embedding-ada-002' FROM = 'title' API_KEY='${OPENAI_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_openai_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_openai_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_openai_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
 ––– output –––
 multi_field_md5: #!/[0-9a-f]{32}/!#
 single_field_md5: #!/[0-9a-f]{32}/!#

--- a/test/clt-tests/mcl/auto-embeddings-parameter-combinations.rec
+++ b/test/clt-tests/mcl/auto-embeddings-parameter-combinations.rec
@@ -17,6 +17,7 @@ API Key Validation: All keys are valid except "wrong" (returns 401 error)
 ––– comment –––
 Start Manticore Search
 ––– block: ../base/start-searchd –––
+––– block: ./base –––
 ––– comment –––
 MOCK SERVER STARTUP
 
@@ -313,7 +314,7 @@ Expected: ALTER fails with error about column not found
 
 Create table first
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_nonexistent_column (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')" 2>&1; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_nonexistent_column (title TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='${OPENAI_API_KEY}')"; echo $?
 ––– output –––
 0
 ––– comment –––

--- a/test/clt-tests/mcl/auto-embeddings-syntax-check.rec
+++ b/test/clt-tests/mcl/auto-embeddings-syntax-check.rec
@@ -19,7 +19,7 @@ ERROR 1064 (42000) at line 1: error adding table 'test_valid_model_no_api_key': 
 ––– comment –––
 Test table creation with valid VoyageAI model and KEY
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_voyage_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title, content' API_KEY='${VOYAGE_API_KEY}') "; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_voyage_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title, content' API_KEY='${VOYAGE_API_KEY}') "; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -89,7 +89,7 @@ SUCCESS: Same FROM fields produce similar vectors (similarity: #!/(1|0\.[0-9]+)/
 ––– comment –––
 Test different FROM field combinations produce different vectors
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_voyage_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title' API_KEY='${VOYAGE_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_voyage_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
+retry_remote_embedding_create_table "CREATE TABLE test_voyage_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title' API_KEY='${VOYAGE_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_voyage_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
 ––– output –––
 multi_field_md5: #!/[0-9a-f]{32}/!#
 single_field_md5: #!/[0-9a-f]{32}/!#

--- a/test/clt-tests/mcl/auto-embeddings-voyage-remote.rec
+++ b/test/clt-tests/mcl/auto-embeddings-voyage-remote.rec
@@ -19,7 +19,7 @@ ERROR 1064 (42000) at line 1: error adding table 'test_valid_model_no_api_key': 
 ––– comment –––
 Test table creation with valid VoyageAI model and KEY
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_voyage_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title, content' API_KEY='${VOYAGE_API_KEY}') "; echo $?
+retry_remote_embedding_create_table "CREATE TABLE test_voyage_remote (title TEXT, content TEXT, description TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title, content' API_KEY='${VOYAGE_API_KEY}') "; echo $?
 ––– output –––
 0
 ––– comment –––
@@ -89,7 +89,7 @@ SUCCESS: Same FROM fields produce similar vectors (similarity: #!/(1|0\.[0-9]+)/
 ––– comment –––
 Test different FROM field combinations produce different vectors
 ––– input –––
-mysql -h0 -P9306 -e "CREATE TABLE test_voyage_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title' API_KEY='${VOYAGE_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_voyage_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
+retry_remote_embedding_create_table "CREATE TABLE test_voyage_title_only (title TEXT, content TEXT, embedding FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME = 'voyage/voyage-3.5-lite' FROM = 'title' API_KEY='${VOYAGE_API_KEY}') "; mysql -h0 -P9306 -e "INSERT INTO test_voyage_title_only (id, title, content) VALUES(1, 'machine learning algorithms', 'completely different content here')"; MD5_MULTI=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_remote WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); MD5_SINGLE=$(mysql -h0 -P9306 -e "SELECT embedding FROM test_voyage_title_only WHERE id=1" | grep -v embedding | md5sum | awk '{print $1}'); echo "multi_field_md5: $MD5_MULTI"; echo "single_field_md5: $MD5_SINGLE"; if [ "$MD5_MULTI" != "$MD5_SINGLE" ]; then echo "SUCCESS: Different FROM specifications produce different vectors"; else echo "INFO: FROM field comparison result"; fi
 ––– output –––
 multi_field_md5: #!/[0-9a-f]{32}/!#
 single_field_md5: #!/[0-9a-f]{32}/!#

--- a/test/clt-tests/mcl/base.recb
+++ b/test/clt-tests/mcl/base.recb
@@ -12,8 +12,32 @@ cosine_similarity() {
         print dot / (sqrt(suma2) * sqrt(sumb2))
     }' "$file1" "$file2"
 }
+
+retry_remote_embedding_create_table() {
+    local sql="$1"
+    local attempts=5
+    local delay=1
+    local attempt output rc
+
+    for attempt in $(seq 1 "$attempts"); do
+        output=$(mysql -h0 -P9306 -e "$sql" 2>&1)
+        rc=$?
+
+        if [ "$rc" -eq 0 ]; then
+            return 0
+        fi
+
+        if [ "$attempt" -eq "$attempts" ]; then
+            printf '%s\n' "$output" >&2
+            return "$rc"
+        fi
+
+        sleep "$delay"
+        delay=$((delay * 2))
+    done
+}
 ––– output –––
 ––– input –––
-export -f cosine_similarity
+export -f cosine_similarity retry_remote_embedding_create_table
 ––– output –––
 


### PR DESCRIPTION
Remote embedding provider calls can fail transiently during CREATE TABLE preallocation, for example with provider-side HTTP 503 responses. Add a shared CLT helper that retries expected-success remote CREATE TABLE calls five times with increasing pauses.