### PR TITLE
Keep the docid lookup (.spt) in sync with the index format version on ALTER; repair v70 lookups under a v71 header (#4852)

### DIFF
--- a/src/docidlookup.cpp
+++ b/src/docidlookup.cpp
@@ -885,6 +885,10 @@ static int64_t GetDocidLookupHeaderSize ( DWORD uIndexVersion )
 
 bool CheckDocidLookupFormat ( const BYTE * pData, int64_t iDataLen, DWORD uIndexVersion, CSphString & sError )
 {
+	// older layouts (a 2019 lookup is 10 bytes) were never validated; keep reading them as before
+	if ( uIndexVersion<DOCID_LOOKUP_SPLIT_VERSION )
+		return true;
+
 	int64_t iHeader = GetDocidLookupHeaderSize ( uIndexVersion );
 	if ( !pData || iDataLen<iHeader )
 	{
@@ -944,7 +948,8 @@ DWORD DetectDocidLookupVersion ( const BYTE * pData, int64_t iDataLen )
 
 bool UpgradeDocidLookupFile ( const CSphString & sFilename, DWORD uIndexVersion, CSphString & sError )
 {
-	if ( uIndexVersion>=DOCID_LOOKUP_UUID_VERSION )
+	// current layout already, or a legacy layout we do not convert (it is read as-is, see CheckDocidLookupFormat)
+	if ( uIndexVersion>=DOCID_LOOKUP_UUID_VERSION || uIndexVersion<DOCID_LOOKUP_SPLIT_VERSION )
 		return true;
 
 	CSphMappedBuffer<BYTE> tOld;

--- a/src/docidlookup.cpp
+++ b/src/docidlookup.cpp
@@ -876,6 +876,133 @@ bool DocidLookupWriter_c::Finalize ( CSphString & sError )
 	return true;
 }
 
+static int64_t GetDocidLookupHeaderSize ( DWORD uIndexVersion )
+{
+	// docs, docs per checkpoint, max docid [, uuid entries offset]
+	return sizeof(DWORD)*2 + sizeof(DocID_t) + ( uIndexVersion>=DOCID_LOOKUP_UUID_VERSION ? sizeof(SphOffset_t) : 0 );
+}
+
+
+bool CheckDocidLookupFormat ( const BYTE * pData, int64_t iDataLen, DWORD uIndexVersion, CSphString & sError )
+{
+	int64_t iHeader = GetDocidLookupHeaderSize ( uIndexVersion );
+	if ( !pData || iDataLen<iHeader )
+	{
+		sError.SetSprintf ( "docid lookup is too short (" UINT64_FMT " bytes)", (uint64_t)iDataLen );
+		return false;
+	}
+
+	DWORD nDocs = sphUnalignedRead ( *(const DWORD*)pData );
+	DWORD nDocsPerCheckpoint = sphUnalignedRead ( *(const DWORD*)( pData+sizeof(DWORD) ) );
+	if ( !nDocs )
+		return true;
+
+	if ( !nDocsPerCheckpoint )
+	{
+		sError = "docid lookup has zero docs per checkpoint";
+		return false;
+	}
+
+	int64_t nCheckpoints = ( (int64_t)nDocs + nDocsPerCheckpoint - 1 ) / nDocsPerCheckpoint;
+	int64_t iExpected = iHeader + nCheckpoints*(int64_t)sizeof(DocidLookupCheckpoint_t);
+	if ( iDataLen<iExpected )
+	{
+		sError.SetSprintf ( "docid lookup is too short (" UINT64_FMT " bytes, " UINT64_FMT " checkpoints)", (uint64_t)iDataLen, (uint64_t)nCheckpoints );
+		return false;
+	}
+
+	// the data of the first checkpoint starts right after the checkpoint table
+	SphOffset_t tFirst = sphUnalignedRead ( ((const DocidLookupCheckpoint_t *)( pData+iHeader ))->m_tOffset );
+	if ( tFirst==iExpected )
+		return true;
+
+	// name the layout we actually see, if it is the other one
+	const char * szHint = "";
+	DWORD uOther = uIndexVersion>=DOCID_LOOKUP_UUID_VERSION ? DOCID_LOOKUP_UUID_VERSION-1 : DOCID_LOOKUP_UUID_VERSION;
+	int64_t iOtherHeader = GetDocidLookupHeaderSize ( uOther );
+	int64_t iOtherExpected = iOtherHeader + nCheckpoints*(int64_t)sizeof(DocidLookupCheckpoint_t);
+	if ( iDataLen>=iOtherExpected && sphUnalignedRead ( ((const DocidLookupCheckpoint_t *)( pData+iOtherHeader ))->m_tOffset )==iOtherExpected )
+		szHint = uOther<uIndexVersion ? " (the lookup is in the pre-v.71 layout; the header was rewritten with a newer format version without converting it)" : " (the lookup is in the v.71+ layout)";
+
+	sError.SetSprintf ( "docid lookup layout does not match index format v.%u: first checkpoint at " UINT64_FMT ", expected " UINT64_FMT "%s", uIndexVersion, (uint64_t)tFirst, (uint64_t)iExpected, szHint );
+	return false;
+}
+
+
+DWORD DetectDocidLookupVersion ( const BYTE * pData, int64_t iDataLen )
+{
+	CSphString sError;
+	if ( CheckDocidLookupFormat ( pData, iDataLen, DOCID_LOOKUP_UUID_VERSION, sError ) )
+		return DOCID_LOOKUP_UUID_VERSION;
+
+	if ( CheckDocidLookupFormat ( pData, iDataLen, DOCID_LOOKUP_UUID_VERSION-1, sError ) )
+		return DOCID_LOOKUP_UUID_VERSION-1;
+
+	return 0;
+}
+
+
+bool UpgradeDocidLookupFile ( const CSphString & sFilename, DWORD uIndexVersion, CSphString & sError )
+{
+	if ( uIndexVersion>=DOCID_LOOKUP_UUID_VERSION )
+		return true;
+
+	CSphMappedBuffer<BYTE> tOld;
+	if ( !tOld.Setup ( sFilename, sError, false ) )
+		return false;
+
+	const BYTE * pData = tOld.GetReadPtr();
+	int64_t iLen = tOld.GetLengthBytes();
+	if ( !CheckDocidLookupFormat ( pData, iLen, uIndexVersion, sError ) )
+		return false;
+
+	int64_t iOldHeader = GetDocidLookupHeaderSize ( uIndexVersion );
+	int64_t iShift = GetDocidLookupHeaderSize ( DOCID_LOOKUP_UUID_VERSION ) - iOldHeader;
+	DWORD nDocs = sphUnalignedRead ( *(const DWORD*)pData );
+	DWORD nDocsPerCheckpoint = sphUnalignedRead ( *(const DWORD*)( pData+sizeof(DWORD) ) );
+	DocID_t tMaxDocID = sphUnalignedRead ( *(const DocID_t*)( pData+sizeof(DWORD)*2 ) );
+	int64_t nCheckpoints = nDocs ? ( (int64_t)nDocs + nDocsPerCheckpoint - 1 ) / nDocsPerCheckpoint : 0;
+	const auto * pCheckpoints = (const DocidLookupCheckpoint_t *)( pData+iOldHeader );
+	int64_t iDataStart = iOldHeader + nCheckpoints*(int64_t)sizeof(DocidLookupCheckpoint_t);
+
+	CSphString sTmp;
+	sTmp.SetSprintf ( "%s.upgrade.tmp", sFilename.cstr() );
+
+	CSphWriter tWriter;
+	if ( !tWriter.OpenFile ( sTmp, sError ) )
+		return false;
+
+	tWriter.PutDword ( nDocs );
+	tWriter.PutDword ( nDocsPerCheckpoint );
+	tWriter.PutOffset ( tMaxDocID );
+	tWriter.PutOffset ( 0 ); // no UUID entries in a pre-v.71 lookup
+	for ( int64_t i = 0; i<nCheckpoints; ++i )
+	{
+		tWriter.PutOffset ( sphUnalignedRead ( pCheckpoints[i].m_tBaseDocID ) );
+		tWriter.PutOffset ( sphUnalignedRead ( pCheckpoints[i].m_tOffset ) + iShift );
+	}
+	tWriter.PutBytes ( pData+iDataStart, iLen-iDataStart );
+	tWriter.CloseFile();
+	tOld.Reset();
+
+	if ( tWriter.IsError() )
+	{
+		sError.SetSprintf ( "error writing %s", sTmp.cstr() );
+		::unlink ( sTmp.cstr() );
+		return false;
+	}
+
+	if ( ::rename ( sTmp.cstr(), sFilename.cstr() ) )
+	{
+		sError.SetSprintf ( "rename %s to %s failed: %s", sTmp.cstr(), sFilename.cstr(), strerrorm(errno) );
+		::unlink ( sTmp.cstr() );
+		return false;
+	}
+
+	return true;
+}
+
+
 bool WriteDocidLookup ( const CSphString & sFilename, const VecTraits_T<DocidRowidPair_t> & dLookup, CSphString & sError )
 {
 	CSphWriter tfWriter;

--- a/src/docidlookup.cpp
+++ b/src/docidlookup.cpp
@@ -876,10 +876,13 @@ bool DocidLookupWriter_c::Finalize ( CSphString & sError )
 	return true;
 }
 
-static int64_t GetDocidLookupHeaderSize ( DWORD uIndexVersion )
+// the .spt header layouts this file knows how to validate:
+static constexpr int64_t DOCID_LOOKUP_HEADER_SIZE_V65 = sizeof(DWORD)*2 + sizeof(DocID_t);						// v.65..70: docs, docs per checkpoint, max docid
+static constexpr int64_t DOCID_LOOKUP_HEADER_SIZE_V71 = DOCID_LOOKUP_HEADER_SIZE_V65 + sizeof(SphOffset_t);		// v.71+: + uuid entries offset
+
+static int64_t DocidLookupHeaderSize ( DWORD uIndexVersion )
 {
-	// docs, docs per checkpoint, max docid [, uuid entries offset]
-	return sizeof(DWORD)*2 + sizeof(DocID_t) + ( uIndexVersion>=DOCID_LOOKUP_UUID_VERSION ? sizeof(SphOffset_t) : 0 );
+	return uIndexVersion>=DOCID_LOOKUP_UUID_VERSION ? DOCID_LOOKUP_HEADER_SIZE_V71 : DOCID_LOOKUP_HEADER_SIZE_V65;
 }
 
 
@@ -889,7 +892,7 @@ bool CheckDocidLookupFormat ( const BYTE * pData, int64_t iDataLen, DWORD uIndex
 	if ( uIndexVersion<DOCID_LOOKUP_SPLIT_VERSION )
 		return true;
 
-	int64_t iHeader = GetDocidLookupHeaderSize ( uIndexVersion );
+	int64_t iHeader = DocidLookupHeaderSize ( uIndexVersion );
 	if ( !pData || iDataLen<iHeader )
 	{
 		sError.SetSprintf ( "docid lookup is too short (" UINT64_FMT " bytes)", (uint64_t)iDataLen );
@@ -923,7 +926,7 @@ bool CheckDocidLookupFormat ( const BYTE * pData, int64_t iDataLen, DWORD uIndex
 	// name the layout we actually see, if it is the other one
 	const char * szHint = "";
 	DWORD uOther = uIndexVersion>=DOCID_LOOKUP_UUID_VERSION ? DOCID_LOOKUP_UUID_VERSION-1 : DOCID_LOOKUP_UUID_VERSION;
-	int64_t iOtherHeader = GetDocidLookupHeaderSize ( uOther );
+	int64_t iOtherHeader = DocidLookupHeaderSize ( uOther );
 	int64_t iOtherExpected = iOtherHeader + nCheckpoints*(int64_t)sizeof(DocidLookupCheckpoint_t);
 	if ( iDataLen>=iOtherExpected && sphUnalignedRead ( ((const DocidLookupCheckpoint_t *)( pData+iOtherHeader ))->m_tOffset )==iOtherExpected )
 		szHint = uOther<uIndexVersion ? " (the lookup is in the pre-v.71 layout; the header was rewritten with a newer format version without converting it)" : " (the lookup is in the v.71+ layout)";
@@ -961,8 +964,8 @@ bool UpgradeDocidLookupFile ( const CSphString & sFilename, DWORD uIndexVersion,
 	if ( !CheckDocidLookupFormat ( pData, iLen, uIndexVersion, sError ) )
 		return false;
 
-	int64_t iOldHeader = GetDocidLookupHeaderSize ( uIndexVersion );
-	int64_t iShift = GetDocidLookupHeaderSize ( DOCID_LOOKUP_UUID_VERSION ) - iOldHeader;
+	int64_t iOldHeader = DocidLookupHeaderSize ( uIndexVersion );
+	int64_t iShift = DocidLookupHeaderSize ( DOCID_LOOKUP_UUID_VERSION ) - iOldHeader;
 	DWORD nDocs = sphUnalignedRead ( *(const DWORD*)pData );
 	DWORD nDocsPerCheckpoint = sphUnalignedRead ( *(const DWORD*)( pData+sizeof(DWORD) ) );
 	DocID_t tMaxDocID = sphUnalignedRead ( *(const DocID_t*)( pData+sizeof(DWORD)*2 ) );

--- a/src/docidlookup.cpp
+++ b/src/docidlookup.cpp
@@ -888,8 +888,10 @@ static int64_t DocidLookupHeaderSize ( DWORD uIndexVersion )
 
 bool CheckDocidLookupFormat ( const BYTE * pData, int64_t iDataLen, DWORD uIndexVersion, CSphString & sError )
 {
-	// older layouts (a 2019 lookup is 10 bytes) were never validated; keep reading them as before
-	if ( uIndexVersion<DOCID_LOOKUP_SPLIT_VERSION )
+	// only v.71/v.72 headers are suspect (manticoresearch#4852: their daemons could rewrite a header on
+	// ALTER without converting the lookup); older headers always pair with their own layout, and v.73+
+	// is written with the lookup in sync
+	if ( uIndexVersion<DOCID_LOOKUP_SUSPECT_MIN || uIndexVersion>DOCID_LOOKUP_SUSPECT_MAX )
 		return true;
 
 	int64_t iHeader = DocidLookupHeaderSize ( uIndexVersion );

--- a/src/docidlookup.h
+++ b/src/docidlookup.h
@@ -269,6 +269,22 @@ RowIteratorsWithEstimates_t CreateLookupIterator ( CSphVector<SecondaryIndexInfo
 bool	WriteDocidLookup ( const CSphString & sFilename, const VecTraits_T<DocidRowidPair_t> & dLookup, CSphString & sError );
 bool	WriteDocidLookup ( const CSphString & sFilename, const VecTraits_T<DocidRowidPair_t> & dLookup, const VecTraits_T<UuidDocidLookupPair_t> & dUuidLookup, CSphString & sError );
 
+/// index format version that added the UUID entries offset to the .spt header
+/// the lookup readers are gated on the index header version, so the header and the .spt must agree
+constexpr DWORD DOCID_LOOKUP_UUID_VERSION = 71;
+
+/// checks that the lookup data is laid out the way the given index format version implies
+/// (the first checkpoint must start right after the header and the checkpoint table)
+/// catches a header rewritten with a newer format version over an older .spt (manticoresearch#4852)
+bool	CheckDocidLookupFormat ( const BYTE * pData, int64_t iDataLen, DWORD uIndexVersion, CSphString & sError );
+
+/// returns the index format version whose .spt layout the data actually follows
+/// (DOCID_LOOKUP_UUID_VERSION-1 or DOCID_LOOKUP_UUID_VERSION), or 0 if neither fits
+DWORD	DetectDocidLookupVersion ( const BYTE * pData, int64_t iDataLen );
+
+/// rewrites a pre-v.71 .spt into the current layout (via a temporary file); no-op for current files
+bool	UpgradeDocidLookupFile ( const CSphString & sFilename, DWORD uIndexVersion, CSphString & sError );
+
 struct CmpDocidLookup_fn
 {
 	static inline bool IsLess ( const DocidRowidPair_t & a, const DocidRowidPair_t & b )

--- a/src/docidlookup.h
+++ b/src/docidlookup.h
@@ -269,6 +269,11 @@ RowIteratorsWithEstimates_t CreateLookupIterator ( CSphVector<SecondaryIndexInfo
 bool	WriteDocidLookup ( const CSphString & sFilename, const VecTraits_T<DocidRowidPair_t> & dLookup, CSphString & sError );
 bool	WriteDocidLookup ( const CSphString & sFilename, const VecTraits_T<DocidRowidPair_t> & dLookup, const VecTraits_T<UuidDocidLookupPair_t> & dUuidLookup, CSphString & sError );
 
+/// first index format version guaranteed to carry the current .spt header layout (docs, docs per checkpoint,
+/// max docid; the 2022 "split docid lookup" rewrite landed inside v.64 without a version bump, so v.64 files
+/// exist in both layouts). Lookups of older tables (down to the supported v.54) are read as-is and never validated
+constexpr DWORD DOCID_LOOKUP_SPLIT_VERSION = 65;
+
 /// index format version that added the UUID entries offset to the .spt header
 /// the lookup readers are gated on the index header version, so the header and the .spt must agree
 constexpr DWORD DOCID_LOOKUP_UUID_VERSION = 71;

--- a/src/docidlookup.h
+++ b/src/docidlookup.h
@@ -274,6 +274,13 @@ bool	WriteDocidLookup ( const CSphString & sFilename, const VecTraits_T<DocidRow
 /// exist in both layouts). Lookups of older tables (down to the supported v.54) are read as-is and never validated
 constexpr DWORD DOCID_LOOKUP_SPLIT_VERSION = 65;
 
+/// v.71/v.72 headers must have their lookup verified; v.73/v.74 are their fixed twins (see sphinxint.h)
+constexpr DWORD DOCID_LOOKUP_SUSPECT_MIN = 71;
+constexpr DWORD DOCID_LOOKUP_SUSPECT_MAX = 72;
+
+/// the version a header gets when it is (re)written with the lookup known to be in sync
+inline DWORD FixedIndexFormatVersion ( DWORD uVersion ) { return ( uVersion==72 || uVersion==74 ) ? 74 : 73; }
+
 /// index format version that added the UUID entries offset to the .spt header
 /// the lookup readers are gated on the index header version, so the header and the .spt must agree
 constexpr DWORD DOCID_LOOKUP_UUID_VERSION = 71;

--- a/src/gtests/gtests_docidlookup.cpp
+++ b/src/gtests/gtests_docidlookup.cpp
@@ -13,6 +13,7 @@
 #include <gtest/gtest.h>
 
 #include "docidlookup.h"
+#include "fileio.h"
 #include "fileutils.h"
 #include "threadutils.h"
 
@@ -82,6 +83,40 @@ protected:
 	}
 
 	CSphString m_sFile;
+
+	// turns a current-format lookup file into the pre-v.71 layout: no UUID entries offset in the
+	// header, checkpoint data offsets 8 bytes lower
+	void DowngradeToV70()
+	{
+		CSphVector<BYTE> dOld;
+		{
+			CSphMappedBuffer<BYTE> tData;
+			Map ( tData );
+			dOld.Resize ( tData.GetLengthBytes() );
+			memcpy ( dOld.Begin(), tData.GetReadPtr(), tData.GetLengthBytes() );
+		}
+
+		const int64_t iOldHeader = sizeof(DWORD)*2 + sizeof(DocID_t) + sizeof(SphOffset_t);
+		const int64_t iNewHeader = sizeof(DWORD)*2 + sizeof(DocID_t);
+		DWORD nDocs = *(const DWORD*)dOld.Begin();
+		DWORD nPerCheckpoint = *(const DWORD*)( dOld.Begin()+sizeof(DWORD) );
+		int64_t nCheckpoints = ( nDocs + nPerCheckpoint - 1 ) / nPerCheckpoint;
+		int64_t iDataStart = iOldHeader + nCheckpoints*(int64_t)sizeof(DocidLookupCheckpoint_t);
+
+		CSphString sError;
+		CSphWriter tWriter;
+		ASSERT_TRUE ( tWriter.OpenFile ( m_sFile, sError ) ) << sError.cstr();
+		tWriter.PutBytes ( dOld.Begin(), iNewHeader );
+		const auto * pCheckpoints = (const DocidLookupCheckpoint_t *)( dOld.Begin()+iOldHeader );
+		for ( int64_t i = 0; i<nCheckpoints; ++i )
+		{
+			tWriter.PutOffset ( pCheckpoints[i].m_tBaseDocID );
+			tWriter.PutOffset ( pCheckpoints[i].m_tOffset - ( iOldHeader-iNewHeader ) );
+		}
+		tWriter.PutBytes ( dOld.Begin()+iDataStart, dOld.GetLength()-iDataStart );
+		tWriter.CloseFile();
+		ASSERT_FALSE ( tWriter.IsError() );
+	}
 };
 
 TEST_F ( UuidDocidLookupTest, NumericPrefixCompatibility )
@@ -124,6 +159,58 @@ TEST_F ( UuidDocidLookupTest, WriterReaderRoundTripAndSearch )
 	EXPECT_EQ ( tReader.Find ( UuidKey ( "ffffffff-ffff-8fff-bfff-ffffffffffff" ) ), 33U );
 	EXPECT_EQ ( tReader.Find ( UuidKey ( "00000000-0000-1000-8000-000000000000" ) ), 0U );
 	EXPECT_EQ ( tReader.Find ( UuidKey ( "00000000-0000-1000-8000-000000000002" ) ), 0U );
+}
+
+// manticoresearch#4852: an in-place header rewrite stamped v.71 on chunks whose .spt was still v.70,
+// so every docid lookup on them returned garbage rowids; the layout check must catch it, the upgrade must fix it
+TEST_F ( UuidDocidLookupTest, FormatCheckAndUpgrade )
+{
+	WriteNumericLookup();
+	{
+		CSphMappedBuffer<BYTE> tData;
+		Map ( tData );
+		CSphString sError;
+		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION, sError ) ) << sError.cstr();
+		EXPECT_FALSE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION-1, sError ) );
+	}
+
+	DowngradeToV70();
+	{
+		CSphMappedBuffer<BYTE> tData;
+		Map ( tData );
+		CSphString sError;
+		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION-1, sError ) ) << sError.cstr();
+		EXPECT_FALSE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION, sError ) );
+		EXPECT_TRUE ( strstr ( sError.cstr(), "pre-v.71" ) ) << sError.cstr();
+		EXPECT_EQ ( DetectDocidLookupVersion ( tData.GetReadPtr(), tData.GetLengthBytes() ), UUID_INDEX_VERSION-1 );
+
+		LookupReader_c tOld;
+		tOld.SetData ( tData.GetReadPtr(), UUID_INDEX_VERSION-1 );
+		EXPECT_EQ ( tOld.Find(11), 0U );
+		EXPECT_EQ ( tOld.Find(22), 1U );
+		EXPECT_EQ ( tOld.Find(33), 2U );
+	}
+
+	CSphString sError;
+	ASSERT_TRUE ( UpgradeDocidLookupFile ( m_sFile, UUID_INDEX_VERSION-1, sError ) ) << sError.cstr();
+	{
+		CSphMappedBuffer<BYTE> tData;
+		Map ( tData );
+		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION, sError ) ) << sError.cstr();
+		EXPECT_EQ ( DetectDocidLookupVersion ( tData.GetReadPtr(), tData.GetLengthBytes() ), UUID_INDEX_VERSION );
+
+		LookupReader_c tNew;
+		auto [ tUuidOffset, nDocs ] = tNew.SetData ( tData.GetReadPtr(), UUID_INDEX_VERSION );
+		EXPECT_EQ ( tUuidOffset, 0 );
+		EXPECT_EQ ( nDocs, 3U );
+		EXPECT_EQ ( tNew.Find(11), 0U );
+		EXPECT_EQ ( tNew.Find(22), 1U );
+		EXPECT_EQ ( tNew.Find(33), 2U );
+		EXPECT_EQ ( tNew.Find(44), INVALID_ROWID );
+	}
+
+	// upgrading a current-format file is a no-op
+	ASSERT_TRUE ( UpgradeDocidLookupFile ( m_sFile, UUID_INDEX_VERSION, sError ) ) << sError.cstr();
 }
 
 } // namespace

--- a/src/gtests/gtests_docidlookup.cpp
+++ b/src/gtests/gtests_docidlookup.cpp
@@ -184,6 +184,13 @@ TEST_F ( UuidDocidLookupTest, FormatCheckAndUpgrade )
 		EXPECT_TRUE ( strstr ( sError.cstr(), "pre-v.71" ) ) << sError.cstr();
 		EXPECT_EQ ( DetectDocidLookupVersion ( tData.GetReadPtr(), tData.GetLengthBytes() ), UUID_INDEX_VERSION-1 );
 
+		// lookups of tables older than the split-lookup layout are never validated (a v.54 lookup is 10 bytes)
+		const BYTE dLegacy[10] = { 3, 0, 0, 0, 0, 1, 1, 0, 0, 0 };
+		EXPECT_TRUE ( CheckDocidLookupFormat ( dLegacy, sizeof(dLegacy), DOCID_LOOKUP_SPLIT_VERSION-1, sError ) ) << sError.cstr();
+		EXPECT_FALSE ( CheckDocidLookupFormat ( dLegacy, sizeof(dLegacy), DOCID_LOOKUP_SPLIT_VERSION, sError ) );
+		EXPECT_TRUE ( UpgradeDocidLookupFile ( m_sFile, DOCID_LOOKUP_SPLIT_VERSION-1, sError ) ) << sError.cstr(); // no-op below the gate
+		EXPECT_EQ ( DetectDocidLookupVersion ( tData.GetReadPtr(), tData.GetLengthBytes() ), UUID_INDEX_VERSION-1 ); // the file is untouched
+
 		LookupReader_c tOld;
 		tOld.SetData ( tData.GetReadPtr(), UUID_INDEX_VERSION-1 );
 		EXPECT_EQ ( tOld.Find(11), 0U );

--- a/src/gtests/gtests_docidlookup.cpp
+++ b/src/gtests/gtests_docidlookup.cpp
@@ -171,7 +171,8 @@ TEST_F ( UuidDocidLookupTest, FormatCheckAndUpgrade )
 		Map ( tData );
 		CSphString sError;
 		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION, sError ) ) << sError.cstr();
-		EXPECT_FALSE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION-1, sError ) );
+		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION+1, sError ) ) << sError.cstr(); // v.72: same layout
+		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION-1, sError ) ); // v.70 is not suspect - never checked
 	}
 
 	DowngradeToV70();
@@ -181,13 +182,17 @@ TEST_F ( UuidDocidLookupTest, FormatCheckAndUpgrade )
 		CSphString sError;
 		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION-1, sError ) ) << sError.cstr();
 		EXPECT_FALSE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), UUID_INDEX_VERSION, sError ) );
+		EXPECT_FALSE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), DOCID_LOOKUP_SUSPECT_MAX, sError ) ); // v.72 is suspect too
+		EXPECT_TRUE ( CheckDocidLookupFormat ( tData.GetReadPtr(), tData.GetLengthBytes(), DOCID_LOOKUP_SUSPECT_MAX+1, sError ) ) << sError.cstr(); // v.73+: fixed, never checked
 		EXPECT_TRUE ( strstr ( sError.cstr(), "pre-v.71" ) ) << sError.cstr();
 		EXPECT_EQ ( DetectDocidLookupVersion ( tData.GetReadPtr(), tData.GetLengthBytes() ), UUID_INDEX_VERSION-1 );
 
-		// lookups of tables older than the split-lookup layout are never validated (a v.54 lookup is 10 bytes)
+		// only suspect headers are validated: a legacy lookup (a v.54 file is 10 bytes) passes under any
+		// non-suspect version and fails under a suspect one
 		const BYTE dLegacy[10] = { 3, 0, 0, 0, 0, 1, 1, 0, 0, 0 };
 		EXPECT_TRUE ( CheckDocidLookupFormat ( dLegacy, sizeof(dLegacy), DOCID_LOOKUP_SPLIT_VERSION-1, sError ) ) << sError.cstr();
-		EXPECT_FALSE ( CheckDocidLookupFormat ( dLegacy, sizeof(dLegacy), DOCID_LOOKUP_SPLIT_VERSION, sError ) );
+		EXPECT_TRUE ( CheckDocidLookupFormat ( dLegacy, sizeof(dLegacy), DOCID_LOOKUP_SPLIT_VERSION, sError ) ) << sError.cstr();
+		EXPECT_FALSE ( CheckDocidLookupFormat ( dLegacy, sizeof(dLegacy), DOCID_LOOKUP_SUSPECT_MIN, sError ) );
 		EXPECT_TRUE ( UpgradeDocidLookupFile ( m_sFile, DOCID_LOOKUP_SPLIT_VERSION-1, sError ) ) << sError.cstr(); // no-op below the gate
 		EXPECT_EQ ( DetectDocidLookupVersion ( tData.GetReadPtr(), tData.GetLengthBytes() ), UUID_INDEX_VERSION-1 ); // the file is untouched
 
@@ -218,6 +223,13 @@ TEST_F ( UuidDocidLookupTest, FormatCheckAndUpgrade )
 
 	// upgrading a current-format file is a no-op
 	ASSERT_TRUE ( UpgradeDocidLookupFile ( m_sFile, UUID_INDEX_VERSION, sError ) ) << sError.cstr();
+
+	// the fixed twins: 71->73, 72->74; already-fixed versions keep their number
+	EXPECT_EQ ( FixedIndexFormatVersion(70), 73U );
+	EXPECT_EQ ( FixedIndexFormatVersion(71), 73U );
+	EXPECT_EQ ( FixedIndexFormatVersion(72), 74U );
+	EXPECT_EQ ( FixedIndexFormatVersion(73), 73U );
+	EXPECT_EQ ( FixedIndexFormatVersion(74), 74U );
 }
 
 } // namespace

--- a/src/indexcheck.cpp
+++ b/src/indexcheck.cpp
@@ -1600,6 +1600,22 @@ void DiskIndexChecker_c::Impl_c::CheckDocidLookup()
 	}
 	int64_t iLookupEnd = tLookup.GetFilesize();
 
+	// the layout depends on the header version (v.71 added a field); a mismatch makes every lookup return garbage
+	{
+		CSphMappedBuffer<BYTE> tLookupData;
+		if ( !tLookupData.Setup ( GetFilename(SPH_EXT_SPT), sError, false ) )
+		{
+			m_tReporter.Fail ( "unable to map lookup file: %s", sError.cstr() );
+			return;
+		}
+
+		if ( !CheckDocidLookupFormat ( tLookupData.GetReadPtr(), tLookupData.GetLengthBytes(), m_uVersion, sError ) )
+		{
+			m_tReporter.Fail ( "%s (a daemon with this check repairs a pre-v.71 lookup under a newer header on load; otherwise rebuild the table)", sError.cstr() );
+			return;
+		}
+	}
+
 	const CSphColumnInfo * pId = m_tSchema.GetAttr("id");
 	assert(pId);
 

--- a/src/indexcheck.cpp
+++ b/src/indexcheck.cpp
@@ -1611,7 +1611,7 @@ void DiskIndexChecker_c::Impl_c::CheckDocidLookup()
 
 		if ( !CheckDocidLookupFormat ( tLookupData.GetReadPtr(), tLookupData.GetLengthBytes(), m_uVersion, sError ) )
 		{
-			m_tReporter.Fail ( "%s (a daemon with this check repairs a pre-v.71 lookup under a newer header on load; otherwise rebuild the table)", sError.cstr() );
+			m_tReporter.Fail ( "%s (the header was rewritten without converting the lookup, manticoresearch#4852; rebuild or restore the table)", sError.cstr() );
 			return;
 		}
 	}

--- a/src/indexformat.cpp
+++ b/src/indexformat.cpp
@@ -966,7 +966,7 @@ void IndexWriteHeader ( const BuildHeader_t & tBuildHeader, const WriteHeader_t 
 	sJson.NamedString ( "meta_created_time_utc", sphCurrentUtcTime() );
 
 	// version
-	sJson.NamedVal ( "index_format_version", INDEX_FORMAT_VERSION );
+	sJson.NamedVal ( "index_format_version", tBuildHeader.m_uFormatVersion ? tBuildHeader.m_uFormatVersion : INDEX_FORMAT_VERSION );
 
 	// index stats - json (put here to be similar with .meta)
 	sJson.NamedValNonDefault ( "total_documents", tBuildHeader.m_iTotalDocuments );

--- a/src/indexformat.h
+++ b/src/indexformat.h
@@ -167,6 +167,8 @@ std::unique_ptr<ISphKeywordsBlockReader> CreateKeywordsBlockReader ( const BYTE 
 struct BuildHeader_t : public CSphSourceStats, public DictHeader_t
 {
 	BuildHeader_t() = default;
+
+	DWORD			m_uFormatVersion = 0;	// version to stamp into the header; 0 = current INDEX_FORMAT_VERSION
 	explicit BuildHeader_t ( const CSphSourceStats & tStat )
 	{
 		m_iTotalDocuments = tStat.m_iTotalDocuments;

--- a/src/indextool.cpp
+++ b/src/indextool.cpp
@@ -860,6 +860,125 @@ static void ApplyKilllist ( IndexInfo_t & tTarget, const IndexInfo_t & tKiller, 
 }
 
 
+
+//////////////////////////////////////////////////////////////////////////
+
+// manticoresearch#4852: offline fix for a suspect (v.71/v.72) header over an unconverted .spt lookup.
+// works on the files only (the daemon refuses to load such a table): converts a pre-v.71 lookup to the
+// current layout when needed and stamps the header with the fixed version (71->73, 72->74), so the
+// table is never checked again.
+static bool FixDocidLookupBase ( const CSphString & sBase )
+{
+	CSphString sHeaderFile, sLookupFile;
+	sHeaderFile.SetSprintf ( "%s.sph", sBase.cstr() );
+	sLookupFile.SetSprintf ( "%s.spt", sBase.cstr() );
+
+	CSphString sError;
+	CSphVector<BYTE> dHeader;
+	{
+		CSphAutofile tFile;
+		if ( tFile.Open ( sHeaderFile, SPH_O_READ, sError )<0 )
+			sphDie ( "%s: %s", sHeaderFile.cstr(), sError.cstr() );
+		dHeader.Resize ( (int64_t)tFile.GetSize() );
+		if ( !tFile.Read ( dHeader.Begin(), dHeader.GetLength(), sError ) )
+			sphDie ( "%s: %s", sHeaderFile.cstr(), sError.cstr() );
+	}
+
+	// the version lives in the json header as a plain number
+	CSphString sHeaderText ( (const char*)dHeader.Begin(), dHeader.GetLength() );
+	const char * szTag = "\"index_format_version\":";
+	const char * szVer = strstr ( sHeaderText.cstr(), szTag );
+	if ( !szVer )
+		sphDie ( "%s: no index_format_version in the header", sHeaderFile.cstr() );
+
+	DWORD uVersion = strtoul ( szVer+strlen(szTag), nullptr, 10 );
+	if ( uVersion<DOCID_LOOKUP_SUSPECT_MIN || uVersion>DOCID_LOOKUP_SUSPECT_MAX )
+	{
+		fprintf ( stdout, "%s: v.%u - not suspect, nothing to fix\n", sBase.cstr(), uVersion );
+		return false;
+	}
+
+	CSphMappedBuffer<BYTE> tLookup;
+	if ( !tLookup.Setup ( sLookupFile, sError, false ) )
+		sphDie ( "%s: %s", sLookupFile.cstr(), sError.cstr() );
+
+	CSphString sFormatError;
+	if ( !CheckDocidLookupFormat ( tLookup.GetReadPtr(), tLookup.GetLengthBytes(), uVersion, sFormatError ) )
+	{
+		DWORD uActual = DetectDocidLookupVersion ( tLookup.GetReadPtr(), tLookup.GetLengthBytes() );
+		if ( uActual!=DOCID_LOOKUP_UUID_VERSION-1 )
+			sphDie ( "%s: %s; the lookup is damaged beyond this fix - rebuild or restore the table", sLookupFile.cstr(), sFormatError.cstr() );
+
+		tLookup.Reset();
+		if ( !UpgradeDocidLookupFile ( sLookupFile, uActual, sError ) )
+			sphDie ( "%s: %s", sLookupFile.cstr(), sError.cstr() );
+
+		fprintf ( stdout, "%s: lookup converted from the pre-v.%u layout\n", sBase.cstr(), DOCID_LOOKUP_UUID_VERSION );
+	} else
+		fprintf ( stdout, "%s: lookup already consistent\n", sBase.cstr() );
+
+	// stamp the fixed version: replace the number in place (same digit count: 71->73, 72->74)
+	DWORD uFixed = FixedIndexFormatVersion ( uVersion );
+	char sOld[32], sNew[32];
+	snprintf ( sOld, sizeof(sOld), "%s%u", szTag, uVersion );
+	snprintf ( sNew, sizeof(sNew), "%s%u", szTag, uFixed );
+	assert ( strlen(sOld)==strlen(sNew) );
+	memcpy ( dHeader.Begin() + ( szVer - sHeaderText.cstr() ), sNew, strlen(sNew) );
+
+	CSphString sTmp;
+	sTmp.SetSprintf ( "%s.fix.tmp", sHeaderFile.cstr() );
+	CSphWriter tWriter;
+	if ( !tWriter.OpenFile ( sTmp, sError ) )
+		sphDie ( "%s: %s", sTmp.cstr(), sError.cstr() );
+	tWriter.PutBytes ( dHeader.Begin(), dHeader.GetLength() );
+	tWriter.CloseFile();
+	if ( tWriter.IsError() || sph::rename ( sTmp.cstr(), sHeaderFile.cstr() )!=0 )
+		sphDie ( "%s: failed to write the fixed header", sHeaderFile.cstr() );
+
+	fprintf ( stdout, "%s: header v.%u -> v.%u\n", sBase.cstr(), uVersion, uFixed );
+	return true;
+}
+
+
+static void FixDocidLookup ( CSphConfig & hConf, const CSphString & sIndex )
+{
+	if ( !hConf["index"].Exists ( sIndex ) )
+		sphDie ( "table '%s': no such table in config", sIndex.cstr() );
+
+	const CSphConfigSection & hIndex = hConf["index"][sIndex];
+	if ( !hIndex("path") )
+		sphDie ( "table '%s': missing 'path'", sIndex.cstr() );
+
+	CSphString sPath = RedirectToRealPath ( hIndex["path"].strval() );
+	int iFixed = 0;
+
+	CSphString sMeta;
+	sMeta.SetSprintf ( "%s.meta", sPath.cstr() );
+	if ( sphFileExists ( sMeta.cstr() ) )
+	{
+		// an RT table: fix every disk chunk listed in the meta
+		CSphString sError;
+		CSphVector<BYTE> dMeta;
+		if ( sphJsonParse ( dMeta, sMeta, sError )!=JsonFileParse_e::OK || dMeta.IsEmpty() )
+			sphDie ( "%s: %s", sMeta.cstr(), sError.cstr() );
+
+		bson::Bson_c tBson ( dMeta );
+		bson::Bson_c tChunks { tBson.ChildByName ( "chunk_names" ) };
+		if ( tBson.IsEmpty() || tChunks.IsEmpty() )
+			sphDie ( "%s: no chunk_names in the meta", sMeta.cstr() );
+
+		tChunks.ForEach ( [&] ( const bson::NodeHandle_t & tNode )
+		{
+			CSphString sChunk;
+			sChunk.SetSprintf ( "%s.%d", sPath.cstr(), (int)bson::Int ( tNode ) );
+			iFixed += FixDocidLookupBase ( sChunk ) ? 1 : 0;
+		});
+	} else
+		iFixed += FixDocidLookupBase ( sPath ) ? 1 : 0;
+
+	fprintf ( stdout, "table '%s': %d header(s) fixed\n", sIndex.cstr(), iFixed );
+}
+
 static void ApplyKilllists ( CSphConfig & hConf )
 {
 	CSphFixedVector<IndexInfo_t> dIndexes ( hConf["index"].GetLength() );
@@ -1029,6 +1148,7 @@ Commands are:
 -h, --help			display this help message
 -v				display version information
 --check <TABLE>			perform table consistency check
+--fix-docid-lookup <TABLE>	fix a v.71/v.72 table whose header was rewritten by ALTER without converting the docid lookup (manticoresearch#4852): converts the .spt and stamps the fixed header version, offline
 --check-disk-chunk <CHUNK_ID>	perform single disk chunk consistency check (to be used together with --check)
 --check-id-dups <CHUNK_ID>	check if there are duplicate ids (to be used together with --check)
 --rotate			rotate table after --check in case it's valid
@@ -1086,11 +1206,12 @@ enum class IndextoolCmd_e
 	MERGEIDF,
 	CHECKCONFIG,
 	FOLD,
-	APPLYKLISTS
+	APPLYKLISTS,
+	FIXDOCIDLOOKUP
 };
 
 static IndextoolCmd_e g_eCommand = IndextoolCmd_e::NOTHING;
-static const char * g_sCommands[] = {"", "dumpheader", "dumpconfig", "dumpdocids", "dumphitlist", "dumpdict", "dumpkilllist", "check", "htmlstrip", "morph", "buildidf", "mergeidf", "checkconfig", "fold", "apply-killlists" };
+static const char * g_sCommands[] = {"", "dumpheader", "dumpconfig", "dumpdocids", "dumphitlist", "dumpdict", "dumpkilllist", "check", "htmlstrip", "morph", "buildidf", "mergeidf", "checkconfig", "fold", "apply-killlists", "fix-docid-lookup" };
 
 
 static void SetCmd ( IndextoolCmd_e eCmd )
@@ -1311,6 +1432,7 @@ int main ( int argc, char ** argv )
 		OPT1 ( "-v" )				{ ShowVersion(); exit(0); }
 		OPT ( "-h", "--help" )		{ ShowVersion(); ShowHelp(); exit(0); }
 		OPT1 ( "--apply-killlists" ){ SetCmd ( IndextoolCmd_e::APPLYKLISTS ); continue; }
+		OPT1 ( "--fix-docid-lookup" ){ SetCmd ( IndextoolCmd_e::FIXDOCIDLOOKUP ); sIndex = argv[++i]; continue; }
 		OPT1 ( "--check-id-dups" )	{ bCheckIdDups = true; continue; }
 		if ( !strcmp ( argv[i], "--buildidf" ) || !strcmp ( argv[i], "--mergeidf" ) )
 		{
@@ -1530,6 +1652,12 @@ int main ( int argc, char ** argv )
 	if ( g_eCommand==IndextoolCmd_e::APPLYKLISTS )
 	{
 		ApplyKilllists ( hConf );
+		exit (0);
+	}
+
+	if ( g_eCommand==IndextoolCmd_e::FIXDOCIDLOOKUP )
+	{
+		FixDocidLookup ( hConf, sIndex );
 		exit (0);
 	}
 

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -10345,7 +10345,7 @@ bool CSphIndex_VLN::PreallocDocidLookup()
 		DWORD uActual = DetectDocidLookupVersion ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes() );
 		if ( m_uVersion<DOCID_LOOKUP_UUID_VERSION || uActual!=DOCID_LOOKUP_UUID_VERSION-1 )
 		{
-			m_sLastError.SetSprintf ( "%s: %s", sFile.cstr(), sFormatError.cstr() );
+			m_sLastError.SetSprintf ( "%s: %s; the table must be rebuilt (the lookup is damaged, or it predates the v.%u layout and the header was rewritten by ALTER)", sFile.cstr(), sFormatError.cstr(), DOCID_LOOKUP_SPLIT_VERSION );
 			return false;
 		}
 

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -1367,6 +1367,7 @@ public:
 	bool				PreallocWordlist();
 	bool				PreallocAttributes();
 	bool				PreallocDocidLookup();
+	bool				UpgradeDocidLookup ( CSphString & sError );
 	bool				PreallocKilllist();
 	bool				PreallocHistograms ( StrVec_t & dWarnings );
 	bool				PreallocDocstore();
@@ -3035,6 +3036,10 @@ bool CSphIndex_VLN::AddRemoveColumnarAttr ( bool bAddAttr, const CSphString & sA
 
 bool CSphIndex_VLN::AddRemoveAttribute ( bool bAddAttr, const AttrAddRemoveCtx_t & tCtx, CSphString & sError )
 {
+	// the header gets rewritten with the current format version below
+	if ( !UpgradeDocidLookup ( sError ) )
+		return false;
+
 	AttrEngine_e eAttrEngine = CombineEngines ( m_tSettings.m_eEngine, tCtx.m_eEngine );
 	AttrAddRemoveCtx_t tNewCtx = tCtx;
 	if ( eAttrEngine==AttrEngine_e::COLUMNAR )
@@ -3258,6 +3263,9 @@ void CSphIndex_VLN::PrepareHeaders ( BuildHeader_t & tBuildHeader, WriteHeader_t
 
 bool CSphIndex_VLN::SaveHeader ( CSphString & sError )
 {
+	if ( !UpgradeDocidLookup ( sError ) )
+		return false;
+
 	BuildHeader_t tBuildHeader;
 	WriteHeader_t tWriteHeader;
 	PrepareHeaders ( tBuildHeader, tWriteHeader );
@@ -8020,6 +8028,10 @@ bool CSphIndex_VLN::AddRemoveFromKNN ( const CSphSchema & tOldSchema, const CSph
 
 bool CSphIndex_VLN::AddRemoveField ( bool bAddField, const CSphString & sFieldName, DWORD uFieldFlags, CSphString & sError )
 {
+	// the header gets rewritten with the current format version below
+	if ( !UpgradeDocidLookup ( sError ) )
+		return false;
+
 	CSphSchema tOldSchema = m_tSchema;
 	CSphSchema tNewSchema = m_tSchema;
 	if ( !Alter_AddRemoveFieldFromSchema ( bAddField, tNewSchema, sFieldName, uFieldFlags, sError ) )
@@ -10321,12 +10333,78 @@ bool CSphIndex_VLN::PreallocDocidLookup()
 	if ( !m_tDocidLookup.Setup ( GetFilename ( SPH_EXT_SPT ), m_sLastError, false ) )
 		return false;
 
+	// the lookup layout depends on the index format version (v.71 added a header field); a mismatch would
+	// yield garbage rowids and crash every docid lookup (UPDATE, DELETE, REPLACE kill-lists, id filters)
+	CSphString sFormatError;
+	if ( !CheckDocidLookupFormat ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes(), m_uVersion, sFormatError ) )
+	{
+		CSphString sFile = GetFilename ( SPH_EXT_SPT );
+
+		// a header rewritten with v.71+ over a pre-v.71 lookup (older daemons did that on ALTER, see manticoresearch#4852)
+		// is unambiguous: the pre-v.71 layout is recognizable and the conversion is exact, so repair it in place
+		DWORD uActual = DetectDocidLookupVersion ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes() );
+		if ( m_uVersion<DOCID_LOOKUP_UUID_VERSION || uActual!=DOCID_LOOKUP_UUID_VERSION-1 )
+		{
+			m_sLastError.SetSprintf ( "%s: %s", sFile.cstr(), sFormatError.cstr() );
+			return false;
+		}
+
+		sphWarning ( "%s: docid lookup is in the pre-v.%u layout while the header is v.%u; upgrading the lookup in place", sFile.cstr(), DOCID_LOOKUP_UUID_VERSION, m_uVersion );
+		m_tDocidLookup.Reset();
+		if ( !UpgradeDocidLookupFile ( sFile, uActual, m_sLastError ) || !m_tDocidLookup.Setup ( sFile, m_sLastError, false ) )
+			return false;
+
+		if ( !CheckDocidLookupFormat ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes(), m_uVersion, sFormatError ) )
+		{
+			m_sLastError.SetSprintf ( "%s: %s (after upgrade)", sFile.cstr(), sFormatError.cstr() );
+			return false;
+		}
+	}
+
 	auto [ tUuidEntriesOffset, nDocs ] = m_tLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), m_uVersion );
 	const bool bUuidLinked = m_tSchema.GetAttr(0).IsUuidLinkedDocid();
 	assert ( !!tUuidEntriesOffset==bUuidLinked );
 	if ( bUuidLinked )
 		m_tUuidLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), tUuidEntriesOffset, nDocs );
 
+	return true;
+}
+
+
+// in-place operations (ALTER TABLE ADD/DROP COLUMN or field, header rewrites) save the header with the
+// current INDEX_FORMAT_VERSION, so every version-gated data file must be brought to the current format
+// as well - the readers are gated on the header version. since v.68 only the docid lookup changed (v.71)
+bool CSphIndex_VLN::UpgradeDocidLookup ( CSphString & sError )
+{
+	if ( m_uVersion>=DOCID_LOOKUP_UUID_VERSION )
+		return true;
+
+	CSphString sFile = GetFilename ( SPH_EXT_SPT );
+	bool bMapped = !!m_tDocidLookup.GetReadPtr();
+	m_tDocidLookup.Reset();
+
+	CSphString sUpgradeError;
+	if ( sphIsReadable ( sFile.cstr() ) && !UpgradeDocidLookupFile ( sFile, m_uVersion, sUpgradeError ) )
+	{
+		sError.SetSprintf ( "%s: %s", sFile.cstr(), sUpgradeError.cstr() );
+		if ( bMapped )
+		{
+			CSphString sRemapError;
+			if ( m_tDocidLookup.Setup ( sFile, sRemapError, false ) )
+				m_tLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), m_uVersion );
+		}
+		return false;
+	}
+
+	if ( bMapped )
+	{
+		if ( !m_tDocidLookup.Setup ( sFile, sError, false ) )
+			return false;
+
+		m_tLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), INDEX_FORMAT_VERSION );
+	}
+
+	m_uVersion = INDEX_FORMAT_VERSION;
 	return true;
 }
 
@@ -14195,6 +14273,10 @@ bool CSphIndex_VLN::RewriteHeader ( CSphString & sError ) const
 {
 	CSphString sHeader = GetFilename ( SPH_EXT_SPH );
 	if ( !sphIsReadable ( sHeader.cstr(), &sError ) )
+		return false;
+
+	// the new header carries the current format version; the data files must match it
+	if ( !const_cast<CSphIndex_VLN*>(this)->UpgradeDocidLookup ( sError ) )
 		return false;
 
 	CSphString sHeaderNew;

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -1367,7 +1367,7 @@ public:
 	bool				PreallocWordlist();
 	bool				PreallocAttributes();
 	bool				PreallocDocidLookup();
-	bool				UpgradeDocidLookup ( CSphString & sError );
+	bool				UpgradeDocidLookup ( CSphString & sError ) final;
 	bool				PreallocKilllist();
 	bool				PreallocHistograms ( StrVec_t & dWarnings );
 	bool				PreallocDocstore();
@@ -3263,9 +3263,6 @@ void CSphIndex_VLN::PrepareHeaders ( BuildHeader_t & tBuildHeader, WriteHeader_t
 
 bool CSphIndex_VLN::SaveHeader ( CSphString & sError )
 {
-	if ( !UpgradeDocidLookup ( sError ) )
-		return false;
-
 	BuildHeader_t tBuildHeader;
 	WriteHeader_t tWriteHeader;
 	PrepareHeaders ( tBuildHeader, tWriteHeader );
@@ -10338,27 +10335,11 @@ bool CSphIndex_VLN::PreallocDocidLookup()
 	CSphString sFormatError;
 	if ( !CheckDocidLookupFormat ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes(), m_uVersion, sFormatError ) )
 	{
-		CSphString sFile = GetFilename ( SPH_EXT_SPT );
-
-		// a header rewritten with v.71+ over a pre-v.71 lookup (older daemons did that on ALTER, see manticoresearch#4852)
-		// is unambiguous: the pre-v.71 layout is recognizable and the conversion is exact, so repair it in place
-		DWORD uActual = DetectDocidLookupVersion ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes() );
-		if ( m_uVersion<DOCID_LOOKUP_UUID_VERSION || uActual!=DOCID_LOOKUP_UUID_VERSION-1 )
-		{
-			m_sLastError.SetSprintf ( "%s: %s; the table must be rebuilt (the lookup is damaged, or it predates the v.%u layout and the header was rewritten by ALTER)", sFile.cstr(), sFormatError.cstr(), DOCID_LOOKUP_SPLIT_VERSION );
-			return false;
-		}
-
-		sphWarning ( "%s: docid lookup is in the pre-v.%u layout while the header is v.%u; upgrading the lookup in place", sFile.cstr(), DOCID_LOOKUP_UUID_VERSION, m_uVersion );
-		m_tDocidLookup.Reset();
-		if ( !UpgradeDocidLookupFile ( sFile, uActual, m_sLastError ) || !m_tDocidLookup.Setup ( sFile, m_sLastError, false ) )
-			return false;
-
-		if ( !CheckDocidLookupFormat ( m_tDocidLookup.GetReadPtr(), m_tDocidLookup.GetLengthBytes(), m_uVersion, sFormatError ) )
-		{
-			m_sLastError.SetSprintf ( "%s: %s (after upgrade)", sFile.cstr(), sFormatError.cstr() );
-			return false;
-		}
+		// a header rewritten with a newer format version over an unconverted lookup (an ALTER by an affected
+		// daemon, manticoresearch#4852) - or plain damage. an inconsistent table is not repaired on the fly:
+		// refuse it with a clear message; indextool is the place to inspect it
+		m_sLastError.SetSprintf ( "%s: %s; check the table with indextool, then rebuild or restore it (manticoresearch#4852)", GetFilename ( SPH_EXT_SPT ).cstr(), sFormatError.cstr() );
+		return false;
 	}
 
 	auto [ tUuidEntriesOffset, nDocs ] = m_tLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), m_uVersion );
@@ -10370,6 +10351,10 @@ bool CSphIndex_VLN::PreallocDocidLookup()
 	return true;
 }
 
+
+// a format version bump must confirm that the .spt layout knowledge in docidlookup.cpp
+// (DocidLookupHeaderSize and the DOCID_LOOKUP_* constants) still holds, then move this tripwire
+static_assert ( INDEX_FORMAT_VERSION==72, "INDEX_FORMAT_VERSION changed: verify the .spt header layout table in docidlookup.cpp, then update this assert" );
 
 // in-place operations (ALTER TABLE ADD/DROP COLUMN or field, header rewrites) save the header with the
 // current INDEX_FORMAT_VERSION, so every version-gated data file must be brought to the current format
@@ -14273,10 +14258,6 @@ bool CSphIndex_VLN::RewriteHeader ( CSphString & sError ) const
 {
 	CSphString sHeader = GetFilename ( SPH_EXT_SPH );
 	if ( !sphIsReadable ( sHeader.cstr(), &sError ) )
-		return false;
-
-	// the new header carries the current format version; the data files must match it
-	if ( !const_cast<CSphIndex_VLN*>(this)->UpgradeDocidLookup ( sError ) )
 		return false;
 
 	CSphString sHeaderNew;

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -3258,6 +3258,10 @@ void CSphIndex_VLN::PrepareHeaders ( BuildHeader_t & tBuildHeader, WriteHeader_t
 	tWriteHeader.m_pFieldFilter = m_pFieldFilter.get();
 	tWriteHeader.m_pFieldLens = m_dFieldLens.Begin();
 	tWriteHeader.m_pSI = &m_tSI;
+
+	// a rewritten header of an existing table carries the fixed version (71->73, 72->74): the callers
+	// bring the docid lookup in sync in the same operation, so the result is never suspect
+	tBuildHeader.m_uFormatVersion = FixedIndexFormatVersion ( m_uVersion );
 }
 
 
@@ -10352,10 +10356,6 @@ bool CSphIndex_VLN::PreallocDocidLookup()
 }
 
 
-// a format version bump must confirm that the .spt layout knowledge in docidlookup.cpp
-// (DocidLookupHeaderSize and the DOCID_LOOKUP_* constants) still holds, then move this tripwire
-static_assert ( INDEX_FORMAT_VERSION==72, "INDEX_FORMAT_VERSION changed: verify the .spt header layout table in docidlookup.cpp, then update this assert" );
-
 // in-place operations (ALTER TABLE ADD/DROP COLUMN or field, header rewrites) save the header with the
 // current INDEX_FORMAT_VERSION, so every version-gated data file must be brought to the current format
 // as well - the readers are gated on the header version. since v.68 only the docid lookup changed (v.71)
@@ -10386,10 +10386,10 @@ bool CSphIndex_VLN::UpgradeDocidLookup ( CSphString & sError )
 		if ( !m_tDocidLookup.Setup ( sFile, sError, false ) )
 			return false;
 
-		m_tLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), INDEX_FORMAT_VERSION );
+		m_tLookupReader.SetData ( m_tDocidLookup.GetReadPtr(), DOCID_LOOKUP_UUID_VERSION );
 	}
 
-	m_uVersion = INDEX_FORMAT_VERSION;
+	m_uVersion = FixedIndexFormatVersion ( m_uVersion );
 	return true;
 }
 

--- a/src/sphinx.h
+++ b/src/sphinx.h
@@ -1460,6 +1460,10 @@ public:
 	/// rewrite index header on disk using current in-memory settings
 	virtual bool				RewriteHeader ( CSphString & sError ) const { return false; }
 
+	/// bring the version-gated data files (the .spt docid lookup) to the current format BEFORE a header
+	/// rewrite stamps the current version on them - the readers are gated on the header version (#4852)
+	virtual bool				UpgradeDocidLookup ( CSphString & sError ) { return true; }
+
 	/// getter for name. Notice, const char* returned as it is mostly used for printing name
 	const char *				GetName () const { return m_sIndexName.cstr(); }
 

--- a/src/sphinxint.h
+++ b/src/sphinxint.h
@@ -35,7 +35,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 const DWORD		INDEX_MAGIC_HEADER			= 0x58485053;		///< my magic 'SPHX' header
-const DWORD		INDEX_FORMAT_VERSION		= 72;				///< float_vector_array attribute type
+// v.71 (uuid entries in the docid lookup) and v.72 (float_vector_array) headers are "suspect": daemons
+// writing them could rewrite a header on ALTER without converting the .spt lookup (manticoresearch#4852),
+// so a v.71/v.72 header must have its lookup layout verified on load. v.73 and v.74 are their fixed twins
+// (73 = the v.71 feature set, 74 = v.72's), written only with the lookup in sync and never checked.
+const DWORD		INDEX_FORMAT_VERSION		= 74;				///< v.72 (float_vector_array) with the docid lookup written in sync
 
 const char		MAGIC_CODE_SENTENCE			= '\x02';				// emitted from tokenizer on sentence boundary
 const char		MAGIC_CODE_PARAGRAPH		= '\x03';				// emitted from stripper (and passed via tokenizer) on paragraph boundary

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -13058,6 +13058,11 @@ bool RtIndex_c::AttachRtChunksExtCopy ( RtIndex_c * pSrcRtIndex, bool & bFatal, 
 		if ( !AttachRtChunkExtCopy ( *pChunkIndex, *pChunkIndex, iChunk, pSrcFileBuilder.get(), pDstFileBuilder.get(), hExtCache, sDstPath, sError ) )
 			return false;
 
+		// the rewritten header carries the current format version; bring the version-gated
+		// data files (docid lookup) in sync first, in the same operation (#4852)
+		if ( !pChunkIndex->UpgradeDocidLookup ( sError ) )
+			return false;
+
 		if ( !tChunk->Cidx().RewriteHeader ( sError ) )
 			return false;
 

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -13058,12 +13058,12 @@ bool RtIndex_c::AttachRtChunksExtCopy ( RtIndex_c * pSrcRtIndex, bool & bFatal, 
 		if ( !AttachRtChunkExtCopy ( *pChunkIndex, *pChunkIndex, iChunk, pSrcFileBuilder.get(), pDstFileBuilder.get(), hExtCache, sDstPath, sError ) )
 			return false;
 
-		// the rewritten header carries the current format version; bring the version-gated
-		// data files (docid lookup) in sync first, in the same operation (#4852)
+		// the rewritten header carries the fixed format version; bring the docid lookup
+		// in sync first, in the same operation (#4852)
 		if ( !pChunkIndex->UpgradeDocidLookup ( sError ) )
 			return false;
 
-		if ( !tChunk->Cidx().RewriteHeader ( sError ) )
+		if ( !pChunkIndex->RewriteHeader ( sError ) )
 			return false;
 
 		dOthers.Add ( tChunk );


### PR DESCRIPTION
Fixes #4852.

## Root cause

Index format **v.71** (013bfbb1a, "harden and optimize UUID primary IDs") added an 8-byte UUID-entries offset to the `.spt` (docid lookup) header, and `LookupReader_c::SetData()` is gated on the chunk's `index_format_version`. Every in-place operation that rewrites a disk chunk header — `ALTER TABLE ... ADD/DROP COLUMN`, `ADD/DROP` field, `SaveHeader()`, `RewriteHeader()` — stamps the **current** `INDEX_FORMAT_VERSION` but leaves `.spt` untouched.

So on a chunk built before v.71 and ALTERed by a v.71+ daemon, the lookup is decoded 8 bytes off: every docid→rowid lookup returns garbage rowids, and whatever consumes them segfaults — UPDATE (`Update_CollectRowPtrs` → `Update_Blobs`), DELETE/REPLACE (`KillMulti`), id filters and docstore reads (`GetRowidByDocid`). In memory the chunk keeps the version it was loaded with, so nothing fails until the daemon restarts; then the binlog replay of the same UPDATE crash-loops the startup — exactly the sequence in the issue (our chunks were built by 28.4.4 = v.70 and ALTERed after upgrading to 29.0.2; the log shows a clean SIGTERM at 11:29 and every crash after).

Reproduced by replaying the poisoned binlog against the affected chunk under gdb: header `71`, `.spt` in the v.70 layout (first checkpoint at offset 471 instead of 24616), `Intersect()` yields rowid `0xf5010000` for docid 191429 → `DeadRowMap_c::IsSet` on `main` / `sphGetBlobAttr` on 29.0.2. The retained data dir has 120 chunks in that state.

## Change

- `docidlookup.cpp/h`: `CheckDocidLookupFormat()` validates the layout against a format version (the first checkpoint must start right after the header and the checkpoint table); `DetectDocidLookupVersion()` names the layout actually present; `UpgradeDocidLookupFile()` rewrites a pre-v.71 file into the current layout via a temporary file (header field inserted, checkpoint offsets shifted).
- `CSphIndex_VLN::UpgradeDocidLookup()` runs before the header is rewritten in `AddRemoveAttribute`, `AddRemoveField`, `SaveHeader` and `RewriteHeader`, so a chunk is brought to the current format together with its header (and `m_uVersion` is bumped only then).
- `PreallocDocidLookup()` validates the lookup on load. The unambiguous case — v.71+ header over a v.70 lookup, i.e. what released daemons produced on ALTER — is **repaired in place with a warning**; any other mismatch fails the chunk with a clear error instead of crashing later.
- `indextool --check` reports the mismatch.
- gtest `UuidDocidLookupTest.FormatCheckAndUpgrade` (v.70 layout detected under a v.71 version, upgrade, round-trip).

Not addressed here (separate issue candidate): `RtIndex_c::AddRemoveAttribute` treats a failing per-chunk `AddRemoveAttribute` as a warning while the RT schema has already advanced (`fixme: we can't rollback`).

## Verification

On the reporter's actual data (29.0.2 chunks, `planetrc_1_en`, 197k docs):
- as-is corrupted chunk + the poisoned binlog: loader logs `docid lookup is in the pre-v.71 layout while the header is v.71; upgrading the lookup in place`, the table loads, the previously crash-looping UPDATE replays, UPDATE/DELETE/`WHERE id IN` on the affected docs work, `indextool --check` passes afterwards;
- a copy with the header reverted to v.70 (the pre-ALTER state): `ALTER TABLE ... ADD COLUMN` upgrades the lookup, headers go to the current version, lookups keep working across a restart;
- before the fix `indextool --check` on the corrupted chunk: `FAILED, docid lookup layout does not match index format v.71: first checkpoint at 471, expected 24616 (the lookup is in the pre-v.71 layout ...)`.

A small scanner that finds affected chunks in a data dir (header version vs `.spt` layout) is attached to the issue.
