### PR TITLE
fix: add binlog replay recovery hints

### DIFF
--- a/src/binlog.cpp
+++ b/src/binlog.cpp
@@ -1548,7 +1548,7 @@ BinlogFileState_e Binlog_c::ReplayBinlog ( BinlogReplayFileDesc_t & tLog, const 
 	BinlogReader_c tReader;
 	if ( !tReader.Open ( sLog, sError ) )
 	{
-		Log ( REPLAY_IGNORE_OPEN_ERROR, "binlog: log open error: %s", sError.cstr() );
+		Log ( REPLAY_IGNORE_OPEN_ERROR, "binlog: log open error: %s; use --replay-flags=ignore-open-errors to skip missing binlog files", sError.cstr() );
 		return BinlogFileState_e::ERROR_NON_READABLE;
 	}
 
@@ -1875,7 +1875,7 @@ bool Binlog_c::ReplayTxn ( const BinlogReplayFileDesc_t & tLog, BinlogReader_c &
 	// could be invalid TXN in binlog
 	if ( !tReplayed.m_bValid )
 	{
-		Log ( REPLAY_IGNORE_TRX_ERROR, "binlog: %s (table=%s, lasttid=" INT64_FMT ", logtid=" INT64_FMT ", pos=" INT64_FMT ", error=%s)",
+		Log ( REPLAY_IGNORE_TRX_ERROR, "binlog: %s (table=%s, lasttid=" INT64_FMT ", logtid=" INT64_FMT ", pos=" INT64_FMT ", error=%s); use --replay-flags=ignore-trx-errors to skip binlog transaction replay errors",
 			  sOp.cstr (), tIndex.m_sName.cstr(), tIndex.m_iMaxTID, iTID, iTxnPos, sError.cstr() );
 		return false;
 	}

--- a/test/clt-tests/bugs/4811-binlog-open-error-replay-flags-hint.rec
+++ b/test/clt-tests/bugs/4811-binlog-open-error-replay-flags-hint.rec
@@ -29,7 +29,7 @@ if mysql --ssl-mode=DISABLED -h127.0.0.1 -P9306 -e "INSERT INTO t(id,f) VALUES(1
 inserted
 removed_missing_binlog
 ––– input –––
-set +e; stdbuf -oL searchd --config /tmp/issue-4811-binlog/manticore.conf >/tmp/issue-4811-binlog/start2.out 2>&1; rc=$?; set -e; if [ "$rc" -ne 0 ] && grep -q -- '--replay-flags=ignore-open-errors' /tmp/issue-4811-binlog/searchd.log /tmp/issue-4811-binlog/start2.out; then echo replay_hint_logged; else echo "unexpected rc=$rc"; cat /tmp/issue-4811-binlog/start2.out; tail -100 /tmp/issue-4811-binlog/searchd.log; fi
+stdbuf -oL searchd --config /tmp/issue-4811-binlog/manticore.conf >/tmp/issue-4811-binlog/start2.out 2>&1 || true; for i in $(seq 1 50); do grep -q -- '--replay-flags=ignore-open-errors' /tmp/issue-4811-binlog/searchd.log /tmp/issue-4811-binlog/start2.out 2>/dev/null && break; sleep 0.1; done; if grep -q -- '--replay-flags=ignore-open-errors' /tmp/issue-4811-binlog/searchd.log /tmp/issue-4811-binlog/start2.out 2>/dev/null; then echo replay_hint_logged; else echo missing_replay_hint; cat /tmp/issue-4811-binlog/start2.out; tail -100 /tmp/issue-4811-binlog/searchd.log; fi
 ––– output –––
 replay_hint_logged
 ––– input –––

--- a/test/clt-tests/bugs/4811-binlog-open-error-replay-flags-hint.rec
+++ b/test/clt-tests/bugs/4811-binlog-open-error-replay-flags-hint.rec
@@ -1,0 +1,38 @@
+––– comment –––
+Issue #4811 regression: when binlog replay fails because a referenced binlog file is missing, the fatal log must mention the recovery flag users can choose explicitly: --replay-flags=ignore-open-errors.
+––– input –––
+rm -rf /tmp/issue-4811-binlog; mkdir -p /tmp/issue-4811-binlog/data /tmp/issue-4811-binlog/binlog; cat > /tmp/issue-4811-binlog/manticore.conf <<'EOF'
+index t
+{
+    type = rt
+    path = /tmp/issue-4811-binlog/data/t
+    rt_field = f
+}
+
+searchd
+{
+    listen = 127.0.0.1:9306:mysql41
+    log = /tmp/issue-4811-binlog/searchd.log
+    query_log = /tmp/issue-4811-binlog/query.log
+    pid_file = /tmp/issue-4811-binlog/searchd.pid
+    binlog_path = /tmp/issue-4811-binlog/binlog
+    binlog_common = 1
+    watchdog = 0
+}
+EOF
+stdbuf -oL searchd --config /tmp/issue-4811-binlog/manticore.conf --stopwait >/dev/null 2>&1 || true; stdbuf -oL searchd --config /tmp/issue-4811-binlog/manticore.conf >/tmp/issue-4811-binlog/start1.out 2>&1; for i in $(seq 1 100); do mysql --ssl-mode=DISABLED -h127.0.0.1 -P9306 -e 'SELECT 1' >/dev/null 2>&1 && { echo ready; break; }; sleep 0.1; done
+––– output –––
+ready
+––– input –––
+if mysql --ssl-mode=DISABLED -h127.0.0.1 -P9306 -e "INSERT INTO t(id,f) VALUES(1,'alpha'); SELECT COUNT(*) FROM t;" >/tmp/issue-4811-binlog/insert.out 2>&1; then echo inserted; else cat /tmp/issue-4811-binlog/insert.out; fi; pid=$(cat /tmp/issue-4811-binlog/searchd.pid); kill -9 "$pid"; for i in $(seq 1 50); do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done; missing=$(find /tmp/issue-4811-binlog/binlog -type f -name 'binlog.*' ! -name '*.meta' | sort | head -1); if [ -n "$missing" ]; then rm -f "$missing"; echo removed_missing_binlog; else echo no_binlog_file; find /tmp/issue-4811-binlog -maxdepth 4 -type f | sort; fi
+––– output –––
+inserted
+removed_missing_binlog
+––– input –––
+set +e; stdbuf -oL searchd --config /tmp/issue-4811-binlog/manticore.conf >/tmp/issue-4811-binlog/start2.out 2>&1; rc=$?; set -e; if [ "$rc" -ne 0 ] && grep -q -- '--replay-flags=ignore-open-errors' /tmp/issue-4811-binlog/searchd.log /tmp/issue-4811-binlog/start2.out; then echo replay_hint_logged; else echo "unexpected rc=$rc"; cat /tmp/issue-4811-binlog/start2.out; tail -100 /tmp/issue-4811-binlog/searchd.log; fi
+––– output –––
+replay_hint_logged
+––– input –––
+stdbuf -oL searchd --config /tmp/issue-4811-binlog/manticore.conf --stopwait >/dev/null 2>&1 || true; rm -rf /tmp/issue-4811-binlog; echo cleaned
+––– output –––
+cleaned

--- a/test/clt-tests/bugs/4811-binlog-trx-error-replay-flags-hint.rec
+++ b/test/clt-tests/bugs/4811-binlog-trx-error-replay-flags-hint.rec
@@ -29,7 +29,7 @@ if mysql --ssl-mode=DISABLED -h127.0.0.1 -P9306 -e "INSERT INTO products(id,name
 inserted
 truncated_binlog
 ––– input –––
-set +e; stdbuf -oL searchd --config /tmp/issue-4811-binlog-trx/manticore.conf >/tmp/issue-4811-binlog-trx/start2.out 2>&1; rc=$?; set -e; if [ "$rc" -ne 0 ] && grep -q -- '--replay-flags=ignore-trx-errors' /tmp/issue-4811-binlog-trx/searchd.log /tmp/issue-4811-binlog-trx/start2.out; then echo replay_trx_hint_logged; else echo "unexpected rc=$rc"; cat /tmp/issue-4811-binlog-trx/start2.out; tail -100 /tmp/issue-4811-binlog-trx/searchd.log; fi
+stdbuf -oL searchd --config /tmp/issue-4811-binlog-trx/manticore.conf >/tmp/issue-4811-binlog-trx/start2.out 2>&1 || true; for i in $(seq 1 50); do grep -q -- '--replay-flags=ignore-trx-errors' /tmp/issue-4811-binlog-trx/searchd.log /tmp/issue-4811-binlog-trx/start2.out 2>/dev/null && break; sleep 0.1; done; if grep -q -- '--replay-flags=ignore-trx-errors' /tmp/issue-4811-binlog-trx/searchd.log /tmp/issue-4811-binlog-trx/start2.out 2>/dev/null; then echo replay_trx_hint_logged; else echo missing_replay_trx_hint; cat /tmp/issue-4811-binlog-trx/start2.out; tail -100 /tmp/issue-4811-binlog-trx/searchd.log; fi
 ––– output –––
 replay_trx_hint_logged
 ––– input –––

--- a/test/clt-tests/bugs/4811-binlog-trx-error-replay-flags-hint.rec
+++ b/test/clt-tests/bugs/4811-binlog-trx-error-replay-flags-hint.rec
@@ -1,0 +1,38 @@
+––– comment –––
+Issue #4811 related regression: when binlog transaction replay fails on a corrupted/truncated binlog, the fatal log must mention the recovery flag users can choose explicitly: --replay-flags=ignore-trx-errors.
+––– input –––
+rm -rf /tmp/issue-4811-binlog-trx; mkdir -p /tmp/issue-4811-binlog-trx/data /tmp/issue-4811-binlog-trx/binlog; cat > /tmp/issue-4811-binlog-trx/manticore.conf <<'EOF'
+index products
+{
+    type = rt
+    path = /tmp/issue-4811-binlog-trx/data/products
+    rt_field = name
+}
+
+searchd
+{
+    listen = 127.0.0.1:9306:mysql41
+    log = /tmp/issue-4811-binlog-trx/searchd.log
+    query_log = /tmp/issue-4811-binlog-trx/query.log
+    pid_file = /tmp/issue-4811-binlog-trx/searchd.pid
+    binlog_path = /tmp/issue-4811-binlog-trx/binlog
+    binlog_common = 1
+    watchdog = 0
+}
+EOF
+stdbuf -oL searchd --config /tmp/issue-4811-binlog-trx/manticore.conf --stopwait >/dev/null 2>&1 || true; stdbuf -oL searchd --config /tmp/issue-4811-binlog-trx/manticore.conf >/tmp/issue-4811-binlog-trx/start1.out 2>&1; for i in $(seq 1 100); do mysql --ssl-mode=DISABLED -h127.0.0.1 -P9306 -e 'SELECT 1' >/dev/null 2>&1 && { echo ready; break; }; sleep 0.1; done
+––– output –––
+ready
+––– input –––
+if mysql --ssl-mode=DISABLED -h127.0.0.1 -P9306 -e "INSERT INTO products(id,name) VALUES(1,'alpha'),(2,'beta'); SELECT COUNT(*) FROM products;" >/tmp/issue-4811-binlog-trx/insert.out 2>&1; then echo inserted; else cat /tmp/issue-4811-binlog-trx/insert.out; fi; pid=$(cat /tmp/issue-4811-binlog-trx/searchd.pid); kill -9 "$pid"; for i in $(seq 1 50); do kill -0 "$pid" 2>/dev/null || break; sleep 0.1; done; log=$(find /tmp/issue-4811-binlog-trx/binlog -type f -name 'binlog.*' ! -name '*.meta' | sort | head -1); size=$(wc -c < "$log"); keep=$((size-1)); truncate -s "$keep" "$log"; echo truncated_binlog
+––– output –––
+inserted
+truncated_binlog
+––– input –––
+set +e; stdbuf -oL searchd --config /tmp/issue-4811-binlog-trx/manticore.conf >/tmp/issue-4811-binlog-trx/start2.out 2>&1; rc=$?; set -e; if [ "$rc" -ne 0 ] && grep -q -- '--replay-flags=ignore-trx-errors' /tmp/issue-4811-binlog-trx/searchd.log /tmp/issue-4811-binlog-trx/start2.out; then echo replay_trx_hint_logged; else echo "unexpected rc=$rc"; cat /tmp/issue-4811-binlog-trx/start2.out; tail -100 /tmp/issue-4811-binlog-trx/searchd.log; fi
+––– output –––
+replay_trx_hint_logged
+––– input –––
+stdbuf -oL searchd --config /tmp/issue-4811-binlog-trx/manticore.conf --stopwait >/dev/null 2>&1 || true; rm -rf /tmp/issue-4811-binlog-trx; echo cleaned
+––– output –––
+cleaned


### PR DESCRIPTION
Mention the matching --replay-flags value in fatal binlog replay errors for missing log files and transaction replay failures.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4811