### PR TITLE
🆕 Update backup version from 1.10.2 to 1.10.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,4 +1,4 @@
-backup 1.10.3+26081411-8d2f5d5f
+backup 1.10.3+26081411-8d2f5d5f-dev
 buddy 4.4.0+26080716-c069f815-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa

--- a/deps.txt
+++ b/deps.txt
@@ -1,4 +1,4 @@
-backup 1.10.3+26081311-bae4430e-dev
+backup 1.10.3+26081411-8d2f5d5f
 buddy 4.4.0+26080716-c069f815-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa

--- a/deps.txt
+++ b/deps.txt
@@ -1,4 +1,4 @@
-backup 1.10.2+26072909-4693a185-dev
+backup 1.10.3+26081311-bae4430e-dev
 buddy 4.4.0+26080716-c069f815-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [backup](https://github.com/manticoresoftware/manticoresearch-backup) version from 1.10.2 to 1.10.3 which includes:

[`8d2f5d5`](https://github.com/manticoresoftware/manticoresearch-backup/commit/8d2f5d5f3df0833f1e4c2568e8bf53ce761b48e6) ci: semver couldn't create a tag since it didn't have the token
