### PR TITLE
fix: preserve remote embedding key on table copy

### DIFF
--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -7055,6 +7055,22 @@ static CSphString BuildCreateTableRt ( const CSphString & sName, const CSphIndex
 }
 
 
+static void CopyHiddenKNNCreateLikeSettings ( CreateTableSettings_t & tCreateTable, const CSphSchema & tSourceSchema )
+{
+	for ( auto & tAttr : tCreateTable.m_dAttrs )
+	{
+		if ( !tAttr.m_bKNN || tAttr.m_tKNNModel.m_sModelName.empty() || !tAttr.m_tKNNModel.m_sAPIKey.empty() )
+			continue;
+
+		const CSphColumnInfo * pSourceAttr = tSourceSchema.GetAttr ( tAttr.m_tAttr.m_sName.cstr() );
+		if ( !pSourceAttr || pSourceAttr->m_tKNNModel.m_sModelName!=tAttr.m_tKNNModel.m_sModelName )
+			continue;
+
+		tAttr.m_tKNNModel.m_sAPIKey = pSourceAttr->m_tKNNModel.m_sAPIKey;
+	}
+}
+
+
 static void HandleMysqlCreateTableLike ( RowBuffer_i & tOut, const SqlStmt_t & tStmt, CSphString & sWarning )
 {
 	SearchFailuresLog_c dErrors;
@@ -7076,6 +7092,7 @@ static void HandleMysqlCreateTableLike ( RowBuffer_i & tOut, const SqlStmt_t & t
 
 	const CSphString & sLike = tStmt.m_tCreateTable.m_sLike;
 	CSphString sCreateTable;
+	const CSphSchema * pSourceSchema = nullptr;
 	switch ( IndexIsServed ( sLike ) )
 	{
 	case RunIdx_e::NOTSERVED:
@@ -7092,7 +7109,8 @@ static void HandleMysqlCreateTableLike ( RowBuffer_i & tOut, const SqlStmt_t & t
 			return;
 		}
 		RIdx_c pIdx { pServed };
-		sCreateTable = BuildCreateTableRt ( tStmt.m_sIndex, pIdx, GetSchemaForCreateTable ( pIdx ), ExtFilesFormat_e::FILE );
+		pSourceSchema = &GetSchemaForCreateTable ( pIdx );
+		sCreateTable = BuildCreateTableRt ( tStmt.m_sIndex, pIdx, *pSourceSchema, ExtFilesFormat_e::FILE );
 		break;
 	}
 	case RunIdx_e::DISTR:
@@ -7120,6 +7138,8 @@ static void HandleMysqlCreateTableLike ( RowBuffer_i & tOut, const SqlStmt_t & t
 
 	SqlStmt_t & tNewCreateTable = dCreateTableStmts[0];
 	tNewCreateTable.m_tCreateTable.m_bIfNotExists = tStmt.m_tCreateTable.m_bIfNotExists;
+	if ( pSourceSchema )
+		CopyHiddenKNNCreateLikeSettings ( tNewCreateTable.m_tCreateTable, *pSourceSchema );
 
 	HandleMysqlCreateTable ( tOut, tNewCreateTable, sWarning );
 }

--- a/test/clt-tests/mcl/auto-embeddings-alter-rename.rec
+++ b/test/clt-tests/mcl/auto-embeddings-alter-rename.rec
@@ -1,0 +1,53 @@
+Issue #4842: ALTER TABLE ... RENAME must preserve the hidden API key for
+remote OpenAI auto-embedding float_vector columns. SHOW CREATE TABLE intentionally
+omits api_key, and Buddy recreates the destination table through the
+CREATE TABLE ... LIKE path, so the hidden key must be copied from the source schema.
+
+––– comment –––
+Start Manticore Search with Buddy because ALTER TABLE ... RENAME is handled there.
+––– block: ../base/start-searchd-with-buddy –––
+––– block: ./base –––
+––– comment –––
+Create and use the source table with the same real OpenAI API-key pattern as other
+OpenAI remote embedding tests. No local mock or custom API_URL is needed.
+––– input –––
+retry_remote_embedding_create_table "CREATE TABLE issue4842_src (title text, embedding float_vector knn_type='hnsw' hnsw_similarity='cosine' model_name='openai/text-embedding-ada-002' from='title' api_key='${OPENAI_API_KEY}')"; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO issue4842_src (id,title) VALUES (1,'green pear')" 2>&1; echo $?
+––– output –––
+0
+––– comment –––
+The regression happened here: the recreated destination table used to lose api_key
+and fail with "Invalid API key for remote model".
+––– input –––
+mysql -h0 -P9306 -e "ALTER TABLE issue4842_src RENAME issue4842_dst" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SHOW TABLES LIKE 'issue4842%'" 2>&1 | grep -oE 'issue4842_[a-z]+' | sort
+––– output –––
+issue4842_dst
+––– comment –––
+The renamed table must still have the hidden key internally for subsequent
+remote embedding calls, but SHOW CREATE TABLE must not expose it.
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO issue4842_dst (id,title) VALUES (2,'red apple')" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SELECT COUNT(*) as count FROM issue4842_dst"
+––– output –––
++-------+
+| count |
++-------+
+|     2 |
++-------+
+––– input –––
+mysql -h0 -P9306 -E -e "SHOW CREATE TABLE issue4842_dst" 2>&1 | grep -o 'api_key' || echo 'api_key hidden'
+––– output –––
+api_key hidden
+––– input –––
+mysql -h0 -P9306 -e "DROP TABLE IF EXISTS issue4842_dst" >/dev/null 2>&1 || true
+––– output –––


### PR DESCRIPTION
Related issue: http://github.com/manticoresoftware/manticoresearch/issues/4842