### PR TITLE
Bump load version from 1.25.0 to 1.26.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -2,7 +2,7 @@ backup 1.10.3+26081411-8d2f5d5f-dev
 buddy 4.4.1+26081318-a3f8fe36-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
-load 1.25.0+26050511-832198ca-dev
+load 1.26.0+26081813-cadeeb3c-dev
 galera 3.37
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.25.0 to 1.26.0 which includes:

[`cadeeb3`](https://github.com/manticoresoftware/manticore-load/commit/cadeeb3c4262defcde95560a0c07cb742aeefc14) feat: add worker lifecycle SQL hooks
