### PR TITLE
Build lightweight test-kit Docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -446,8 +446,8 @@ jobs:
       MCL_RUNTIME_ARTIFACT_NAME: mcl_runtime_linux_debug_x86_64
 
   build_linux_release:
-    if: needs.meta.outputs.run_builds == 'true'
-    needs: [meta]
+    if: always() && needs.meta.outputs.run_builds == 'true' && (needs.mcl_cached_package_jammy.result == 'success' || needs.mcl_package_jammy.result == 'success')
+    needs: [meta, mcl_cached_package_jammy, mcl_package_jammy]
     name: Linux release build
     uses: ./.github/workflows/build_template.yml
     secrets: inherit
@@ -455,32 +455,15 @@ jobs:
       artifact_name: release_build
       cache_key: build_linux_release_x86_64
       artifact_list: "build/xml build/CMakeFiles/CMake*.log build/api/libsphinxclient/testcli build/src/indexer build/src/indextool build/src/searchd build/src/tests build/src/gtests/gmanticoretest build/config/*.c build/config/*.h build/**/*.cxx build/**/*.gcno build/manticore*deb"
+      MCL_PACKAGE_ARTIFACT_NAME: mcl_package_jammy_x86_64
+      MCL_PACKAGE_SHA: ${{ needs.meta.outputs.mcl_full_sha }}
       cmake_command: |
         export CMAKE_TOOLCHAIN_FILE=$(pwd)/dist/build_dockers/cross/linux.cmake
         export PACK=1
         export PACK_KEEP_TESTS=1
         ctest -VV -S misc/ctest/gltest.cmake --no-compress-output
+        cmake -S . -B build -DPACK_BUNDLE=1
         cmake --build build --target package
-
-  build_linux_bundle:
-    if: always() && needs.meta.outputs.run_builds == 'true' && (needs.mcl_cached_package_jammy.result == 'success' || needs.mcl_package_jammy.result == 'success')
-    needs: [meta, mcl_test_package_cache_probe, mcl_cached_package_jammy, mcl_package_jammy]
-    name: Linux bundle package
-    uses: ./.github/workflows/build_template.yml
-    secrets: inherit
-    with:
-      artifact_name: linux_bundle_package
-      cache_key: build_linux_bundle_x86_64
-      artifact_list: "build/manticore_*_amd64.deb"
-      MCL_PACKAGE_ARTIFACT_NAME: mcl_package_jammy_x86_64
-      MCL_PACKAGE_SHA: ${{ needs.meta.outputs.mcl_full_sha }}
-      MCL_REPO_TYPE: dev
-      cmake_command: |
-        mkdir build
-        cd build
-        export BUNDLE_REPO_TYPE=dev
-        cmake -DPACK=1 -DPACK_BUNDLE=1 ..
-        cmake --build . --target package
 
   build_linux_release_tests:
     if: needs.meta.outputs.run_builds == 'true'
@@ -1022,62 +1005,29 @@ jobs:
         with:
           name: test_kit_light_docker
           path: .
-      - name: Load light image
-        run: gzip -dc test_kit_light_docker.tar.gz | docker load
       - name: Calculate short commit hash
         id: sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Pushing docker image to repo
         id: test-kit-push
-        env:
-          TEST_RESULT: ${{ needs.clt.result }}
-          BUILD_COMMIT: ${{ steps.sha.outputs.sha_short }}
         run: |
-          /bin/bash dist/test_kit_docker_push.sh
+          TEST_RESULT=${{ needs.clt.result }} BUILD_COMMIT=${{ steps.sha.outputs.sha_short }} /bin/bash dist/test_kit_docker_push.sh
 
   test_kit_light_docker_build:
-    if: always() && needs.meta.outputs.run_builds == 'true' && needs.build_linux_bundle.result == 'success'
-    needs: [meta, build_linux_bundle]
+    if: always() && needs.meta.outputs.run_builds == 'true' && needs.build_linux_release.result == 'success'
+    needs: [meta, build_linux_release]
     name: Light Test Kit docker image build
     runs-on: ubuntu-22.04
-    env:
-      REPO_OWNER: ${{ github.repository_owner }}
-      BRANCH_TAG: ${{ needs.meta.outputs.branch_tag }}
-      EXPECTED_COMMIT: ${{ github.sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
       - name: Download bundle package
         uses: manticoresoftware/download_artifact_with_retries@v5
         with:
-          name: linux_bundle_package
+          name: release_build
           path: ./bundle-package
-      - name: Unpack bundle package
-        run: |
-          set -euo pipefail
-          if [[ -f bundle-package/artifact.tar ]]; then
-            tar -xf bundle-package/artifact.tar -C bundle-package
-          fi
-          find bundle-package -type f -name 'manticore*.deb' -print | sort
-      - name: Resolve image tags
-        id: tags
-        run: |
-          set -euo pipefail
-          short_sha="$(git rev-parse --short HEAD)"
-          echo "commit=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${short_sha}" >> "$GITHUB_OUTPUT"
-          echo "branch=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
       - name: Build and verify official-style image
-        env:
-          IMAGE_COMMIT: ${{ steps.tags.outputs.commit }}
-          IMAGE_BRANCH: ${{ steps.tags.outputs.branch }}
         run: ./dist/test_kit_light_docker_build.sh bundle-package
-      - name: Save light image
-        env:
-          IMAGE_COMMIT: ${{ steps.tags.outputs.commit }}
-          IMAGE_BRANCH: ${{ steps.tags.outputs.branch }}
-        run: |
-          set -euo pipefail
-          docker save "$IMAGE_COMMIT" "$IMAGE_BRANCH" | gzip -1 > test_kit_light_docker.tar.gz
       - name: Upload light image artifact
         uses: actions/upload-artifact@v6
         with:
@@ -1214,7 +1164,6 @@ jobs:
       - test_windows_plain
       - test_windows_rt
       - test_windows_mcl
-      - build_linux_bundle
       - test_kit_light_docker_build
       - build_freebsd
       - build_aarch64
@@ -1247,7 +1196,6 @@ jobs:
             "test_windows_plain:${{ needs.test_windows_plain.result }}:${{ needs.test_windows_plain.outputs.test_outcome }}"
             "test_windows_rt:${{ needs.test_windows_rt.result }}:${{ needs.test_windows_rt.outputs.test_outcome }}"
             "test_windows_mcl:${{ needs.test_windows_mcl.result }}:${{ needs.test_windows_mcl.outputs.test_outcome }}"
-            "build_linux_bundle:${{ needs.build_linux_bundle.result }}"
             "test_kit_light_docker_build:${{ needs.test_kit_light_docker_build.result }}"
             "build_freebsd:${{ needs.build_freebsd.result }}"
             "build_aarch64:${{ needs.build_aarch64.result }}"
@@ -1301,10 +1249,6 @@ jobs:
             fi
           fi
           if [[ "${{ needs.meta.outputs.run_builds }}" == "true" ]]; then
-            if [[ "${{ needs.build_linux_bundle.result }}" != "success" ]]; then
-              echo "build_linux_bundle: required but result was ${{ needs.build_linux_bundle.result }}"
-              failed=1
-            fi
             if [[ "${{ needs.test_kit_light_docker_build.result }}" != "success" ]]; then
               echo "test_kit_light_docker_build: required but result was ${{ needs.test_kit_light_docker_build.result }}"
               failed=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1319,7 +1319,7 @@ jobs:
           echo "* Overall: success" >> "$GITHUB_STEP_SUMMARY"
 
   test_kit_light_docker_push:
-    if: needs.final_status.result == 'success' && needs.meta.outputs.run_builds == 'true'
+    if: always() && needs.final_status.result == 'success' && needs.meta.outputs.run_builds == 'true' && needs.test_kit_light_docker_build.result == 'success'
     needs: [final_status, meta, test_kit_light_docker_build]
     name: Push Light Test Kit docker image
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1026,7 +1026,7 @@ jobs:
         with:
           name: release_build
           path: ./bundle-package
-      - name: Build and verify official-style image
+      - name: Build official-style image
         run: ./dist/test_kit_light_docker_build.sh bundle-package
       - name: Upload light image artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -462,6 +462,26 @@ jobs:
         ctest -VV -S misc/ctest/gltest.cmake --no-compress-output
         cmake --build build --target package
 
+  build_linux_bundle:
+    if: always() && needs.meta.outputs.run_builds == 'true' && (needs.mcl_cached_package_jammy.result == 'success' || needs.mcl_package_jammy.result == 'success')
+    needs: [meta, mcl_test_package_cache_probe, mcl_cached_package_jammy, mcl_package_jammy]
+    name: Linux bundle package
+    uses: ./.github/workflows/build_template.yml
+    secrets: inherit
+    with:
+      artifact_name: linux_bundle_package
+      cache_key: build_linux_bundle_x86_64
+      artifact_list: "build/manticore_*_amd64.deb"
+      MCL_PACKAGE_ARTIFACT_NAME: mcl_package_jammy_x86_64
+      MCL_PACKAGE_SHA: ${{ needs.meta.outputs.mcl_full_sha }}
+      MCL_REPO_TYPE: dev
+      cmake_command: |
+        mkdir build
+        cd build
+        export BUNDLE_REPO_TYPE=dev
+        cmake -DPACK=1 -DPACK_BUNDLE=1 ..
+        cmake --build . --target package
+
   build_linux_release_tests:
     if: needs.meta.outputs.run_builds == 'true'
     needs: [meta]
@@ -1004,6 +1024,56 @@ jobs:
         run: |
           TEST_RESULT=${{ needs.clt.result }} BUILD_COMMIT=${{ steps.sha.outputs.sha_short }} /bin/bash dist/test_kit_docker_push.sh
 
+  test_kit_light_docker_build:
+    if: always() && needs.meta.outputs.run_builds == 'true' && needs.build_linux_bundle.result == 'success'
+    needs: [meta, build_linux_bundle]
+    name: Light Test Kit docker image build
+    runs-on: ubuntu-22.04
+    env:
+      REPO_OWNER: ${{ github.repository_owner }}
+      BRANCH_TAG: ${{ needs.meta.outputs.branch_tag }}
+      EXPECTED_COMMIT: ${{ github.sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Download bundle package
+        uses: manticoresoftware/download_artifact_with_retries@v5
+        with:
+          name: linux_bundle_package
+          path: ./bundle-package
+      - name: Unpack bundle package
+        run: |
+          set -euo pipefail
+          if [[ -f bundle-package/artifact.tar ]]; then
+            tar -xf bundle-package/artifact.tar -C bundle-package
+          fi
+          find bundle-package -type f -name 'manticore*.deb' -print | sort
+      - name: Resolve image tags
+        id: tags
+        run: |
+          set -euo pipefail
+          short_sha="$(git rev-parse --short HEAD)"
+          echo "commit=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "branch=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Build and verify official-style image
+        env:
+          IMAGE_COMMIT: ${{ steps.tags.outputs.commit }}
+          IMAGE_BRANCH: ${{ steps.tags.outputs.branch }}
+        run: ./dist/test_kit_light_docker_build.sh bundle-package
+      - name: Save light image
+        env:
+          IMAGE_COMMIT: ${{ steps.tags.outputs.commit }}
+          IMAGE_BRANCH: ${{ steps.tags.outputs.branch }}
+        run: |
+          set -euo pipefail
+          docker save "$IMAGE_COMMIT" "$IMAGE_BRANCH" | gzip -1 > test_kit_light_docker.tar.gz
+      - name: Upload light image artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: test_kit_light_docker
+          path: test_kit_light_docker.tar.gz
+          compression-level: 0
+
   build_aarch64:
     if: needs.meta.outputs.run_builds == 'true'
     needs: [meta]
@@ -1133,6 +1203,8 @@ jobs:
       - test_windows_plain
       - test_windows_rt
       - test_windows_mcl
+      - build_linux_bundle
+      - test_kit_light_docker_build
       - build_freebsd
       - build_aarch64
       - clt
@@ -1164,6 +1236,8 @@ jobs:
             "test_windows_plain:${{ needs.test_windows_plain.result }}:${{ needs.test_windows_plain.outputs.test_outcome }}"
             "test_windows_rt:${{ needs.test_windows_rt.result }}:${{ needs.test_windows_rt.outputs.test_outcome }}"
             "test_windows_mcl:${{ needs.test_windows_mcl.result }}:${{ needs.test_windows_mcl.outputs.test_outcome }}"
+            "build_linux_bundle:${{ needs.build_linux_bundle.result }}"
+            "test_kit_light_docker_build:${{ needs.test_kit_light_docker_build.result }}"
             "build_freebsd:${{ needs.build_freebsd.result }}"
             "build_aarch64:${{ needs.build_aarch64.result }}"
           )
@@ -1216,6 +1290,14 @@ jobs:
             fi
           fi
           if [[ "${{ needs.meta.outputs.run_builds }}" == "true" ]]; then
+            if [[ "${{ needs.build_linux_bundle.result }}" != "success" ]]; then
+              echo "build_linux_bundle: required but result was ${{ needs.build_linux_bundle.result }}"
+              failed=1
+            fi
+            if [[ "${{ needs.test_kit_light_docker_build.result }}" != "success" ]]; then
+              echo "test_kit_light_docker_build: required but result was ${{ needs.test_kit_light_docker_build.result }}"
+              failed=1
+            fi
             for entry in "${runtime_results[@]}"; do
               name="${entry%%:*}"
               rest="${entry#*:}"
@@ -1235,3 +1317,44 @@ jobs:
             exit 1
           fi
           echo "* Overall: success" >> "$GITHUB_STEP_SUMMARY"
+
+  test_kit_light_docker_push:
+    if: needs.final_status.result == 'success' && needs.meta.outputs.run_builds == 'true'
+    needs: [final_status, meta, test_kit_light_docker_build]
+    name: Push Light Test Kit docker image
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Download light image artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: test_kit_light_docker
+          path: .
+      - name: Load light image
+        run: gzip -dc test_kit_light_docker.tar.gz | docker load
+      - name: Resolve image tags
+        id: tags
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          BRANCH_TAG: ${{ needs.meta.outputs.branch_tag }}
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA:0:7}"
+          echo "commit=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${short_sha}" >> "$GITHUB_OUTPUT"
+          echo "branch=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
+      - name: Log in to GHCR
+        env:
+          GHCR_USER: ${{ vars.GHCR_USER || github.actor }}
+          GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD || github.token }}
+        run: echo "$GHCR_PASSWORD" | docker login ghcr.io --username "$GHCR_USER" --password-stdin
+      - name: Push light image tags
+        env:
+          IMAGE_COMMIT: ${{ steps.tags.outputs.commit }}
+          IMAGE_BRANCH: ${{ steps.tags.outputs.branch }}
+        run: |
+          set -euo pipefail
+          docker push "$IMAGE_COMMIT"
+          docker push "$IMAGE_BRANCH"
+          {
+            echo "Pushed light test-kit to $IMAGE_COMMIT"
+            echo "Pushed light test-kit to $IMAGE_BRANCH"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -978,12 +978,13 @@ jobs:
       ref: ${{ github.sha }}
 
   test_kit_docker_push:
-    if: always() && needs.meta.outputs.run_image_push == 'true' && (needs.test_kit_docker_build.result == 'success' || needs.test_kit_docker_reuse.result == 'success')
+    if: always() && needs.meta.outputs.run_image_push == 'true' && (needs.test_kit_docker_build.result == 'success' || needs.test_kit_docker_reuse.result == 'success') && needs.test_kit_light_docker_build.result == 'success'
     needs:
       - clt
       - meta
       - test_kit_docker_build
       - test_kit_docker_reuse
+      - test_kit_light_docker_build
       - test_linux_debug_plain
       - test_linux_debug_rt
       - test_linux_debug_mcl
@@ -1016,13 +1017,23 @@ jobs:
           if [[ -f artifact.tar ]]; then
             tar -xf artifact.tar
           fi
+      - name: Download light image artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: test_kit_light_docker
+          path: .
+      - name: Load light image
+        run: gzip -dc test_kit_light_docker.tar.gz | docker load
       - name: Calculate short commit hash
         id: sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Pushing docker image to repo
         id: test-kit-push
+        env:
+          TEST_RESULT: ${{ needs.clt.result }}
+          BUILD_COMMIT: ${{ steps.sha.outputs.sha_short }}
         run: |
-          TEST_RESULT=${{ needs.clt.result }} BUILD_COMMIT=${{ steps.sha.outputs.sha_short }} /bin/bash dist/test_kit_docker_push.sh
+          /bin/bash dist/test_kit_docker_push.sh
 
   test_kit_light_docker_build:
     if: always() && needs.meta.outputs.run_builds == 'true' && needs.build_linux_bundle.result == 'success'
@@ -1317,44 +1328,3 @@ jobs:
             exit 1
           fi
           echo "* Overall: success" >> "$GITHUB_STEP_SUMMARY"
-
-  test_kit_light_docker_push:
-    if: always() && needs.final_status.result == 'success' && needs.meta.outputs.run_builds == 'true' && needs.test_kit_light_docker_build.result == 'success'
-    needs: [final_status, meta, test_kit_light_docker_build]
-    name: Push Light Test Kit docker image
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Download light image artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: test_kit_light_docker
-          path: .
-      - name: Load light image
-        run: gzip -dc test_kit_light_docker.tar.gz | docker load
-      - name: Resolve image tags
-        id: tags
-        env:
-          REPO_OWNER: ${{ github.repository_owner }}
-          BRANCH_TAG: ${{ needs.meta.outputs.branch_tag }}
-        run: |
-          set -euo pipefail
-          short_sha="${GITHUB_SHA:0:7}"
-          echo "commit=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${short_sha}" >> "$GITHUB_OUTPUT"
-          echo "branch=ghcr.io/${REPO_OWNER}/manticoresearch:test-kit-light-${BRANCH_TAG}" >> "$GITHUB_OUTPUT"
-      - name: Log in to GHCR
-        env:
-          GHCR_USER: ${{ vars.GHCR_USER || github.actor }}
-          GHCR_PASSWORD: ${{ secrets.GHCR_PASSWORD || github.token }}
-        run: echo "$GHCR_PASSWORD" | docker login ghcr.io --username "$GHCR_USER" --password-stdin
-      - name: Push light image tags
-        env:
-          IMAGE_COMMIT: ${{ steps.tags.outputs.commit }}
-          IMAGE_BRANCH: ${{ steps.tags.outputs.branch }}
-        run: |
-          set -euo pipefail
-          docker push "$IMAGE_COMMIT"
-          docker push "$IMAGE_BRANCH"
-          {
-            echo "Pushed light test-kit to $IMAGE_COMMIT"
-            echo "Pushed light test-kit to $IMAGE_BRANCH"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/dist/test_kit_docker_push.sh
+++ b/dist/test_kit_docker_push.sh
@@ -78,8 +78,13 @@ docker import \
 [ -n "$img_url_branch" ] && docker tag "$img_url" "$img_url_branch"
 [ -n "$img_url_hash" ] && docker tag "$img_url" "$img_url_hash"
 
+light_images=(
+	"${hub_repo}:test-kit-light-${BUILD_COMMIT}"
+	"${hub_repo}:test-kit-light-${BRANCH_TAG}"
+)
+
 # pusing to ghcr.io
-[ -n "$GHCR_USER" ] && for img in "$img_url" "$img_url_latest" "$img_url_tag" "$img_url_branch" "$img_url_hash"; do
+[ -n "$GHCR_USER" ] && for img in "$img_url" "$img_url_latest" "$img_url_tag" "$img_url_branch" "$img_url_hash" "${light_images[@]}"; do
 	[ -n "$img" ] || continue
 	docker push "$img" \
 	  && echo "❗ Pushed the image to $img" \

--- a/dist/test_kit_docker_push.sh
+++ b/dist/test_kit_docker_push.sh
@@ -78,10 +78,9 @@ docker import \
 [ -n "$img_url_branch" ] && docker tag "$img_url" "$img_url_branch"
 [ -n "$img_url_hash" ] && docker tag "$img_url" "$img_url_hash"
 
-light_images=(
-	"${hub_repo}:test-kit-light-${BUILD_COMMIT}"
-	"${hub_repo}:test-kit-light-${BRANCH_TAG}"
-)
+docker load -i test_kit_light_docker.tar.gz
+light_images=( "${hub_repo}:test-kit-light-${BUILD_COMMIT}" "${hub_repo}:test-kit-light-${BRANCH_TAG}" )
+for img in "${light_images[@]}"; do docker tag test-kit-light:img "$img"; done
 
 # pusing to ghcr.io
 [ -n "$GHCR_USER" ] && for img in "$img_url" "$img_url_latest" "$img_url_tag" "$img_url_branch" "$img_url_hash" "${light_images[@]}"; do

--- a/dist/test_kit_light_docker_build.sh
+++ b/dist/test_kit_light_docker_build.sh
@@ -6,10 +6,8 @@ bundle_dir="${1:?Usage: $0 <bundle-package-directory>}"
 
 work_dir="$(mktemp -d)"
 container="manticore-light-smoke-$$"
-server_pid=""
 cleanup() {
   docker rm -f "$container" >/dev/null 2>&1 || true
-  [[ -z "$server_pid" ]] || { kill "$server_pid" >/dev/null 2>&1 || true; wait "$server_pid" 2>/dev/null || true; }
   rm -rf "$work_dir"
 }
 trap cleanup EXIT
@@ -18,16 +16,15 @@ trap cleanup EXIT
 package="$(find "$bundle_dir" -type f -name 'manticore_[0-9]*_amd64.deb' -print -quit)"
 [[ -n "$package" ]] || { echo "Bundle package not found" >&2; exit 1; }
 
-mkdir "$work_dir/http"
-cp "$package" "$work_dir/http/manticore_test-kit_amd64.deb"
 docker_ref=6132e279e57e1ebe226e90d27ee2ba9676a19251
 curl -fsSL "https://github.com/manticoresoftware/docker/archive/$docker_ref.tar.gz" | tar -xz -C "$work_dir"
+docker_dir="$work_dir/docker-$docker_ref"
+cp "$package" "$docker_dir/manticore_test-kit_amd64.deb"
+sed -i.bak "s/^#ADD \\*deb /ADD *deb /; s/^ENV DAEMON_URL .*/ENV DAEMON_URL \${DAEMON_URL}/" "$docker_dir/Dockerfile"
+rm "$docker_dir/Dockerfile.bak"
 
-python3 -m http.server 18080 --bind 0.0.0.0 --directory "$work_dir/http" >"$work_dir/http.log" 2>&1 &
-server_pid=$!
-docker build --platform linux/amd64 --add-host host.docker.internal:host-gateway \
-  --build-arg DEV=0 --build-arg DAEMON_URL=http://host.docker.internal:18080/manticore_test-kit__ARCH_64.deb \
-  --tag test-kit-light:img "$work_dir/docker-$docker_ref"
+docker build --platform linux/amd64 --build-arg DEV=0 --build-arg DAEMON_URL= \
+  --tag test-kit-light:img "$docker_dir"
 
 docker run --detach --name "$container" test-kit-light:img >/dev/null
 for _ in {1..60}; do

--- a/dist/test_kit_light_docker_build.sh
+++ b/dist/test_kit_light_docker_build.sh
@@ -2,115 +2,40 @@
 set -euo pipefail
 
 bundle_dir="${1:?Usage: $0 <bundle-package-directory>}"
-: "${IMAGE_COMMIT:?IMAGE_COMMIT must be set}"
-: "${IMAGE_BRANCH:?IMAGE_BRANCH must be set}"
-
-docker_repo="${DOCKER_REPO:-https://github.com/manticoresoftware/docker.git}"
-docker_ref="${DOCKER_REF:-6132e279e57e1ebe226e90d27ee2ba9676a19251}"
-http_port="${HTTP_PORT:-18080}"
-expected_commit="${EXPECTED_COMMIT:-}"
-expected_commit="${expected_commit:0:7}"
+: "${GITHUB_SHA:?GITHUB_SHA must be set}"
 
 work_dir="$(mktemp -d)"
 container="manticore-light-smoke-$$"
 server_pid=""
-
 cleanup() {
   docker rm -f "$container" >/dev/null 2>&1 || true
-  if [[ -n "$server_pid" ]]; then
-    kill "$server_pid" >/dev/null 2>&1 || true
-    wait "$server_pid" 2>/dev/null || true
-  fi
+  [[ -z "$server_pid" ]] || { kill "$server_pid" >/dev/null 2>&1 || true; wait "$server_pid" 2>/dev/null || true; }
   rm -rf "$work_dir"
 }
 trap cleanup EXIT
 
-bundle_packages=()
-while IFS= read -r package; do
-  bundle_packages+=("$package")
-done < <(find "$bundle_dir" -type f -name 'manticore_*_amd64.deb' | sort)
+[[ ! -f "$bundle_dir/artifact.tar" ]] || tar -xf "$bundle_dir/artifact.tar" -C "$bundle_dir"
+package="$(find "$bundle_dir" -type f -name 'manticore_[0-9]*_amd64.deb' -print -quit)"
+[[ -n "$package" ]] || { echo "Bundle package not found" >&2; exit 1; }
 
-if [[ "${#bundle_packages[@]}" -ne 1 ]]; then
-  echo "Expected exactly one amd64 Manticore bundle package, found ${#bundle_packages[@]}:" >&2
-  find "$bundle_dir" -type f -name 'manticore*.deb' -print | sort >&2 || true
-  exit 1
-fi
+mkdir "$work_dir/http"
+cp "$package" "$work_dir/http/manticore_test-kit_amd64.deb"
+docker_ref=6132e279e57e1ebe226e90d27ee2ba9676a19251
+curl -fsSL "https://github.com/manticoresoftware/docker/archive/$docker_ref.tar.gz" | tar -xz -C "$work_dir"
 
-bundle_package="${bundle_packages[0]}"
-if ! dpkg-deb -c "$bundle_package" | grep -E '/usr/bin/searchd$' >/dev/null; then
-  echo "Package is not a self-contained Manticore bundle: $bundle_package" >&2
-  exit 1
-fi
-
-http_root="$work_dir/http"
-docker_context="$work_dir/docker"
-mkdir -p "$http_root"
-cp "$bundle_package" "$http_root/manticore_test-kit_amd64.deb"
-
-git init --quiet "$docker_context"
-git -C "$docker_context" remote add origin "$docker_repo"
-git -C "$docker_context" fetch --quiet --depth 1 origin "$docker_ref"
-git -C "$docker_context" checkout --quiet --detach FETCH_HEAD
-resolved_docker_ref="$(git -C "$docker_context" rev-parse HEAD)"
-if [[ "$docker_ref" =~ ^[0-9a-f]{40}$ && "$resolved_docker_ref" != "$docker_ref" ]]; then
-  echo "Expected Docker repository commit $docker_ref, got $resolved_docker_ref" >&2
-  exit 1
-fi
-echo "Using official Docker repository commit $resolved_docker_ref"
-test -f "$docker_context/Dockerfile"
-
-python3 -m http.server "$http_port" --bind 0.0.0.0 --directory "$http_root" >"$work_dir/http.log" 2>&1 &
+python3 -m http.server 18080 --bind 0.0.0.0 --directory "$work_dir/http" >"$work_dir/http.log" 2>&1 &
 server_pid=$!
-for _ in $(seq 1 30); do
-  if curl --fail --silent "http://127.0.0.1:${http_port}/manticore_test-kit_amd64.deb" >/dev/null; then
-    break
-  fi
+docker build --platform linux/amd64 --add-host host.docker.internal:host-gateway \
+  --build-arg DEV=0 --build-arg DAEMON_URL=http://host.docker.internal:18080/manticore_test-kit__ARCH_64.deb \
+  --tag test-kit-light:img "$work_dir/docker-$docker_ref"
+
+docker run --detach --name "$container" test-kit-light:img >/dev/null
+for _ in {1..60}; do
+  docker exec "$container" mysql -e 'SHOW VERSION' >/dev/null 2>&1 && break
   sleep 1
 done
-if ! curl --fail --silent "http://127.0.0.1:${http_port}/manticore_test-kit_amd64.deb" >/dev/null; then
-  cat "$work_dir/http.log" >&2
-  exit 1
-fi
-
-daemon_url="http://host.docker.internal:${http_port}/manticore_test-kit__ARCH_64.deb"
-docker build \
-  --platform linux/amd64 \
-  --add-host host.docker.internal:host-gateway \
-  --build-arg DEV=0 \
-  --build-arg "DAEMON_URL=$daemon_url" \
-  --tag "$IMAGE_COMMIT" \
-  --tag "$IMAGE_BRANCH" \
-  "$docker_context"
-
-kill "$server_pid" >/dev/null 2>&1 || true
-wait "$server_pid" 2>/dev/null || true
-server_pid=""
-
-docker run --detach --name "$container" "$IMAGE_COMMIT" >/dev/null
-ready=false
-for _ in $(seq 1 60); do
-  if docker logs "$container" 2>&1 | grep -q 'accepting connections'; then
-    ready=true
-    break
-  fi
-  if ! docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null | grep -qx true; then
-    break
-  fi
-  sleep 1
-done
-if [[ "$ready" != true ]]; then
-  docker logs "$container" >&2 || true
-  exit 1
-fi
-
-version_output="$(docker exec "$container" searchd --version 2>&1)"
-printf '%s\n' "$version_output"
-if [[ -n "$expected_commit" ]] && ! grep -q "$expected_commit" <<<"$version_output"; then
-  echo "Built image version does not contain expected commit $expected_commit" >&2
-  exit 1
-fi
-
+version="$(docker exec "$container" searchd --version 2>&1)"
+printf '%s\n' "$version"
+grep -q "${GITHUB_SHA:0:7}" <<<"$version"
 docker exec "$container" mysql -e "CREATE TABLE light_smoke(title text); INSERT INTO light_smoke(id,title) VALUES(1,'hello'); SELECT id FROM light_smoke WHERE MATCH('hello')" >/dev/null
-
-echo "Built and verified $IMAGE_COMMIT"
-echo "Built and verified $IMAGE_BRANCH"
+docker save test-kit-light:img | gzip -1 > test_kit_light_docker.tar.gz

--- a/dist/test_kit_light_docker_build.sh
+++ b/dist/test_kit_light_docker_build.sh
@@ -2,12 +2,9 @@
 set -euo pipefail
 
 bundle_dir="${1:?Usage: $0 <bundle-package-directory>}"
-: "${GITHUB_SHA:?GITHUB_SHA must be set}"
 
 work_dir="$(mktemp -d)"
-container="manticore-light-smoke-$$"
 cleanup() {
-  docker rm -f "$container" >/dev/null 2>&1 || true
   rm -rf "$work_dir"
 }
 trap cleanup EXIT
@@ -26,13 +23,4 @@ rm "$docker_dir/Dockerfile.bak"
 docker build --platform linux/amd64 --build-arg DEV=0 --build-arg DAEMON_URL= \
   --tag test-kit-light:img "$docker_dir"
 
-docker run --detach --name "$container" test-kit-light:img >/dev/null
-for _ in {1..60}; do
-  docker exec "$container" mysql -e 'SHOW VERSION' >/dev/null 2>&1 && break
-  sleep 1
-done
-version="$(docker exec "$container" searchd --version 2>&1)"
-printf '%s\n' "$version"
-grep -q "${GITHUB_SHA:0:7}" <<<"$version"
-docker exec "$container" mysql -e "CREATE TABLE light_smoke(title text); INSERT INTO light_smoke(id,title) VALUES(1,'hello'); SELECT id FROM light_smoke WHERE MATCH('hello')" >/dev/null
 docker save test-kit-light:img | gzip -1 > test_kit_light_docker.tar.gz

--- a/dist/test_kit_light_docker_build.sh
+++ b/dist/test_kit_light_docker_build.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -euo pipefail
+
+bundle_dir="${1:?Usage: $0 <bundle-package-directory>}"
+: "${IMAGE_COMMIT:?IMAGE_COMMIT must be set}"
+: "${IMAGE_BRANCH:?IMAGE_BRANCH must be set}"
+
+docker_repo="${DOCKER_REPO:-https://github.com/manticoresoftware/docker.git}"
+docker_ref="${DOCKER_REF:-6132e279e57e1ebe226e90d27ee2ba9676a19251}"
+http_port="${HTTP_PORT:-18080}"
+expected_commit="${EXPECTED_COMMIT:-}"
+expected_commit="${expected_commit:0:7}"
+
+work_dir="$(mktemp -d)"
+container="manticore-light-smoke-$$"
+server_pid=""
+
+cleanup() {
+  docker rm -f "$container" >/dev/null 2>&1 || true
+  if [[ -n "$server_pid" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT
+
+bundle_packages=()
+while IFS= read -r package; do
+  bundle_packages+=("$package")
+done < <(find "$bundle_dir" -type f -name 'manticore_*_amd64.deb' | sort)
+
+if [[ "${#bundle_packages[@]}" -ne 1 ]]; then
+  echo "Expected exactly one amd64 Manticore bundle package, found ${#bundle_packages[@]}:" >&2
+  find "$bundle_dir" -type f -name 'manticore*.deb' -print | sort >&2 || true
+  exit 1
+fi
+
+bundle_package="${bundle_packages[0]}"
+if ! dpkg-deb -c "$bundle_package" | grep -E '/usr/bin/searchd$' >/dev/null; then
+  echo "Package is not a self-contained Manticore bundle: $bundle_package" >&2
+  exit 1
+fi
+
+http_root="$work_dir/http"
+docker_context="$work_dir/docker"
+mkdir -p "$http_root"
+cp "$bundle_package" "$http_root/manticore_test-kit_amd64.deb"
+
+git init --quiet "$docker_context"
+git -C "$docker_context" remote add origin "$docker_repo"
+git -C "$docker_context" fetch --quiet --depth 1 origin "$docker_ref"
+git -C "$docker_context" checkout --quiet --detach FETCH_HEAD
+resolved_docker_ref="$(git -C "$docker_context" rev-parse HEAD)"
+if [[ "$docker_ref" =~ ^[0-9a-f]{40}$ && "$resolved_docker_ref" != "$docker_ref" ]]; then
+  echo "Expected Docker repository commit $docker_ref, got $resolved_docker_ref" >&2
+  exit 1
+fi
+echo "Using official Docker repository commit $resolved_docker_ref"
+test -f "$docker_context/Dockerfile"
+
+python3 -m http.server "$http_port" --bind 0.0.0.0 --directory "$http_root" >"$work_dir/http.log" 2>&1 &
+server_pid=$!
+for _ in $(seq 1 30); do
+  if curl --fail --silent "http://127.0.0.1:${http_port}/manticore_test-kit_amd64.deb" >/dev/null; then
+    break
+  fi
+  sleep 1
+done
+if ! curl --fail --silent "http://127.0.0.1:${http_port}/manticore_test-kit_amd64.deb" >/dev/null; then
+  cat "$work_dir/http.log" >&2
+  exit 1
+fi
+
+daemon_url="http://host.docker.internal:${http_port}/manticore_test-kit__ARCH_64.deb"
+docker build \
+  --platform linux/amd64 \
+  --add-host host.docker.internal:host-gateway \
+  --build-arg DEV=0 \
+  --build-arg "DAEMON_URL=$daemon_url" \
+  --tag "$IMAGE_COMMIT" \
+  --tag "$IMAGE_BRANCH" \
+  "$docker_context"
+
+kill "$server_pid" >/dev/null 2>&1 || true
+wait "$server_pid" 2>/dev/null || true
+server_pid=""
+
+docker run --detach --name "$container" "$IMAGE_COMMIT" >/dev/null
+ready=false
+for _ in $(seq 1 60); do
+  if docker logs "$container" 2>&1 | grep -q 'accepting connections'; then
+    ready=true
+    break
+  fi
+  if ! docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null | grep -qx true; then
+    break
+  fi
+  sleep 1
+done
+if [[ "$ready" != true ]]; then
+  docker logs "$container" >&2 || true
+  exit 1
+fi
+
+version_output="$(docker exec "$container" searchd --version 2>&1)"
+printf '%s\n' "$version_output"
+if [[ -n "$expected_commit" ]] && ! grep -q "$expected_commit" <<<"$version_output"; then
+  echo "Built image version does not contain expected commit $expected_commit" >&2
+  exit 1
+fi
+
+docker exec "$container" mysql -e "CREATE TABLE light_smoke(title text); INSERT INTO light_smoke(id,title) VALUES(1,'hello'); SELECT id FROM light_smoke WHERE MATCH('hello')" >/dev/null
+
+echo "Built and verified $IMAGE_COMMIT"
+echo "Built and verified $IMAGE_BRANCH"


### PR DESCRIPTION
- build an exact-MCL Manticore bundle alongside the existing test-kit image
- build it with a pinned, unchanged official Dockerfile
- publish only `test-kit-light-<short-sha>` and `test-kit-light-<branch>` after the existing final test gate succeeds