### PR TITLE
🆕 Update load version from 1.25.0 to 1.26.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.46.3+26051811-3109a9a2-dev
 mcl 13.5.0+26052519-f61b5675-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
-load 1.25.0+26050511-832198ca-dev
+load 1.26.0+26081813-cadeeb3c-dev
 galera 3.37
 ---
 ! Do not change the separator that splits this desc from the data

--- a/deps.txt
+++ b/deps.txt
@@ -3,7 +3,7 @@ buddy 3.46.3+26051811-3109a9a2-dev
 mcl 13.5.0+26052519-f61b5675-dev
 executor 1.4.3+26033010-390b6e66-dev
 tzdata 1.0.1 250714 7eebffa
-load 1.26.0+26081813-cadeeb3c-dev
+load 1.26.0+26081813-fac2ff17-dev
 galera 3.37
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.25.0 to 1.26.0 which includes:

- [`fac2ff1`](https://github.com/manticoresoftware/manticore-load/commit/fac2ff1786e91a96c6f9dff011dc5972d0db06b6) ci: Change update-deps action reference from master to main
- [`cadeeb3`](https://github.com/manticoresoftware/manticore-load/commit/cadeeb3c4262defcde95560a0c07cb742aeefc14) feat: add worker lifecycle SQL hooks

