### PR TITLE
🆕 Update buddy version from 4.2.0 to 4.3.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.2+26072909-4693a185-dev
-buddy 4.2.0+26063013-dc2f8c9f-dev
+buddy 4.3.0+26080612-d07689b3-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.25.0+26050511-832198ca-dev


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 4.2.0 to 4.3.0 which includes:

[`d07689b`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/d07689b325ff0a8eefe68deb1a84841d7911f56f) Feat: Retries for conversational router tool calling (#691)
