### PR TITLE
🆕 Update buddy version from 4.4.0 to 4.4.1

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.2+26072909-4693a185-dev
-buddy 4.4.1+26081318-a3f8fe36-dev
+buddy 4.4.1+26081318-a3f8fe36
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.25.0+26050511-832198ca-dev

--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.2+26072909-4693a185-dev
-buddy 4.4.0+26080716-c069f815-dev
+buddy 4.4.1+26081318-a3f8fe36-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.25.0+26050511-832198ca-dev


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 4.4.0 to 4.4.1 which includes:

[`a3f8fe3`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/a3f8fe36626990bbdd3ad8bc8ef506a9b81261db) fix: JDBC driver support (#694)
