### PR TITLE
ci(mcl): skip quality checks on release embeddings builds

### DIFF
--- a/.github/workflows/mcl_pack_publish.yml
+++ b/.github/workflows/mcl_pack_publish.yml
@@ -122,6 +122,9 @@ jobs:
       source_ref: ${{ inputs.source_ref }}
       distr: ${{ matrix.distr }}
       arch: ${{ matrix.arch }}
+      # quality checks (cargo test + clippy) are owned by the columnar repo CI,
+      # which runs them on every push; don't repeat them on release builds
+      run_quality_checks: false
 
   pack_debian_ubuntu:
     if: ${{ inputs.enabled }}


### PR DESCRIPTION
The quality-check job (cargo test + clippy) is owned by the columnar repository CI, which runs it on every push to the pinned SHA. Release builds re-ran it via the default run_quality_checks=true; test.yml already passes false. Align the release path the same way.

As discussed before we decided to extract RELATED ci back to columnar and keep it as first guard of changes to see any issues without need to update submodule tip here.

The related pull request: https://github.com/manticoresoftware/columnar/pull/202