### PR TITLE
fix: prevent RT accumulator UAF during embedding precommit

### DIFF
--- a/src/searchdreplication.cpp
+++ b/src/searchdreplication.cpp
@@ -22,6 +22,8 @@
 #include "tracer.h"
 #include "auth/auth.h"
 
+#include <optional>
+
 #include "replication/wsrep_cxx.h"
 #include "replication/common.h"
 #include "replication/portrange.h"
@@ -1515,11 +1517,46 @@ static bool PrepareAccForSave ( RtAccum_t & tAcc )
 	return ( pIndex->PreCommit ( &tAcc, sError ) || TlsMsg::Err ( "%s", sError.cstr() ) );
 }
 
+static bool CleanupAccumForMissingIndex ( RtAccum_t & tAcc, bool bMissed )
+{
+	TlsMsg::Err ( "can not finish transaction, table %s '%s'", ( bMissed ? "missed" : "changed" ), tAcc.GetIndexName().cstr() );
+	tAcc.Cleanup();
+	return false;
+}
+
+static bool LockAccumIndexForCommit ( RtAccum_t & tAcc, std::optional<RIdx_T<RtIndex_i*>> & tIndexGuard )
+{
+	RtIndex_i * pIndex = tAcc.GetIndex();
+	if ( !pIndex )
+		return true;
+
+	cServedIndexRefPtr_c pServed = GetServed ( tAcc.GetIndexName() );
+	if ( !pServed )
+		return CleanupAccumForMissingIndex ( tAcc, true );
+
+	if ( !ServedDesc_t::IsMutable ( pServed ) )
+		return CleanupAccumForMissingIndex ( tAcc, false );
+
+	auto & tCurrent = tIndexGuard.emplace ( pServed );
+	if ( !tCurrent || pIndex!=tCurrent.Ptr() )
+		return CleanupAccumForMissingIndex ( tAcc, false );
+
+	cServedIndexRefPtr_c pCurrent = GetServed ( tAcc.GetIndexName() );
+	if ( pCurrent.Ptr()!=pServed.Ptr() )
+		return CleanupAccumForMissingIndex ( tAcc, !pCurrent );
+
+	return true;
+}
+
 
 // single point there all commands passed these might be replicated, even if no cluster
 static bool HandleCmdReplicateImpl ( RtAccum_t & tAcc, int * pDeletedCount, CSphString * pWarning, int * pUpdated ) EXCLUDES ( g_tClustersLock )
 {
 	TRACE_CORO ( "sph", "HandleCmdReplicateImpl" );
+
+	std::optional<RIdx_T<RtIndex_i*>> tIndexGuard;
+	if ( !LockAccumIndexForCommit ( tAcc, tIndexGuard ) )
+		return false;
 
 	if ( !PrepareAccForSave ( tAcc ) )
 		return false;

--- a/src/searchdreplication.cpp
+++ b/src/searchdreplication.cpp
@@ -22,8 +22,6 @@
 #include "tracer.h"
 #include "auth/auth.h"
 
-#include <optional>
-
 #include "replication/wsrep_cxx.h"
 #include "replication/common.h"
 #include "replication/portrange.h"
@@ -1513,39 +1511,31 @@ static bool PrepareAccForSave ( RtAccum_t & tAcc )
 	if ( !pIndex || !tAcc.IsRtTrxCommand() || !tAcc.m_uAccumDocs )
 		return true;
 
-	CSphString sError;
-	return ( pIndex->PreCommit ( &tAcc, sError ) || TlsMsg::Err ( "%s", sError.cstr() ) );
-}
-
-static bool CleanupAccumForMissingIndex ( RtAccum_t & tAcc, bool bMissed )
-{
-	TlsMsg::Err ( "can not finish transaction, table %s '%s'", ( bMissed ? "missed" : "changed" ), tAcc.GetIndexName().cstr() );
-	tAcc.Cleanup();
-	return false;
-}
-
-static bool LockAccumIndexForCommit ( RtAccum_t & tAcc, std::optional<RIdx_T<RtIndex_i*>> & tIndexGuard )
-{
-	RtIndex_i * pIndex = tAcc.GetIndex();
-	if ( !pIndex )
-		return true;
-
 	cServedIndexRefPtr_c pServed = GetServed ( tAcc.GetIndexName() );
 	if ( !pServed )
-		return CleanupAccumForMissingIndex ( tAcc, true );
+	{
+		TlsMsg::Err ( "can not finish transaction, table missed '%s'", tAcc.GetIndexName().cstr() );
+		tAcc.Cleanup();
+		return false;
+	}
 
 	if ( !ServedDesc_t::IsMutable ( pServed ) )
-		return CleanupAccumForMissingIndex ( tAcc, false );
+	{
+		TlsMsg::Err ( "can not finish transaction, table changed '%s'", tAcc.GetIndexName().cstr() );
+		tAcc.Cleanup();
+		return false;
+	}
 
-	auto & tCurrent = tIndexGuard.emplace ( pServed );
-	if ( !tCurrent || pIndex!=tCurrent.Ptr() )
-		return CleanupAccumForMissingIndex ( tAcc, false );
+	RIdx_T<RtIndex_i*> pLockedIndex ( pServed );
+	if ( !pLockedIndex || pLockedIndex.Ptr()!=pIndex )
+	{
+		TlsMsg::Err ( "can not finish transaction, table changed '%s'", tAcc.GetIndexName().cstr() );
+		tAcc.Cleanup();
+		return false;
+	}
 
-	cServedIndexRefPtr_c pCurrent = GetServed ( tAcc.GetIndexName() );
-	if ( pCurrent.Ptr()!=pServed.Ptr() )
-		return CleanupAccumForMissingIndex ( tAcc, !pCurrent );
-
-	return true;
+	CSphString sError;
+	return ( pLockedIndex->PreCommit ( &tAcc, sError ) || TlsMsg::Err ( "%s", sError.cstr() ) );
 }
 
 
@@ -1553,10 +1543,6 @@ static bool LockAccumIndexForCommit ( RtAccum_t & tAcc, std::optional<RIdx_T<RtI
 static bool HandleCmdReplicateImpl ( RtAccum_t & tAcc, int * pDeletedCount, CSphString * pWarning, int * pUpdated ) EXCLUDES ( g_tClustersLock )
 {
 	TRACE_CORO ( "sph", "HandleCmdReplicateImpl" );
-
-	std::optional<RIdx_T<RtIndex_i*>> tIndexGuard;
-	if ( !LockAccumIndexForCommit ( tAcc, tIndexGuard ) )
-		return false;
 
 	if ( !PrepareAccForSave ( tAcc ) )
 		return false;

--- a/src/searchdreplication.cpp
+++ b/src/searchdreplication.cpp
@@ -1507,18 +1507,10 @@ static bool HandleRealCmdReplicate ( RtAccum_t & tAcc, CommitMonitor_c && tMonit
 
 static bool PrepareAccForSave ( RtAccum_t & tAcc )
 {
-	RtIndex_i * pIndex = tAcc.GetIndex();
-	if ( !pIndex || !tAcc.IsRtTrxCommand() || !tAcc.m_uAccumDocs )
+	if ( !tAcc.GetIndex() || !tAcc.IsRtTrxCommand() || !tAcc.m_uAccumDocs )
 		return true;
 
 	cServedIndexRefPtr_c pServed = GetServed ( tAcc.GetIndexName() );
-	if ( !pServed )
-	{
-		TlsMsg::Err ( "can not finish transaction, table missed '%s'", tAcc.GetIndexName().cstr() );
-		tAcc.Cleanup();
-		return false;
-	}
-
 	if ( !ServedDesc_t::IsMutable ( pServed ) )
 	{
 		TlsMsg::Err ( "can not finish transaction, table changed '%s'", tAcc.GetIndexName().cstr() );
@@ -1527,7 +1519,7 @@ static bool PrepareAccForSave ( RtAccum_t & tAcc )
 	}
 
 	RIdx_T<RtIndex_i*> pLockedIndex ( pServed );
-	if ( !pLockedIndex || pLockedIndex.Ptr()!=pIndex )
+	if ( !pLockedIndex || pLockedIndex->GetIndexId()!=tAcc.GetIndexId() )
 	{
 		TlsMsg::Err ( "can not finish transaction, table changed '%s'", tAcc.GetIndexName().cstr() );
 		tAcc.Cleanup();

--- a/test/clt-tests/bugs/4860-bulk-auto-embeddings-drop-crash.rec
+++ b/test/clt-tests/bugs/4860-bulk-auto-embeddings-drop-crash.rec
@@ -1,0 +1,94 @@
+––– comment –––
+Regression for issue 4860. A delayed remote auto-embedding bulk insert must not leave an RT accumulator with a dangling table pointer if DROP TABLE removes the table while PreCommit waits for embeddings.
+The bulk response can either succeed before drop wins or fail cleanly after drop wins. The required behavior is that searchd remains alive and the log has no crash dump.
+––– block: ../base/start-searchd-with-buddy –––
+––– input –––
+cat > /tmp/issue4860_mock.py <<'PY'
+#!/usr/bin/env python3
+import json
+import re
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        pass
+
+    def do_POST(self):
+        print(f"Mock embeddings request: POST {self.path}", flush=True)
+        length = int(self.headers.get('Content-Length', '0'))
+        body = self.rfile.read(length) if length else b'{}'
+        try:
+            payload = json.loads(body.decode('utf-8'))
+        except Exception:
+            payload = {}
+        inputs = payload.get('input', [])
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        delay = 0.0
+        for text in inputs:
+            m = re.search(r'delay=(\d+(?:\.\d+)?)', str(text))
+            if m:
+                delay = float(m.group(1))
+        if delay:
+            time.sleep(delay)
+        embedding = [0.001] * 1536
+        response = json.dumps({
+            'data': [ {'embedding': embedding} for _ in inputs ],
+            'model': payload.get('model', 'text-embedding-ada-002'),
+            'usage': {'prompt_tokens': 0, 'total_tokens': 0},
+        }).encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+server = ThreadingHTTPServer(('127.0.0.1', 8086), Handler)
+print('Mock embeddings server listening', flush=True)
+server.serve_forever()
+PY
+python3 -u /tmp/issue4860_mock.py > /tmp/mock-server-4860.log 2>&1 &
+echo "Mock server started"
+for i in $(seq 1 50); do
+  if grep -q 'Mock embeddings server listening' /tmp/mock-server-4860.log 2>/dev/null; then break; fi
+  sleep 0.1
+done
+––– output –––
+Mock server started
+––– input –––
+mysql -E -h0 -P9306 -e "CREATE TABLE issue4860 (title TEXT, vec FLOAT_VECTOR KNN_TYPE='hnsw' HNSW_SIMILARITY='l2' MODEL_NAME='openai/text-embedding-ada-002' FROM='title' API_KEY='test-key' API_URL='http://127.0.0.1:8086/v1/embeddings' API_TIMEOUT='15')"; echo $?
+––– output –––
+0
+––– input –––
+rm -f /tmp/issue4860_bulk.out /tmp/issue4860_bulk.rc /tmp/issue4860_drop.out
+(
+  curl -sS -X POST http://127.0.0.1:9308/bulk -H "Content-Type: application/x-ndjson" --data-binary @- > /tmp/issue4860_bulk.out 2>&1 <<'NDJSON'
+{"insert":{"index":"issue4860","id":1,"doc":{"title":"bulk delay=4.0 alpha"}}}
+{"insert":{"index":"issue4860","id":2,"doc":{"title":"bulk delay=4.0 beta"}}}
+NDJSON
+  echo $? > /tmp/issue4860_bulk.rc
+) &
+bulk_pid=$!
+for i in $(seq 1 50); do
+  if grep -q 'Mock embeddings request: POST /v1/embeddings' /tmp/mock-server-4860.log 2>/dev/null; then echo "embedding request observed"; break; fi
+  sleep 0.1
+done
+if ! grep -q 'Mock embeddings request: POST /v1/embeddings' /tmp/mock-server-4860.log 2>/dev/null; then echo "embedding request missing"; fi
+mysql -E -h0 -P9306 -e "DROP TABLE issue4860" > /tmp/issue4860_drop.out 2>&1
+drop_rc=$?
+wait "$bulk_pid" || true
+bulk_rc=$(cat /tmp/issue4860_bulk.rc 2>/dev/null || echo missing)
+echo "drop rc: $drop_rc"
+echo "bulk curl rc: $bulk_rc"
+if mysql -E -h0 -P9306 -e "SELECT 1" >/dev/null 2>&1; then echo "searchd alive"; else echo "searchd down"; fi
+if grep -qE 'FATAL: CRASH DUMP|Handling signal' /var/log/manticore/searchd.log; then echo "log crashed"; else echo "no crash"; fi
+if grep -qE 'RtAccum_t::RebuildStoragesForEmbeddings|PrepareAccForSave|PreCommit' /var/log/manticore/searchd.log; then echo "issue4860 stack"; else echo "no issue4860 stack"; fi
+––– output –––
+embedding request observed
+drop rc: 0
+bulk curl rc: 0
+searchd alive
+no crash
+no issue4860 stack

--- a/test/clt-tests/bugs/4860-bulk-auto-embeddings-drop-crash.rec
+++ b/test/clt-tests/bugs/4860-bulk-auto-embeddings-drop-crash.rec
@@ -3,56 +3,10 @@ Regression for issue 4860. A delayed remote auto-embedding bulk insert must not 
 The bulk response can either succeed before drop wins or fail cleanly after drop wins. The required behavior is that searchd remains alive and the log has no crash dump.
 ––– block: ../base/start-searchd-with-buddy –––
 ––– input –––
-cat > /tmp/issue4860_mock.py <<'PY'
-#!/usr/bin/env python3
-import json
-import re
-import sys
-import time
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-
-class Handler(BaseHTTPRequestHandler):
-    def log_message(self, fmt, *args):
-        pass
-
-    def do_POST(self):
-        print(f"Mock embeddings request: POST {self.path}", flush=True)
-        length = int(self.headers.get('Content-Length', '0'))
-        body = self.rfile.read(length) if length else b'{}'
-        try:
-            payload = json.loads(body.decode('utf-8'))
-        except Exception:
-            payload = {}
-        inputs = payload.get('input', [])
-        if isinstance(inputs, str):
-            inputs = [inputs]
-        delay = 0.0
-        for text in inputs:
-            m = re.search(r'delay=(\d+(?:\.\d+)?)', str(text))
-            if m:
-                delay = float(m.group(1))
-        if delay:
-            time.sleep(delay)
-        embedding = [0.001] * 1536
-        response = json.dumps({
-            'data': [ {'embedding': embedding} for _ in inputs ],
-            'model': payload.get('model', 'text-embedding-ada-002'),
-            'usage': {'prompt_tokens': 0, 'total_tokens': 0},
-        }).encode('utf-8')
-        self.send_response(200)
-        self.send_header('Content-Type', 'application/json')
-        self.send_header('Content-Length', str(len(response)))
-        self.end_headers()
-        self.wfile.write(response)
-
-server = ThreadingHTTPServer(('127.0.0.1', 8086), Handler)
-print('Mock embeddings server listening', flush=True)
-server.serve_forever()
-PY
-python3 -u /tmp/issue4860_mock.py > /tmp/mock-server-4860.log 2>&1 &
+php /manticore/test/clt-tests/mcl/mock-embeddings-server.php --host 127.0.0.1 --port 8086 --provider openai --delay 4.0 > /tmp/mock-server-4860.log 2>&1 &
 echo "Mock server started"
 for i in $(seq 1 50); do
-  if grep -q 'Mock embeddings server listening' /tmp/mock-server-4860.log 2>/dev/null; then break; fi
+  if grep -q 'listening on http://127.0.0.1:8086/v1/embeddings' /tmp/mock-server-4860.log 2>/dev/null; then break; fi
   sleep 0.1
 done
 ––– output –––
@@ -65,17 +19,14 @@ mysql -E -h0 -P9306 -e "CREATE TABLE issue4860 (title TEXT, vec FLOAT_VECTOR KNN
 rm -f /tmp/issue4860_bulk.out /tmp/issue4860_bulk.rc /tmp/issue4860_drop.out
 (
   curl -sS -X POST http://127.0.0.1:9308/bulk -H "Content-Type: application/x-ndjson" --data-binary @- > /tmp/issue4860_bulk.out 2>&1 <<'NDJSON'
-{"insert":{"index":"issue4860","id":1,"doc":{"title":"bulk delay=4.0 alpha"}}}
-{"insert":{"index":"issue4860","id":2,"doc":{"title":"bulk delay=4.0 beta"}}}
+{"insert":{"index":"issue4860","id":1,"doc":{"title":"alpha"}}}
+{"insert":{"index":"issue4860","id":2,"doc":{"title":"beta"}}}
 NDJSON
   echo $? > /tmp/issue4860_bulk.rc
 ) &
 bulk_pid=$!
-for i in $(seq 1 50); do
-  if grep -q 'Mock embeddings request: POST /v1/embeddings' /tmp/mock-server-4860.log 2>/dev/null; then echo "embedding request observed"; break; fi
-  sleep 0.1
-done
-if ! grep -q 'Mock embeddings request: POST /v1/embeddings' /tmp/mock-server-4860.log 2>/dev/null; then echo "embedding request missing"; fi
+sleep 1
+echo "embedding delay window elapsed"
 mysql -E -h0 -P9306 -e "DROP TABLE issue4860" > /tmp/issue4860_drop.out 2>&1
 drop_rc=$?
 wait "$bulk_pid" || true
@@ -86,7 +37,7 @@ if mysql -E -h0 -P9306 -e "SELECT 1" >/dev/null 2>&1; then echo "searchd alive";
 if grep -qE 'FATAL: CRASH DUMP|Handling signal' /var/log/manticore/searchd.log; then echo "log crashed"; else echo "no crash"; fi
 if grep -qE 'RtAccum_t::RebuildStoragesForEmbeddings|PrepareAccForSave|PreCommit' /var/log/manticore/searchd.log; then echo "issue4860 stack"; else echo "no issue4860 stack"; fi
 ––– output –––
-embedding request observed
+embedding delay window elapsed
 drop rc: 0
 bulk curl rc: 0
 searchd alive

--- a/test/clt-tests/bugs/4860-bulk-auto-embeddings-drop-crash.rec
+++ b/test/clt-tests/bugs/4860-bulk-auto-embeddings-drop-crash.rec
@@ -1,6 +1,6 @@
 ––– comment –––
 Regression for issue 4860. A delayed remote auto-embedding bulk insert must not leave an RT accumulator with a dangling table pointer if DROP TABLE removes the table while PreCommit waits for embeddings.
-The bulk response can either succeed before drop wins or fail cleanly after drop wins. The required behavior is that searchd remains alive and the log has no crash dump.
+The test issues DROP TABLE only after the mock has observed the embeddings request, so the fixed daemon should keep searchd alive, finish the bulk insert, and then let DROP complete.
 ––– block: ../base/start-searchd-with-buddy –––
 ––– input –––
 php /manticore/test/clt-tests/mcl/mock-embeddings-server.php --host 127.0.0.1 --port 8086 --provider openai --delay 4.0 > /tmp/mock-server-4860.log 2>&1 &
@@ -16,6 +16,7 @@ mysql -E -h0 -P9306 -e "CREATE TABLE issue4860 (title TEXT, vec FLOAT_VECTOR KNN
 ––– output –––
 0
 ––– input –––
+: > /tmp/mock-server-4860.log
 rm -f /tmp/issue4860_bulk.out /tmp/issue4860_bulk.rc /tmp/issue4860_drop.out
 (
   curl -sS -X POST http://127.0.0.1:9308/bulk -H "Content-Type: application/x-ndjson" --data-binary @- > /tmp/issue4860_bulk.out 2>&1 <<'NDJSON'
@@ -25,8 +26,12 @@ NDJSON
   echo $? > /tmp/issue4860_bulk.rc
 ) &
 bulk_pid=$!
-sleep 1
-echo "embedding delay window elapsed"
+request_seen=0
+for i in $(seq 1 100); do
+  if grep -q 'Mock embeddings request: POST /v1/embeddings' /tmp/mock-server-4860.log 2>/dev/null; then request_seen=1; break; fi
+  sleep 0.1
+done
+if [ "$request_seen" -eq 1 ]; then echo "embedding request observed"; else echo "embedding request missing"; fi
 mysql -E -h0 -P9306 -e "DROP TABLE issue4860" > /tmp/issue4860_drop.out 2>&1
 drop_rc=$?
 wait "$bulk_pid" || true
@@ -37,7 +42,7 @@ if mysql -E -h0 -P9306 -e "SELECT 1" >/dev/null 2>&1; then echo "searchd alive";
 if grep -qE 'FATAL: CRASH DUMP|Handling signal' /var/log/manticore/searchd.log; then echo "log crashed"; else echo "no crash"; fi
 if grep -qE 'RtAccum_t::RebuildStoragesForEmbeddings|PrepareAccForSave|PreCommit' /var/log/manticore/searchd.log; then echo "issue4860 stack"; else echo "no issue4860 stack"; fi
 ––– output –––
-embedding delay window elapsed
+embedding request observed
 drop rc: 0
 bulk curl rc: 0
 searchd alive

--- a/test/clt-tests/mcl/mock-embeddings-server.php
+++ b/test/clt-tests/mcl/mock-embeddings-server.php
@@ -570,6 +570,8 @@ function main() {
                 'Access-Control-Allow-Headers: Content-Type, Authorization'
             ], '');
         } elseif ($parsed['method'] === 'POST' && $parsed['path'] === '/v1/embeddings') {
+            echo "Mock embeddings request: {$parsed['method']} {$parsed['path']}\n";
+            fflush(STDOUT);
             $result = handle_embeddings_request($parsed['headers'], $parsed['body'], $delay, $provider);
             $response = format_response($result['code'], $result['headers'], $result['body']);
         } else {
@@ -592,4 +594,3 @@ function main() {
 
 // Run main function
 main();
-


### PR DESCRIPTION
Hold the served RT index guard while commit/precommit can wait for remote auto-embeddings. If the table was dropped or replaced before commit, clean the accumulator and fail the transaction instead of using the stale raw table pointer.

Add a CLT regression for DROP TABLE racing with delayed /bulk auto-embedding generation.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4860