### PR TITLE
fix: more sync optimize_cutoff_KNN

### DIFF
--- a/src/indexsettings.cpp
+++ b/src/indexsettings.cpp
@@ -3260,6 +3260,7 @@ bool MutableIndexSettings_c::Load ( const char * sFileName, const char * sIndexN
 	{
 		m_iOptimizeCutoff = tOptimizeCutoff.IntVal();
 		m_iOptimizeCutoff = Max ( m_iOptimizeCutoff, 1 );
+		m_iOptimizeCutoffKNN = m_iOptimizeCutoff;
 		m_dLoaded.BitSet ( (int)MutableName_e::OPTIMIZE_CUTOFF );
 	}
 
@@ -3387,6 +3388,7 @@ bool MutableIndexSettings_c::Load ( const CSphConfigSection & hIndex, bool bNeed
 	{
 		m_iOptimizeCutoff = hIndex.GetInt ( GetMutableName ( MutableName_e::OPTIMIZE_CUTOFF ), g_iOptimizeCutoff );
 		m_iOptimizeCutoff = Max ( m_iOptimizeCutoff, 1 );
+		m_iOptimizeCutoffKNN = m_iOptimizeCutoff;
 		m_dLoaded.BitSet ( (int)MutableName_e::OPTIMIZE_CUTOFF );
 	}
 
@@ -3572,6 +3574,7 @@ void MutableIndexSettings_c::Combine ( const MutableIndexSettings_c & tOther )
 	if ( tOther.m_dLoaded.BitGet ( (int)MutableName_e::OPTIMIZE_CUTOFF ) )
 	{
 		m_iOptimizeCutoff = tOther.m_iOptimizeCutoff;
+		m_iOptimizeCutoffKNN = tOther.m_iOptimizeCutoffKNN;
 		m_dLoaded.BitSet ( (int)MutableName_e::OPTIMIZE_CUTOFF );
 	}
 

--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -15319,8 +15319,9 @@ void ConfigureSearchd ( const CSphConfig & hConf, bool bNeedPIDFile, bool bTestM
 
 	g_iAutoOptimizeCutoffMultiplier = hSearchd.GetInt ( "auto_optimize", 1 );
 	g_bOptimizeCutoffExplicit = hSearchd.Exists ( "optimize_cutoff" );
-	MutableIndexSettings_c::GetDefaults().m_iOptimizeCutoff = hSearchd.GetInt ( "optimize_cutoff", AutoOptimizeCutoff() );
-	MutableIndexSettings_c::GetDefaults().m_iOptimizeCutoffKNN = hSearchd.GetInt ( "optimize_cutoff", AutoOptimizeCutoffKNN() );
+	const auto iOptimizeCutoff = hSearchd.OptInt("optimize_cutoff");
+	MutableIndexSettings_c::GetDefaults().m_iOptimizeCutoff = iOptimizeCutoff.value_or ( AutoOptimizeCutoff() );
+	MutableIndexSettings_c::GetDefaults().m_iOptimizeCutoffKNN = iOptimizeCutoff.value_or ( AutoOptimizeCutoffKNN() );
 
 	SetPseudoSharding ( hSearchd.GetInt ( "pseudo_sharding", 1 )!=0 );
 	SetOptionSI ( hSearchd, bTestMode );

--- a/src/sphinxutils.h
+++ b/src/sphinxutils.h
@@ -285,6 +285,14 @@ public:
 		return pEntry ? pEntry->intval() : iDefault;
 	}
 
+	std::optional<int> OptInt ( const char * sKey ) const
+	{
+		CSphVariant * pEntry = (*this)( sKey );
+		if (!pEntry)
+			return std::nullopt;
+		return pEntry->intval();
+	}
+
 	/// get float option value by key and default value
 	float GetFloat ( const char * sKey, float fDefault=0.0f ) const
 	{


### PR DESCRIPTION
Default value set in searchd config, and also by 'set global'. However, per-index config only optimize_cutoff was stored. Now if value is set per-index, it is used both for plain optimize and for KNN cutoff.

ref: https://github.com/manticoresoftware/manticoresearch/issues/4738