### PR TITLE
Drop idle persistent agent sockets after fatal failures

### DIFF
--- a/src/searchdha.cpp
+++ b/src/searchdha.cpp
@@ -237,6 +237,22 @@ void PersistentConnectionsPool_c::ReturnConnection ( int iSocket )
 	m_dSockets[Step ( &m_iWit )] = iSocket;
 }
 
+void PersistentConnectionsPool_c::CloseIdleConnections ()
+{
+	ScopedMutex_t tGuard ( m_dDataLock );
+
+	int iRead = m_iRit;
+	for ( int i = 0; i<m_iFreeWindow; ++i )
+	{
+		int & iSock = m_dSockets[Step ( &iRead )];
+		if ( iSock>=0 )
+		{
+			sphSockClose ( iSock );
+			iSock = -1;
+		}
+	}
+}
+
 // close all the sockets in the pool.
 void PersistentConnectionsPool_c::Shutdown ()
 {
@@ -1662,6 +1678,8 @@ bool AgentConn_t::Fatal ( AgentStats_e eStat, const char * sMessage, ... )
 	va_end ( ap );
 	sphLogDebugv ( "%d FATAL: %s", m_iStoreTag, m_sFailure.cstr () ); // want to log failure at extended log mode wo recompile of daemon
 	State ( Agent_e::RETRY );
+	if ( IsPersistent () )
+		m_tDesc.m_pDash->m_pPersPool->CloseIdleConnections ();
 	Finish ( true );
 	agent_stats_inc ( *this, eStat );
 	return false;
@@ -3894,4 +3912,3 @@ bool sphNBSockEof ( int iSock )
 		return true;
 	return false;
 }
-

--- a/src/searchdha.h
+++ b/src/searchdha.h
@@ -132,6 +132,7 @@ public:
 	void	ReInit ( int iPoolSize ) REQUIRES ( !m_dDataLock );
 	int		RentConnection () REQUIRES ( !m_dDataLock );
 	void	ReturnConnection ( int iSocket ) REQUIRES ( !m_dDataLock );
+	void	CloseIdleConnections () REQUIRES ( !m_dDataLock );
 	void	Shutdown () REQUIRES ( !m_dDataLock );
 };
 


### PR DESCRIPTION
## Summary

- close idle persistent agent sockets after a fatal remote agent failure
- keep the existing failed in-flight socket close path unchanged
- force subsequent persistent-agent requests for the same host to establish fresh connections

## Why

With distributed tables that use persistent remote agents (`conn=pconn`), a fatal network/protocol failure can leave other idle sockets for the same remote host in the persistent pool. Those sockets may be stale or associated with the same broken remote state, and can be reused by later requests.

On a fatal failure we already close the active socket. This change also drops idle sockets in the same persistent pool so the next request does not reuse potentially poisoned connections.

## Changes

- add `PersistentConnectionsPool_c::CloseIdleConnections()`
- call it from `AgentConn_t::Fatal()` for persistent agents before closing the failed socket

## Checks

- `git diff --check upstream/main..HEAD`
