### PR TITLE
fix: geo anchor with missing lat/lon attrs crashes searchd (binary api)

### DIFF
--- a/src/queuecreator.cpp
+++ b/src/queuecreator.cpp
@@ -1396,8 +1396,11 @@ bool QueueCreator_c::MaybeAddGeodistColumn ()
 		return true;
 
 	// replace columnar lat/lon with expressions before adding geodist
-	if ( !ReplaceWithColumnarItem ( m_tQuery.m_sGeoLatAttr, SPH_EVAL_PREFILTER ) ) return false;
-	if ( !ReplaceWithColumnarItem ( m_tQuery.m_sGeoLongAttr, SPH_EVAL_PREFILTER ) ) return false;
+	// only when the attr exists, a missing anchor attr is reported by CreateExprGeodist()
+	if ( m_pSorterSchema->GetAttrIndex ( m_tQuery.m_sGeoLatAttr.cstr() )>=0
+		&& !ReplaceWithColumnarItem ( m_tQuery.m_sGeoLatAttr, SPH_EVAL_PREFILTER ) ) return false;
+	if ( m_pSorterSchema->GetAttrIndex ( m_tQuery.m_sGeoLongAttr.cstr() )>=0
+		&& !ReplaceWithColumnarItem ( m_tQuery.m_sGeoLongAttr, SPH_EVAL_PREFILTER ) ) return false;
 
 	auto pExpr = CreateExprGeodist ( m_tQuery, *m_pSorterSchema, m_sError );
 	if ( !pExpr )


### PR DESCRIPTION
(binary protocol) Setting a geo anchor to a pair of attributes that don't exist causes a crash. Avoid sending a non-existent attribute to ReplaceWithColumnarItem.

I found this bug while prepping for an upgrade and running a huge query log from a pre-columnar version of manticore against the latest version. 

This restores old behavior and you get "unknown latitude attribute '(name)'" instead of a crash

_There isn't a test yet. I didn't know what to do about a test for a binary api only thing?_