### PR TITLE
RT: rebuild the per-attribute embedding model table on every ALTER - ALTER-added MVA columns lost their values (#4872)

### DIFF
--- a/src/accumulator.cpp
+++ b/src/accumulator.cpp
@@ -336,6 +336,7 @@ bool RtAccum_t::FetchEmbeddings ( TableEmbeddings_c * pEmbeddings, const CSphVec
 
 	assert(m_pIndex);
 	const CSphSchema & tSchema = m_pIndex->GetInternalSchema();
+	assert ( dAttrsWithModels.GetLength()==tSchema.GetAttrsCount() ); // the table is walked in parallel with the attributes (manticoresearch#4872)
 
 	// we need to rebuild our blobs/columnar storage (to replace empty data with fetched floatvectors), but they are immutable by design
 	// so we'll have to rebuild the blobs/columnar storage fully

--- a/src/accumulator.cpp
+++ b/src/accumulator.cpp
@@ -336,7 +336,7 @@ bool RtAccum_t::FetchEmbeddings ( TableEmbeddings_c * pEmbeddings, const CSphVec
 
 	assert(m_pIndex);
 	const CSphSchema & tSchema = m_pIndex->GetInternalSchema();
-	assert ( dAttrsWithModels.GetLength()==tSchema.GetAttrsCount() ); // the table is walked in parallel with the attributes (manticoresearch#4872)
+	assert ( dAttrsWithModels.GetLength()==tSchema.GetAttrsCount() ); // fix #4872
 
 	// we need to rebuild our blobs/columnar storage (to replace empty data with fetched floatvectors), but they are immutable by design
 	// so we'll have to rebuild the blobs/columnar storage fully

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -5983,20 +5983,23 @@ bool RtIndex_c::PreallocDiskChunks ( FilenameBuilder_i * pFilenameBuilder, StrVe
 }
 
 
-static bool PrepareEmbeddingModelsForSchema ( CSphSchema & tSchema, std::unique_ptr<TableEmbeddings_c> & pEmbeddings, CSphVector<AttrWithModel_t> & dAttrsWithModels, CSphString & sError )
+static bool SchemaHasEmbeddingModels ( const CSphSchema & tSchema )
 {
-	pEmbeddings.reset();
-	dAttrsWithModels.Reset();
-
-	bool bHaveModels = false;
 	for ( int i = 0 ; i < tSchema.GetAttrsCount(); i++ )
-		bHaveModels |= !tSchema.GetAttr(i).m_tKNNModel.m_sModelName.empty();
+		if ( !tSchema.GetAttr(i).m_tKNNModel.m_sModelName.empty() )
+			return true;
 
-	if ( !bHaveModels )
-		return true;
+	return false;
+}
 
+
+// fills the per-attribute model table for tSchema (the accumulator walks it in parallel with the schema attributes,
+// so it must be rebuilt whenever the attributes change); models that tEmbeddings already holds are reused, the
+// others are loaded into it
+static bool PrepareAttrsWithModels ( CSphSchema & tSchema, TableEmbeddings_c & tEmbeddings, CSphVector<AttrWithModel_t> & dAttrsWithModels, CSphString & sError )
+{
+	dAttrsWithModels.Reset();
 	dAttrsWithModels.Resize ( tSchema.GetAttrsCount() );
-	pEmbeddings = std::make_unique<TableEmbeddings_c>();
 	for ( int i = 0; i < tSchema.GetAttrsCount(); i++ )
 	{
 		const auto & tAttr = tSchema.GetAttr(i);
@@ -6008,12 +6011,16 @@ static bool PrepareEmbeddingModelsForSchema ( CSphSchema & tSchema, std::unique_
 		if ( !ParseEmbeddingSources ( dAttrsWithModels[i].m_dFrom, tAttr.m_sKNNFrom, tSchema, sError ) )
 			return false;
 
-		if ( !pEmbeddings->Load ( tAttr.m_sName, tAttr.m_tKNNModel, sError ) )
-			return false;
+		auto pModel = tEmbeddings.GetModel ( tAttr.m_sName );
+		if ( !pModel )
+		{
+			if ( !tEmbeddings.Load ( tAttr.m_sName, tAttr.m_tKNNModel, sError ) )
+				return false;
 
-		auto pModel = pEmbeddings->GetModel ( tAttr.m_sName );
+			pModel = tEmbeddings.GetModel ( tAttr.m_sName );
+		}
+
 		assert(pModel);
-
 		dAttrsWithModels[i].m_pModel = pModel;
 
 		// fixme! modifying the schema
@@ -6021,6 +6028,20 @@ static bool PrepareEmbeddingModelsForSchema ( CSphSchema & tSchema, std::unique_
 	}
 
 	return true;
+}
+
+
+// loads the models of tSchema from scratch and fills the per-attribute model table
+static bool PrepareEmbeddingModelsForSchema ( CSphSchema & tSchema, std::unique_ptr<TableEmbeddings_c> & pEmbeddings, CSphVector<AttrWithModel_t> & dAttrsWithModels, CSphString & sError )
+{
+	pEmbeddings.reset();
+	dAttrsWithModels.Reset();
+
+	if ( !SchemaHasEmbeddingModels ( tSchema ) )
+		return true;
+
+	pEmbeddings = std::make_unique<TableEmbeddings_c>();
+	return PrepareAttrsWithModels ( tSchema, *pEmbeddings, dAttrsWithModels, sError );
 }
 
 bool RtIndex_c::LoadEmbeddingModels ( CSphString & sError )
@@ -9894,6 +9915,12 @@ bool RtIndex_c::AddRemoveField ( bool bAdd, const CSphString & sFieldName, DWORD
 	if ( !Alter_AddRemoveFieldFromSchema ( bAdd, tNewSchema, sFieldName, uFieldFlags, sError ) )
 		return false;
 
+	// the embedding sources (FROM=...) are resolved to field ids, so they must follow the new schema;
+	// dropping a field an embedding is built from is refused here
+	CSphVector<AttrWithModel_t> dPreparedAttrsWithModels;
+	if ( m_pEmbeddings && !PrepareAttrsWithModels ( tNewSchema, *m_pEmbeddings, dPreparedAttrsWithModels, sError ) )
+		return false;
+
 	m_tSchema = tNewSchema;
 
 	auto tGuard = RtGuard();
@@ -9908,6 +9935,9 @@ bool RtIndex_c::AddRemoveField ( bool bAdd, const CSphString & sFieldName, DWORD
 		AddFieldToRamchunk ( sFieldName, uFieldFlags, tOldSchema, tNewSchema );
 	else
 		RemoveFieldFromRamchunk ( sFieldName, tOldSchema, tNewSchema );
+
+	if ( m_pEmbeddings )
+		m_dAttrsWithModels.SwapData ( dPreparedAttrsWithModels );
 
 	// fixme: we can't rollback at this point
 	RaiseAlterGeneration();
@@ -9976,7 +10006,18 @@ bool RtIndex_c::AddRemoveAttribute ( bool bAdd, const AttrAddRemoveCtx_t & tCtx,
 	std::unique_ptr<TableEmbeddings_c> pPreparedEmbeddings;
 	CSphVector<AttrWithModel_t> dPreparedAttrsWithModels;
 
+	// the per-attribute model table is parallel to the schema attributes, so it must be rebuilt on EVERY attribute
+	// change, not only when the added column is model-backed: the accumulator repacks the blob storage of each
+	// inserted document along that table, and a blob attribute added past its end was never copied - an MVA added
+	// with ALTER to a table with an auto-embedding column silently lost every value (manticoresearch#4872).
+	// a model-backed column loads its models from scratch (its settings are new); any other change keeps the loaded ones
 	const bool bModelBackedEmbedding = ( bAdd && IsModelBackedEmbedding ( tNewCtx ) );
+	if ( !bModelBackedEmbedding && m_pEmbeddings )
+	{
+		if ( !PrepareAttrsWithModels ( tNewSchema, *m_pEmbeddings, dPreparedAttrsWithModels, sError ) )
+			return false;
+	}
+
 	if ( bModelBackedEmbedding )
 	{
 		if ( !PrepareEmbeddingModelsForSchema ( tNewSchema, pPreparedEmbeddings, dPreparedAttrsWithModels, sError ) )
@@ -10018,6 +10059,15 @@ bool RtIndex_c::AddRemoveAttribute ( bool bAdd, const AttrAddRemoveCtx_t & tCtx,
 	{
 		m_pEmbeddings = std::move ( pPreparedEmbeddings );
 		m_dAttrsWithModels.SwapData ( dPreparedAttrsWithModels );
+	}
+	else if ( m_pEmbeddings )
+	{
+		m_dAttrsWithModels.SwapData ( dPreparedAttrsWithModels );
+		if ( !SchemaHasEmbeddingModels ( m_tSchema ) ) // the last model-backed column was dropped
+		{
+			m_pEmbeddings.reset();
+			m_dAttrsWithModels.Reset();
+		}
 	}
 
 	// fixme: we can't rollback at this point

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -5993,9 +5993,7 @@ static bool SchemaHasEmbeddingModels ( const CSphSchema & tSchema )
 }
 
 
-// fills the per-attribute model table for tSchema (the accumulator walks it in parallel with the schema attributes,
-// so it must be rebuilt whenever the attributes change); models that tEmbeddings already holds are reused, the
-// others are loaded into it
+// models that tEmbeddings already holds are reused; the others are loaded into it
 static bool PrepareAttrsWithModels ( CSphSchema & tSchema, TableEmbeddings_c & tEmbeddings, CSphVector<AttrWithModel_t> & dAttrsWithModels, CSphString & sError )
 {
 	dAttrsWithModels.Reset();
@@ -6031,7 +6029,6 @@ static bool PrepareAttrsWithModels ( CSphSchema & tSchema, TableEmbeddings_c & t
 }
 
 
-// loads the models of tSchema from scratch and fills the per-attribute model table
 static bool PrepareEmbeddingModelsForSchema ( CSphSchema & tSchema, std::unique_ptr<TableEmbeddings_c> & pEmbeddings, CSphVector<AttrWithModel_t> & dAttrsWithModels, CSphString & sError )
 {
 	pEmbeddings.reset();
@@ -9915,11 +9912,14 @@ bool RtIndex_c::AddRemoveField ( bool bAdd, const CSphString & sFieldName, DWORD
 	if ( !Alter_AddRemoveFieldFromSchema ( bAdd, tNewSchema, sFieldName, uFieldFlags, sError ) )
 		return false;
 
-	// the embedding sources (FROM=...) are resolved to field ids, so they must follow the new schema;
-	// dropping a field an embedding is built from is refused here
+	// the embedding sources (FROM=...) are field ids - rebuild them for the new schema (fix #4872)
 	CSphVector<AttrWithModel_t> dPreparedAttrsWithModels;
 	if ( m_pEmbeddings && !PrepareAttrsWithModels ( tNewSchema, *m_pEmbeddings, dPreparedAttrsWithModels, sError ) )
+	{
+		if ( !bAdd )
+			sError.SetSprintf ( "%s; a field used as an embedding source can be dropped after the embedding column itself is dropped", sError.cstr() );
 		return false;
+	}
 
 	m_tSchema = tNewSchema;
 
@@ -10006,11 +10006,7 @@ bool RtIndex_c::AddRemoveAttribute ( bool bAdd, const AttrAddRemoveCtx_t & tCtx,
 	std::unique_ptr<TableEmbeddings_c> pPreparedEmbeddings;
 	CSphVector<AttrWithModel_t> dPreparedAttrsWithModels;
 
-	// the per-attribute model table is parallel to the schema attributes, so it must be rebuilt on EVERY attribute
-	// change, not only when the added column is model-backed: the accumulator repacks the blob storage of each
-	// inserted document along that table, and a blob attribute added past its end was never copied - an MVA added
-	// with ALTER to a table with an auto-embedding column silently lost every value (manticoresearch#4872).
-	// a model-backed column loads its models from scratch (its settings are new); any other change keeps the loaded ones
+	// m_dAttrsWithModels is parallel to the schema attributes - rebuild it on every attribute change (fix #4872)
 	const bool bModelBackedEmbedding = ( bAdd && IsModelBackedEmbedding ( tNewCtx ) );
 	if ( !bModelBackedEmbedding && m_pEmbeddings )
 	{

--- a/test/clt-tests/mcl/auto-embeddings-alter-add-mva.rec
+++ b/test/clt-tests/mcl/auto-embeddings-alter-add-mva.rec
@@ -57,8 +57,18 @@ mysql -h0 -P9306 -N -B -e "SELECT id FROM t WHERE knn(vec, 1, 'four') LIMIT 1" |
 ––– output –––
 4
 ––– comment –––
-A field the embedding is built from can not be dropped any more (the sources are resolved against the new schema)
+A field the embedding is built from can not be dropped while a model still uses it; the error names the way out
 ––– input –––
 mysql -h0 -P9306 -e "ALTER TABLE t DROP COLUMN title" 2>&1 | head -1
 ––– output –––
-ERROR 1064 (42000) at line 1: table t: embedding source 'title' not found
+ERROR 1064 (42000) at line 1: table t: embedding source 'title' not found; a field used as an embedding source can be dropped after the embedding column itself is dropped
+––– comment –––
+The supported order: drop the model-backed column first, then its former source; the table stays functional
+––– input –––
+mysql -h0 -P9306 -e "ALTER TABLE t DROP COLUMN vec; ALTER TABLE t DROP COLUMN title; INSERT INTO t (id, m, m2, u2) VALUES (5,(83,84),(93,94),13)" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -N -B -e "SELECT id, m, m2, u2 FROM t WHERE id=5" | grep -v '^+' | sed 's/^| *//; s/ *| */,/g; s/,$//' | tr '\t' ','
+––– output –––
+5,83,84,93,94,13

--- a/test/clt-tests/mcl/auto-embeddings-alter-add-mva.rec
+++ b/test/clt-tests/mcl/auto-embeddings-alter-add-mva.rec
@@ -1,0 +1,64 @@
+Issue #4872: a multi (MVA) column added with ALTER TABLE to a table that has an auto-embedding float_vector must keep the values written by INSERT / REPLACE
+
+The per-attribute model table of an RT table was built when the table was loaded and only rebuilt when the added column was itself model-backed. The accumulator repacks the blob storage of every inserted document along that table, so a blob attribute added later was never copied: the MVA came back empty, with no error, while an int added by the same ALTER survived (rowwise attributes are not repacked). Dropping an attribute in front of the vector column misaligned the table the same way. The table is now rebuilt on every ALTER.
+
+––– block: ../base/start-searchd –––
+––– block: ./base –––
+––– input –––
+mysql -h0 -P9306 -e "CREATE TABLE t (title text, m multi, u int, vec float_vector KNN_TYPE='hnsw' HNSW_SIMILARITY='cosine' MODEL_NAME='sentence-transformers/all-MiniLM-L6-v2' FROM='title')" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "INSERT INTO t (id, title, m, u) VALUES (1,'one',(11,12),5),(2,'two',(21,22),6); FLUSH RAMCHUNK t" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "ALTER TABLE t ADD COLUMN m2 multi; ALTER TABLE t ADD COLUMN u2 int" 2>&1; echo $?
+––– output –––
+0
+––– comment –––
+REPLACE of a doc that lives in the disk chunk and INSERT of a new one (RAM chunk): the added MVA must arrive like the added int
+––– input –––
+mysql -h0 -P9306 -e "REPLACE INTO t (id, title, m, u, m2, u2) VALUES (1,'one replaced',(11,12),5,(41,42),8); INSERT INTO t (id, title, m, u, m2, u2) VALUES (3,'three',(31,32),7,(61,62),10)" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SELECT id, m, u, m2, u2 FROM t ORDER BY id ASC"
+––– output –––
++------+-------+------+-------+------+
+| id   | m     | u    | m2    | u2   |
++------+-------+------+-------+------+
+|    1 | 11,12 |    5 | 41,42 |    8 |
+|    2 | 21,22 |    6 |       |    0 |
+|    3 | 31,32 |    7 | 61,62 |   10 |
++------+-------+------+-------+------+
+––– comment –––
+The embeddings of the rewritten docs are still generated from the title
+––– input –––
+mysql -h0 -P9306 -N -B -e "SELECT id FROM t WHERE knn(vec, 1, 'three') LIMIT 1" | grep -v '^+' | tr -d '| '
+––– output –––
+3
+––– comment –––
+Dropping an attribute in front of the vector column shifts the attribute ids: inserts must still carry the MVAs and get an embedding
+––– input –––
+mysql -h0 -P9306 -e "ALTER TABLE t DROP COLUMN u; INSERT INTO t (id, title, m, m2, u2) VALUES (4,'four',(81,82),(91,92),12)" 2>&1; echo $?
+––– output –––
+0
+––– input –––
+mysql -h0 -P9306 -e "SELECT id, m, m2, u2 FROM t WHERE id=4"
+––– output –––
++------+-------+-------+------+
+| id   | m     | m2    | u2   |
++------+-------+-------+------+
+|    4 | 81,82 | 91,92 |   12 |
++------+-------+-------+------+
+––– input –––
+mysql -h0 -P9306 -N -B -e "SELECT id FROM t WHERE knn(vec, 1, 'four') LIMIT 1" | grep -v '^+' | tr -d '| '
+––– output –––
+4
+––– comment –––
+A field the embedding is built from can not be dropped any more (the sources are resolved against the new schema)
+––– input –––
+mysql -h0 -P9306 -e "ALTER TABLE t DROP COLUMN title" 2>&1 | head -1
+––– output –––
+ERROR 1064 (42000) at line 1: table t: embedding source 'title' not found


### PR DESCRIPTION
Fixes #4872.

### Root cause

An RT table with an auto-embedding `float_vector` keeps a per-attribute table of models (`m_dAttrsWithModels`, one entry per schema attribute). On commit the accumulator repacks the blob storage of every inserted document by walking that table (`RtAccum_t::RebuildStoragesForEmbeddings`: `ARRAY_FOREACH ( i, dAttrsWithModels )`). The table was built when the table was loaded (`PrepareEmbeddingModelsForSchema`) and `RtIndex_c::AddRemoveAttribute` only rebuilt it when the added column was itself model-backed. After a plain `ALTER TABLE ... ADD COLUMN m2 multi` it was therefore shorter than the schema, and the blob attributes past its end were never copied into the new blob pool: the MVA came back empty, with no error. An added `int` survived because rowwise attributes are not repacked; `UPDATE` worked because it does not go through the accumulator; a table whose vector has no `MODEL_NAME` was fine because the repack never runs. A `DROP COLUMN` in front of the vector column misaligned the table the same way, and `AddRemoveField` never refreshed the `FROM=` source ids either.

### Fix

- `PrepareEmbeddingModelsForSchema` is split into `PrepareAttrsWithModels` (fills the table for a schema, reusing the models a `TableEmbeddings_c` already holds, loading the others) and the from-scratch wrapper it was.
- `AddRemoveAttribute` / `AddRemoveField` rebuild the table for the new schema on every change. A model-backed column keeps today's behaviour (models loaded from scratch, its settings are new); any other change keeps the loaded models, so a plain ALTER does not reload them. When the last model-backed column is dropped the embeddings state is released.
- Dropping a field an embedding is built `FROM` is now refused (`table t: embedding source 'title' not found`) instead of leaving a stale field id behind - please tell me if you would rather keep that permissive.
- Contract assert in `RtAccum_t::FetchEmbeddings` (table length == attribute count), no release-build checks.

### Test

`test/clt-tests/mcl/auto-embeddings-alter-add-mva.rec` with `sentence-transformers/all-MiniLM-L6-v2`: CREATE with an auto-embedding column, INSERT + FLUSH RAMCHUNK, ADD COLUMN multi + int, REPLACE of a disk-chunk doc and INSERT of a RAM-chunk doc (both MVAs must arrive, embeddings still generated), DROP COLUMN in front of the vector column + INSERT, DROP of the source field refused.

Verified locally with a build of this branch against the reproducer from the issue (all values kept, knn on the rewritten docs works); on 29.0.2 the same steps lose the MVA values as reported.