### PR TITLE
🆕 Update buddy version from 4.4.2 to 4.4.3

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,5 +1,5 @@
 backup 1.10.4+26083111-f330f780-dev
-buddy 4.4.2+26082819-2abf5555-dev
+buddy 4.4.3+26083121-976df147-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
 load 1.26.0+26081813-fac2ff17-dev


### PR DESCRIPTION
Update [buddy](https://github.com/manticoresoftware/manticoresearch-buddy) version from 4.4.2 to 4.4.3 which includes:

[`976df14`](https://github.com/manticoresoftware/manticoresearch-buddy/commit/976df147283fb27bdc0aba43f42c10209380c8eb) fix: pass auth to backup plugin requests
