### PR TITLE
fix: reduce infix merge memory usage

### DIFF
--- a/misc/issue-4850-memory-benchmark.sh
+++ b/misc/issue-4850-memory-benchmark.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Peak-RSS benchmark for GitHub issue #4850. Runs an isolated local searchd,
+# creates several RT disk chunks with high-cardinality terms, then merges them.
+
+searchd=${SEARCHD:-./build-4850/src/searchd}
+chunks=${CHUNKS:-10}
+docs_per_chunk=${DOCS_PER_CHUNK:-1000}
+words_per_doc=${WORDS_PER_DOC:-8}
+word_suffix_len=${WORD_SUFFIX_LEN:-24}
+min_infix_len=${MIN_INFIX_LEN:-3}
+port=${PORT:-$((19000 + $$ % 1000))}
+root=${RUN_DIR:-$(pwd)/issue-4850-run-$min_infix_len-$$}
+
+sql() {
+    mysql --protocol=tcp -h127.0.0.1 -P"$port" --batch --raw --skip-column-names "$@"
+}
+
+cleanup() {
+    if [ -s "$root/searchd.pid" ]; then
+        "$searchd" --config "$root/manticore.conf" --stopwait >/dev/null 2>&1 || true
+    fi
+    [ "${KEEP_RUN_DIR:-0}" = 1 ] || rm -rf "$root"
+}
+trap cleanup EXIT
+
+mkdir -p "$root/data" "$root/binlog"
+cat >"$root/manticore.conf" <<EOF
+searchd {
+    listen = 127.0.0.1:$port:mysql
+    log = $root/searchd.log
+    query_log = $root/query.log
+    pid_file = $root/searchd.pid
+    data_dir = $root/data
+    binlog_path = $root/binlog
+}
+EOF
+
+"$searchd" --config "$root/manticore.conf" >"$root/stdout.log" 2>"$root/stderr.log"
+for _ in $(seq 1 60); do
+    printf 'SELECT 1;\n' | sql >/dev/null 2>&1 && break
+    sleep 1
+done
+printf 'SELECT 1;\n' | sql >/dev/null
+
+pid=$(cat "$root/searchd.pid")
+: >"$root/rss.tsv"
+(
+    while kill -0 "$pid" 2>/dev/null; do
+        ps -o rss=,vsz= -p "$pid" | awk -v now="$(date +%s)" '{print now, $1, $2}' >>"$root/rss.tsv"
+        sleep 0.1
+    done
+) &
+sampler=$!
+
+printf "CREATE TABLE t(title text) min_infix_len='%s' morphology='none';\n" "$min_infix_len" | sql
+printf 'SET GLOBAL parallel_chunk_merges = 1;\n' | sql
+
+for chunk in $(seq 1 "$chunks"); do
+    start=$((1 + (chunk - 1) * docs_per_chunk))
+    awk -v start="$start" -v docs="$docs_per_chunk" -v words="$words_per_doc" -v suffix_len="$word_suffix_len" 'BEGIN {
+        alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+        q = sprintf("%c", 39)
+        printf "INSERT INTO t(id,title) VALUES "
+        for (doc = start; doc < start + docs; doc++) {
+            srand(doc)
+            title = ""
+            for (w = 0; w < words; w++) {
+                suffix = ""
+                for (i = 0; i < suffix_len; i++)
+                    suffix = suffix substr(alphabet, int(rand() * length(alphabet)) + 1, 1)
+                title = title (w ? " " : "") sprintf("w%08x%x%s", doc, w, suffix)
+            }
+            printf "%s(%d,%s%s%s)", (doc == start ? "" : ","), doc, q, title, q
+        }
+        printf ";\n"
+    }' | sql
+    printf 'FLUSH RAMCHUNK t;\n' | sql >/dev/null
+done
+
+printf 'SHOW TABLE t STATUS LIKE '\''disk_chunks'\'';\n' | sql
+echo START_OPTIMIZE
+started=$SECONDS
+printf 'OPTIMIZE TABLE t OPTION cutoff=1;\n' | sql >"$root/optimize.out" 2>"$root/optimize.err" &
+optimizer=$!
+
+while kill -0 "$pid" 2>/dev/null && [ $((SECONDS - started)) -le 900 ]; do
+    printf 'SHOW TABLE t STATUS LIKE '\''disk_chunks'\'';\nSHOW TABLE t STATUS LIKE '\''optimizing'\'';\n' | sql >"$root/status.out" 2>&1 || true
+    if awk '$1=="disk_chunks" && $2=="1"{chunks=1} $1=="optimizing" && $2=="0"{idle=1} END{exit(chunks && idle ? 0 : 1)}' "$root/status.out"; then
+        break
+    fi
+    sleep 1
+done
+wait "$optimizer" || true
+kill "$sampler" >/dev/null 2>&1 || true
+wait "$sampler" 2>/dev/null || true
+
+printf 'SELECT id FROM t WHERE MATCH('\''*00000001*'\'') LIMIT 5;\n' | sql >"$root/query.out"
+awk 'BEGIN{rss=0;vsz=0} $2>rss{rss=$2} $3>vsz{vsz=$3} END{print "peak_rss_kb=" rss; print "peak_vsz_kb=" vsz}' "$root/rss.tsv"
+echo "merge_seconds=$((SECONDS - started))"
+echo "query_rows=$(awk 'END{print NR+0}' "$root/query.out")"
+find "$root/data" -type f -name '*.spi' -exec stat -f 'spi_bytes=%z' {} \; -exec shasum -a 256 {} \;
+echo "run_dir=$root"

--- a/src/dict/dict_base.cpp
+++ b/src/dict/dict_base.cpp
@@ -17,11 +17,11 @@
 #include "tokenizer/tokenizer.h"
 
 void CSphDict::DictBegin ( CSphAutofile&, CSphAutofile&, int ) {}
-void CSphDict::SortedDictBegin ( CSphAutofile&, int, int ) {}
+void CSphDict::SortedDictBegin ( CSphAutofile&, int, int, int ) {}
 void CSphDict::DictEntry ( const DictEntry_t& ) {}
 void CSphDict::DictEndEntries ( SphOffset_t ) {}
 
-bool CSphDict::DictEnd ( DictHeader_t*, int, CSphString& )
+bool CSphDict::DictEnd ( DictHeader_t*, int, int, CSphString& )
 {
 	return true;
 }

--- a/src/dict/dict_base.h
+++ b/src/dict/dict_base.h
@@ -145,7 +145,7 @@ public:
 	virtual void DictBegin ( CSphAutofile& tTempDict, CSphAutofile& tDict, int iDictLimit );
 
 	/// begin creating dictionary file, assuming sorted entries came (when processing ready dicts like merge, add/delete field, etc.)
-	virtual void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes );
+	virtual void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes, int iMinInfixLen );
 
 	/// add next keyword entry to final dict
 	virtual void DictEntry ( const DictEntry_t& tEntry );
@@ -154,7 +154,7 @@ public:
 	virtual void DictEndEntries ( SphOffset_t iDoclistOffset );
 
 	/// end indexing, store dictionary and checkpoints
-	virtual bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, CSphString& sError );
+	virtual bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, int iMinInfixLen, CSphString& sError );
 
 	/// check whether there were any errors during indexing
 	virtual bool DictIsError() const;

--- a/src/dict/dict_crc.cpp
+++ b/src/dict/dict_crc.cpp
@@ -16,17 +16,17 @@
 
 void DiskDictTraits_c::DictBegin ( CSphAutofile&, CSphAutofile& tDict, int iLimit )
 {
-	DiskDictTraits_c::SortedDictBegin ( tDict, iLimit, 0 );
+	DiskDictTraits_c::SortedDictBegin ( tDict, iLimit, 0, 0 );
 }
 
-void DiskDictTraits_c::SortedDictBegin ( CSphAutofile& tDict, int, int )
+void DiskDictTraits_c::SortedDictBegin ( CSphAutofile& tDict, int, int, int )
 {
 	m_wrDict.CloseFile();
 	m_wrDict.SetFile ( tDict, nullptr, m_sWriterError );
 	m_wrDict.PutByte ( 1 );
 }
 
-bool DiskDictTraits_c::DictEnd ( DictHeader_t* pHeader, int, CSphString& sError )
+bool DiskDictTraits_c::DictEnd ( DictHeader_t* pHeader, int, int, CSphString& sError )
 {
 	// flush wordlist checkpoints
 	pHeader->m_iDictCheckpointsOffset = m_wrDict.GetPos();

--- a/src/dict/dict_crc.h
+++ b/src/dict/dict_crc.h
@@ -25,10 +25,10 @@
 struct DiskDictTraits_c: TemplateDictTraits_c
 {
 	void DictBegin ( CSphAutofile& tTempDict, CSphAutofile& tDict, int iDictLimit ) override;
-	void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes ) override;
+	void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes, int iMinInfixLen ) override;
 	void DictEntry ( const DictEntry_t& tEntry ) override;
 	void DictEndEntries ( SphOffset_t iDoclistOffset ) override;
-	bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, CSphString& sError ) override;
+	bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, int iMinInfixLen, CSphString& sError ) override;
 	bool DictIsError() const final { return m_wrDict.IsError(); }
 	void SetSkiplistBlockSize ( int iSize ) final { m_iSkiplistBlockSize = iSize; }
 

--- a/src/dict/dict_keywords.cpp
+++ b/src/dict/dict_keywords.cpp
@@ -134,10 +134,10 @@ public:
 	void HitblockReset() final;
 
 	void DictBegin ( CSphAutofile& tTempDict, CSphAutofile& tDict, int iDictLimit ) final;
-	void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes ) final;
+	void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes, int iMinInfixLen ) final;
 	void DictEntry ( const DictEntry_t& tEntry ) final;
 	void DictEndEntries ( SphOffset_t ) final {};
-	bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, CSphString& sError ) final;
+	bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, int iMinInfixLen, CSphString& sError ) final;
 
 	SphWordID_t GetWordID ( BYTE* pWord ) final;
 	SphWordID_t GetWordIDWithMarkers ( BYTE* pWord ) final;
@@ -572,7 +572,7 @@ void CSphDictKeywords::DictBegin ( CSphAutofile& tTempDict, CSphAutofile& tDict,
 	m_wrDict.PutByte ( 1 );
 }
 
-void CSphDictKeywords::SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes )
+void CSphDictKeywords::SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes, int iMinInfixLen )
 {
 	m_sError = CSphString();
 	m_iTmpFD = -1;
@@ -585,7 +585,7 @@ void CSphDictKeywords::SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, in
 
 	m_pFinalizer = std::make_unique<KeywordDictFinalization_t>();
 	CSphString sError;
-	m_pFinalizer->m_pInfixer = sphCreateInfixBuilder ( iInfixCodepointBytes, &sError, GetSettings().GetDictFormat() );
+	m_pFinalizer->m_pInfixer = sphCreateInfixBuilder ( iInfixCodepointBytes, iMinInfixLen, &sError, GetSettings().GetDictFormat() );
 	assert ( sError.IsEmpty() );
 }
 
@@ -611,7 +611,7 @@ void CSphDictKeywords::PutCheckpoint ( const CSphWordlistCheckpoint& tCheckpoint
 	m_wrDict.PutOffset ( tCheckpoint.m_iWordlistOffset );
 }
 
-bool CSphDictKeywords::DictEnd ( DictHeader_t* pHeader, int iMemLimit, CSphString& sError )
+bool CSphDictKeywords::DictEnd ( DictHeader_t* pHeader, int iMemLimit, int iMinInfixLen, CSphString& sError )
 {
 	if ( IsSorted() )
 		return SortedDictEnd ( pHeader, sError );
@@ -645,7 +645,7 @@ bool CSphDictKeywords::DictEnd ( DictHeader_t* pHeader, int iMemLimit, CSphStrin
 	m_pFinalizer = std::make_unique<KeywordDictFinalization_t>();
 
 	// infix builder, if needed
-	m_pFinalizer->m_pInfixer = sphCreateInfixBuilder ( pHeader->m_iInfixCodepointBytes, &sError, GetSettings().GetDictFormat() );
+	m_pFinalizer->m_pInfixer = sphCreateInfixBuilder ( pHeader->m_iInfixCodepointBytes, iMinInfixLen, &sError, GetSettings().GetDictFormat() );
 	if ( !sError.IsEmpty() )
 		return false;
 

--- a/src/dict/dict_proxy.h
+++ b/src/dict/dict_proxy.h
@@ -57,10 +57,10 @@ public:
 
 public:
 	void DictBegin ( CSphAutofile& tTempDict, CSphAutofile& tDict, int iDictLimit ) final { m_pDict->DictBegin ( tTempDict, tDict, iDictLimit ); };
-	void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes ) final { m_pDict->SortedDictBegin ( tDict, iDictLimit, iInfixCodepointBytes ); };
+	void SortedDictBegin ( CSphAutofile& tDict, int iDictLimit, int iInfixCodepointBytes, int iMinInfixLen ) final { m_pDict->SortedDictBegin ( tDict, iDictLimit, iInfixCodepointBytes, iMinInfixLen ); };
 	void DictEntry ( const DictEntry_t& tEntry ) final { m_pDict->DictEntry ( tEntry ); };
 	void DictEndEntries ( SphOffset_t iDoclistOffset ) final { m_pDict->DictEndEntries ( iDoclistOffset ); };
-	bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, CSphString& sError ) final { return m_pDict->DictEnd ( pHeader, iMemLimit, sError ); };
+	bool DictEnd ( DictHeader_t* pHeader, int iMemLimit, int iMinInfixLen, CSphString& sError ) final { return m_pDict->DictEnd ( pHeader, iMemLimit, iMinInfixLen, sError ); };
 	bool DictIsError() const final { return m_pDict->DictIsError(); };
 
 public:

--- a/src/dict/infix/infix_builder.cpp
+++ b/src/dict/infix/infix_builder.cpp
@@ -16,7 +16,11 @@
 #include "std/crc32.h"
 #include "fileio.h"
 
+#include <algorithm>
 #include <array>
+#include <cstdint>
+#include <queue>
+#include <vector>
 
 //////////////////////////////////////////////////////////////////////////
 // KEYWORDS STORING DICTIONARY, INFIX HASH BUILDER
@@ -47,112 +51,176 @@ struct Infix_t
 
 class InfixIntvec_c
 {
-private:
-	// do not change the order of fields in this union - it matters a lot
-	union {
-		std::array<DWORD, 4> m_dData;
-		struct
-		{
-			int m_iDynLen;
-			int m_iDynLimit;
-			DWORD* m_pDynData;
-		};
-	};
+	static constexpr uintptr_t INLINE_FLAG = 1;
+	static constexpr int INLINE_LEN_SHIFT = 1;
+	static constexpr int INLINE_VALUE_SHIFT = 3;
+	static constexpr int INLINE_VALUE_BITS = 24;
+	static constexpr int DYNAMIC_INITIAL_LIMIT = 16;
 
-	bool IsDynamic() const noexcept
+	uintptr_t m_uData = 0;
+
+	bool IsDynamic() const noexcept { return m_uData && !( m_uData & INLINE_FLAG ); }
+	int GetInlineLength() const noexcept { return (int)( ( m_uData >> INLINE_LEN_SHIFT ) & 3 ); }
+	DWORD GetInline ( int iIndex ) const noexcept
 	{
-		return ( m_dData[0] & 0x80000000UL ) != 0;
+		return (DWORD)( ( m_uData >> ( INLINE_VALUE_SHIFT + INLINE_VALUE_BITS * iIndex ) ) & INFIX_CHECKPOINT_ID_MAX );
+	}
+	DWORD* GetDynamic() noexcept { return reinterpret_cast<DWORD*>(m_uData); }
+	const DWORD* GetDynamic() const noexcept { return reinterpret_cast<const DWORD*>(m_uData); }
+
+	void Reset()
+	{
+		if ( IsDynamic() )
+			delete[] GetDynamic();
+		m_uData = 0;
 	}
 
 public:
-	InfixIntvec_c()
+	InfixIntvec_c() = default;
+	InfixIntvec_c ( const InfixIntvec_c& ) = delete;
+	InfixIntvec_c& operator= ( const InfixIntvec_c& ) = delete;
+	InfixIntvec_c ( InfixIntvec_c&& rhs ) noexcept
+		: m_uData ( std::exchange ( rhs.m_uData, 0 ) )
+	{}
+
+	InfixIntvec_c& operator= ( InfixIntvec_c&& rhs ) noexcept
 	{
-		m_dData.fill(0);
+		if ( this!=&rhs )
+		{
+			Reset();
+			m_uData = std::exchange ( rhs.m_uData, 0 );
+		}
+		return *this;
 	}
 
-	~InfixIntvec_c()
-	{
-		if ( IsDynamic() )
-			SafeDeleteArray ( m_pDynData );
-	}
+	~InfixIntvec_c() { Reset(); }
 
 	void Add ( DWORD uVal )
 	{
-		if ( !m_dData[0] )
+		if ( !m_uData )
 		{
-			// empty
-			m_dData[0] = uVal | 0x01000000UL;
+			m_uData = INLINE_FLAG | ( uintptr_t(1) << INLINE_LEN_SHIFT ) | ( uintptr_t(uVal & INFIX_CHECKPOINT_ID_MAX) << INLINE_VALUE_SHIFT );
 			return;
 		}
 
 		if ( !IsDynamic() )
 		{
-			// 1..4 static entries
-			int iLen = m_dData[0] >> 24;
-			DWORD uLast = m_dData[iLen - 1] & 0x00ffffffUL;
-
-			// redundant
-			if ( uVal == uLast )
+			int iLen = GetInlineLength();
+			if ( uVal == GetInline ( iLen - 1 ) )
 				return;
 
-			// grow static part
-			if ( iLen < 4 )
+			if ( iLen==1 )
 			{
-				m_dData[iLen] = uVal;
-				m_dData[0] = ( m_dData[0] & 0x00ffffffUL ) | ( ++iLen << 24 );
+				m_uData = ( m_uData & ~( uintptr_t(3) << INLINE_LEN_SHIFT ) )
+					| ( uintptr_t(2) << INLINE_LEN_SHIFT )
+					| ( uintptr_t(uVal & INFIX_CHECKPOINT_ID_MAX) << ( INLINE_VALUE_SHIFT + INLINE_VALUE_BITS ) );
 				return;
 			}
 
-			// dynamize
-			DWORD* pDyn = new DWORD[16];
-			memcpy ( pDyn, m_dData.data(), 4 * sizeof ( DWORD ) );
-			pDyn[0] &= 0x00ffffffUL;
+			auto* pDyn = new DWORD[DYNAMIC_INITIAL_LIMIT + 2];
+			pDyn[0] = 3;
+			pDyn[1] = DYNAMIC_INITIAL_LIMIT;
+			pDyn[2] = GetInline(0);
+			pDyn[3] = GetInline(1);
 			pDyn[4] = uVal;
-			m_iDynLen = 0x80000005UL; // dynamic flag, len=5
-			m_iDynLimit = 16;		  // limit=16
-			m_pDynData = pDyn;
+			m_uData = reinterpret_cast<uintptr_t>(pDyn);
+			assert ( !( m_uData & INLINE_FLAG ) );
 			return;
 		}
 
-		// N dynamic entries
-		int iLen = m_iDynLen & 0x00ffffffUL;
-		if ( uVal == m_pDynData[iLen - 1] )
+		DWORD* pDyn = GetDynamic();
+		int iLen = (int)pDyn[0];
+		if ( uVal == pDyn[iLen + 1] )
 			return;
-		if ( iLen >= m_iDynLimit )
+		if ( iLen >= (int)pDyn[1] )
 		{
-			m_iDynLimit *= 2;
-			auto* pNew = new DWORD[m_iDynLimit];
-			memcpy ( pNew, m_pDynData, iLen * sizeof ( DWORD ) );
-			delete[] ( std::exchange ( m_pDynData, pNew ) );
+			int iLimit = (int)pDyn[1] * 2;
+			auto* pNew = new DWORD[iLimit + 2];
+			memcpy ( pNew, pDyn, ( iLen + 2 ) * sizeof ( DWORD ) );
+			pNew[1] = iLimit;
+			delete[] pDyn;
+			pDyn = pNew;
+			m_uData = reinterpret_cast<uintptr_t>(pDyn);
 		}
 
-		m_pDynData[iLen] = uVal;
-		++m_iDynLen;
-
+		pDyn[iLen + 2] = uVal;
+		++pDyn[0];
 	}
 
 	int GetLength() const noexcept
 	{
-		if ( !IsDynamic() )
-			return m_dData[0] >> 24;
-		return m_iDynLen & 0x00ffffffUL;
+		return IsDynamic() ? (int)GetDynamic()[0] : GetInlineLength();
 	}
+
 
 	DWORD operator[] ( int iIndex ) const noexcept
 	{
-		if ( !IsDynamic() )
-			return m_dData[iIndex] & 0x00ffffffUL;
-		return m_pDynData[iIndex];
+		return IsDynamic() ? GetDynamic()[iIndex + 2] : GetInline(iIndex);
 	}
 };
 
+static_assert ( sizeof(InfixIntvec_c)==sizeof(uintptr_t) );
+static_assert ( sizeof(uintptr_t)>=8, "infix checkpoint packing requires a 64-bit build" );
 
-template<int SIZE>
+
 struct InfixHashEntry_t
 {
-	Infix_t<SIZE> m_tKey;	///< key, owned by the hash
+	uint64_t m_uKey = 0;	///< packed key, owned by the hash
 	InfixIntvec_c m_tValue; ///< data, owned by the hash
 	int m_iNext;			///< next entry in hash arena
+};
+
+
+template<typename T>
+class InfixArena_c
+{
+	static constexpr int BLOCK_LENGTH = 1 << 20;
+	std::vector<std::unique_ptr<CSphSwapVector<T>>> m_dBlocks;
+	int m_iLength = 0;
+
+public:
+	T& Add()
+	{
+		if ( !( m_iLength % BLOCK_LENGTH ) )
+		{
+			auto pBlock = std::make_unique<CSphSwapVector<T>>();
+			pBlock->Reserve ( BLOCK_LENGTH );
+			m_dBlocks.push_back ( std::move ( pBlock ) );
+		}
+
+		++m_iLength;
+		return m_dBlocks.back()->Add();
+	}
+
+	int GetLength() const noexcept { return m_iLength; }
+	int GetBlocksCount() const noexcept { return (int)m_dBlocks.size(); }
+	int GetBlockLength ( int iBlock ) const noexcept { return m_dBlocks[iBlock]->GetLength(); }
+
+	T& operator[] ( int iIndex ) noexcept
+	{
+		return (*m_dBlocks[iIndex / BLOCK_LENGTH])[iIndex % BLOCK_LENGTH];
+	}
+
+	const T& operator[] ( int iIndex ) const noexcept
+	{
+		return (*m_dBlocks[iIndex / BLOCK_LENGTH])[iIndex % BLOCK_LENGTH];
+	}
+
+	T& GetBlockEntry ( int iBlock, int iIndex ) noexcept { return (*m_dBlocks[iBlock])[iIndex]; }
+	const T& GetBlockEntry ( int iBlock, int iIndex ) const noexcept { return (*m_dBlocks[iBlock])[iIndex]; }
+
+	template<typename COMP>
+	void SortBlocks ( COMP&& fnComp )
+	{
+		for ( int i = 0; i < GetBlocksCount(); ++i )
+			std::sort ( m_dBlocks[i]->Begin() + ( i ? 0 : 1 ), m_dBlocks[i]->Begin() + m_dBlocks[i]->GetLength(), fnComp );
+	}
+
+	void Reset()
+	{
+		m_dBlocks.clear();
+		m_iLength = 0;
+	}
 };
 
 
@@ -160,26 +228,101 @@ template<int SIZE>
 class InfixBuilder_c final: public ISphInfixBuilder
 {
 	std::array<int, INFIX_ARENA_LENGTH> m_dHash; ///< all the hash entries
-	CSphSwapVector<InfixHashEntry_t<SIZE>> m_dArena;
+	InfixArena_c<InfixHashEntry_t> m_dArena;
+	static constexpr int LONG_KEY_BLOCK_SHIFT = 20;
+	static constexpr int LONG_KEY_BLOCK_LENGTH = 1 << LONG_KEY_BLOCK_SHIFT;
+	std::vector<std::unique_ptr<CSphTightVector<BYTE>>> m_dLongKeyBlocks;
 	CSphVector<InfixBlock_t> m_dBlocks;
 	CSphTightVector<BYTE> m_dBlocksWords;
 	CSphVector<int> m_dCodepointBytes;
 	DictFormat_e m_eDictFormat = DictFormat_e::KEYWORDS;
+	int m_iMinInfixLen = 2;
 
 private:
-	void AddEntry ( const Infix_t<SIZE>& tKey, DWORD uHash, int iCheckpoint )
+	static constexpr uint64_t LONG_KEY_FLAG = 0x80;
+
+	int GetKeyLength ( uint64_t uKey ) const noexcept { return (int)( uKey & 0x7f ); }
+	bool IsLongKey ( uint64_t uKey ) const noexcept { return ( uKey & LONG_KEY_FLAG )!=0; }
+	uint64_t GetLongKeyOffset ( uint64_t uKey ) const noexcept { return uKey >> 8; }
+
+	uint64_t StoreKey ( const Infix_t<SIZE>& tKey, uint64_t uInlineKey, int iLength )
+	{
+		if ( iLength<=7 )
+			return uInlineKey | iLength;
+
+		if ( m_dLongKeyBlocks.empty() || m_dLongKeyBlocks.back()->GetLength() + iLength > LONG_KEY_BLOCK_LENGTH )
+		{
+			auto pBlock = std::make_unique<CSphTightVector<BYTE>>();
+			pBlock->Reserve ( LONG_KEY_BLOCK_LENGTH );
+			m_dLongKeyBlocks.push_back ( std::move(pBlock) );
+		}
+
+		uint64_t uOffset = ( uint64_t(m_dLongKeyBlocks.size()-1) << LONG_KEY_BLOCK_SHIFT ) | m_dLongKeyBlocks.back()->GetLength();
+		assert ( uOffset < ( uint64_t(1) << 56 ) );
+		m_dLongKeyBlocks.back()->Append ( tKey.m_Data.data(), iLength );
+		return ( uOffset << 8 ) | LONG_KEY_FLAG | iLength;
+	}
+
+	const BYTE* GetLongKey ( uint64_t uKey ) const noexcept
+	{
+		uint64_t uOffset = GetLongKeyOffset(uKey);
+		return m_dLongKeyBlocks[uOffset >> LONG_KEY_BLOCK_SHIFT]->Begin() + ( uOffset & ( LONG_KEY_BLOCK_LENGTH - 1 ) );
+	}
+
+	BYTE GetKeyByte ( uint64_t uKey, int iIndex ) const noexcept
+	{
+		return IsLongKey(uKey)
+			? GetLongKey(uKey)[iIndex]
+			: BYTE ( uKey >> ( 56 - iIndex*8 ) );
+	}
+
+	bool KeyEquals ( uint64_t uStored, const Infix_t<SIZE>& tKey, uint64_t uInlineKey, int iLength ) const noexcept
+	{
+		if ( iLength!=GetKeyLength(uStored) )
+			return false;
+		if ( !IsLongKey(uStored) )
+			return uStored==( uInlineKey | iLength );
+		return !memcmp ( GetLongKey(uStored), tKey.m_Data.data(), iLength );
+	}
+
+	bool KeyLess ( uint64_t a, uint64_t b ) const noexcept
+	{
+		if ( !IsLongKey(a) && !IsLongKey(b) )
+			return a<b;
+
+		int iLenA = GetKeyLength(a);
+		int iLenB = GetKeyLength(b);
+		int iCommon = Min ( iLenA, iLenB );
+		for ( int i = 0; i < iCommon; ++i )
+		{
+			BYTE uA = GetKeyByte ( a, i );
+			BYTE uB = GetKeyByte ( b, i );
+			if ( uA!=uB )
+				return uA<uB;
+		}
+		return iLenA<iLenB;
+	}
+
+	void UnpackKey ( uint64_t uKey, Infix_t<SIZE>& tKey ) const noexcept
+	{
+		tKey.Reset();
+		for ( int i = 0; i < GetKeyLength(uKey); ++i )
+			tKey.m_Data[i] = GetKeyByte ( uKey, i );
+	}
+
+	void AddEntry ( const Infix_t<SIZE>& tKey, uint64_t uInlineKey, int iKeyLength, DWORD uHash, int iCheckpoint )
 	{
 		uHash &= ( INFIX_ARENA_LENGTH - 1 );
 
 		int iEntry = m_dArena.GetLength();
-		InfixHashEntry_t<SIZE>& tNew = m_dArena.Add();
-		tNew.m_tKey = tKey;
+		InfixHashEntry_t& tNew = m_dArena.Add();
+		tNew.m_uKey = StoreKey ( tKey, uInlineKey, iKeyLength );
 		tNew.m_tValue.Add ( iCheckpoint ); // len=1, data=iCheckpoint
 		tNew.m_iNext = std::exchange ( m_dHash[uHash], iEntry );
 	}
 
 	/// get value pointer by key
-	InfixIntvec_c* LookupEntry ( const Infix_t<SIZE>& tKey, DWORD uHash )
+	InfixIntvec_c* LookupEntry ( const Infix_t<SIZE>& tKey, uint64_t uInlineKey, int iKeyLength, DWORD uHash )
 	{
 		uHash &= ( INFIX_ARENA_LENGTH - 1 );
 		int iEntry = m_dHash[uHash];
@@ -187,7 +330,7 @@ private:
 
 		while ( iEntry )
 		{
-			if ( m_dArena[iEntry].m_tKey == tKey )
+			if ( KeyEquals ( m_dArena[iEntry].m_uKey, tKey, uInlineKey, iKeyLength ) )
 			{
 				// mtf it, if needed
 				if ( iiEntry )
@@ -201,20 +344,22 @@ private:
 	}
 
 public:
-	explicit InfixBuilder_c ( DictFormat_e eDictFormat )
+	InfixBuilder_c ( int iMinInfixLen, DictFormat_e eDictFormat )
 		: m_eDictFormat ( eDictFormat )
+		, m_iMinInfixLen ( Max ( 2, Min ( iMinInfixLen, 6 ) ) )
 	{
+		assert ( m_iMinInfixLen>=2 );
 		// init the hash
 		for ( auto& uHash : m_dHash )
 			uHash = 0;
-		m_dArena.Reserve ( INFIX_ARENA_LENGTH );
-		m_dArena.Resize ( 1 ); // 0 is a reserved index
+		m_dArena.Add(); // 0 is a reserved index
 	}
 
 	void AddWord ( const BYTE* pWord, int iWordLength, int iCheckpoint, bool bHasMorphology ) override;
 	void SaveEntries ( CSphWriter& wrDict ) override;
 	int64_t SaveEntryBlocks ( CSphWriter& wrDict ) override;
 	int64_t GetBlocksWordsSize() const override { return m_dBlocksWords.GetLength64(); }
+	int GetEntriesCount() const override { return Max ( 0, m_dArena.GetLength() - 1 ); }
 };
 
 
@@ -233,7 +378,7 @@ void InfixBuilder_c<2>::AddWord ( const BYTE* pWord, int iWordLength, int iCheck
 	}
 
 	Infix_t<2> sKey;
-	for ( int p = 0; p <= iWordLength - 2; ++p )
+	for ( int p = 0; p <= iWordLength - m_iMinInfixLen; ++p )
 	{
 		sKey.Reset();
 
@@ -241,19 +386,29 @@ void InfixBuilder_c<2>::AddWord ( const BYTE* pWord, int iWordLength, int iCheck
 		const BYTE* s = pWord + p;
 		const BYTE* sMax = s + Min ( 6, iWordLength - p );
 
-		DWORD uHash = CRC32_start ( *s );
-		*pKey++ = *s++; // copy first infix byte
+		BYTE uByte = *s++;
+		DWORD uHash = CRC32_start ( uByte );
+		*pKey++ = uByte; // copy first infix byte
+		uint64_t uInlineKey = uint64_t(uByte) << 56;
+		int iKeyLength = 1;
+		int iChars = 1;
 
 		while ( s < sMax )
 		{
-			CRC32_step ( uHash, *s );
-			*pKey++ = *s++; // copy another infix byte
+			uByte = *s++;
+			CRC32_step ( uHash, uByte );
+			*pKey++ = uByte; // copy another infix byte
+			if ( iKeyLength<7 )
+				uInlineKey |= uint64_t(uByte) << ( 56 - iKeyLength*8 );
+			++iKeyLength;
+			if ( ++iChars < m_iMinInfixLen )
+				continue;
 
-			InfixIntvec_c * pVal = LookupEntry ( sKey, uHash );
+			InfixIntvec_c * pVal = LookupEntry ( sKey, uInlineKey, iKeyLength, uHash );
 			if ( pVal )
 				pVal->Add ( iCheckpoint );
 			else
-				AddEntry ( sKey, uHash, iCheckpoint );
+				AddEntry ( sKey, uInlineKey, iKeyLength, uHash, iCheckpoint );
 		}
 	}
 }
@@ -308,7 +463,7 @@ void InfixBuilder_c<SIZE>::AddWord ( const BYTE* pWord, int iWordLength, int iCh
 
 	// generate infixes
 	Infix_t<SIZE> sKey;
-	for ( int p = 0; p <= iCodes - 2; ++p )
+	for ( int p = 0; p <= iCodes - m_iMinInfixLen; ++p )
 	{
 		sKey.Reset();
 		BYTE* pKey = sKey.m_Data.data();
@@ -319,30 +474,43 @@ void InfixBuilder_c<SIZE>::AddWord ( const BYTE* pWord, int iWordLength, int iCh
 
 		// copy first infix codepoint
 		DWORD uHash = 0xffffffffUL;
+		uint64_t uInlineKey = 0;
+		int iKeyLength = 0;
 		do
 		{
-			CRC32_step ( uHash, *s );
-			*pKey++ = *s++;
+			BYTE uByte = *s++;
+			CRC32_step ( uHash, uByte );
+			*pKey++ = uByte;
+			if ( iKeyLength<7 )
+				uInlineKey |= uint64_t(uByte) << ( 56 - iKeyLength*8 );
+			++iKeyLength;
 		} while ( ( *s & 0xC0 ) == 0x80 );
 
 		assert ( s - ( pWord + m_dCodepointBytes[p] ) == ( m_dCodepointBytes[p + 1] - m_dCodepointBytes[p] ) );
+		int iChars = 1;
 
 		while ( s < sMax && pKey < pKeyMax && pKey + sphUtf8CharBytes ( *s ) <= pKeyMax )
 		{
 			// copy next infix codepoint
 			do
 			{
-				CRC32_step ( uHash, *s );
-				*pKey++ = *s++;
+				BYTE uByte = *s++;
+				CRC32_step ( uHash, uByte );
+				*pKey++ = uByte;
+				if ( iKeyLength<7 )
+					uInlineKey |= uint64_t(uByte) << ( 56 - iKeyLength*8 );
+				++iKeyLength;
 			} while ( ( *s & 0xC0 ) == 0x80 && pKey < pKeyMax );
 
 			assert ( sphUTF8Len ( (const char*)sKey.m_Data.data(), sizeof ( sKey.m_Data ) ) >= 2 );
+			if ( ++iChars < m_iMinInfixLen )
+				continue;
 
-			InfixIntvec_c* pVal = LookupEntry ( sKey, uHash );
+			InfixIntvec_c* pVal = LookupEntry ( sKey, uInlineKey, iKeyLength, uHash );
 			if ( pVal )
 				pVal->Add ( iCheckpoint );
 			else
-				AddEntry ( sKey, uHash, iCheckpoint );
+				AddEntry ( sKey, uInlineKey, iKeyLength, uHash, iCheckpoint );
 		}
 
 		assert ( (size_t)( pKey - (BYTE*)sKey.m_Data.data() ) <= int ( sizeof ( sKey.m_Data ) ) );
@@ -371,19 +539,37 @@ void InfixBuilder_c<SIZE>::SaveEntries ( CSphWriter& wrDict )
 
 	wrDict.PutBlob ( g_sTagInfixEntries );
 
-	CSphVector<int> dIndex;
-	dIndex.Resize ( m_dArena.GetLength() - 1 );
-	dIndex.FillSeq(1);
-	dIndex.Sort ( Lesser ( [this] ( int a, int b ) noexcept { return m_dArena[a].m_tKey.m_Data < m_dArena[b].m_tKey.m_Data; } ) );
+	auto fnEntryLess = [this] ( const InfixHashEntry_t& a, const InfixHashEntry_t& b ) noexcept
+	{
+		return KeyLess ( a.m_uKey, b.m_uKey );
+	};
+	m_dArena.SortBlocks ( fnEntryLess );
+
+	struct Cursor_t { int m_iBlock; int m_iEntry; };
+	auto fnCursorGreater = [this] ( const Cursor_t& a, const Cursor_t& b ) noexcept
+	{
+		return KeyLess ( m_dArena.GetBlockEntry ( b.m_iBlock, b.m_iEntry ).m_uKey,
+			m_dArena.GetBlockEntry ( a.m_iBlock, a.m_iEntry ).m_uKey );
+	};
+	std::priority_queue<Cursor_t, std::vector<Cursor_t>, decltype(fnCursorGreater)> qEntries ( fnCursorGreater );
+	for ( int i = 0; i < m_dArena.GetBlocksCount(); ++i )
+		if ( m_dArena.GetBlockLength(i) > ( i ? 0 : 1 ) )
+			qEntries.push ( { i, i ? 0 : 1 } );
 
 	m_dBlocksWords.Reserve ( m_dArena.GetLength() / INFIX_BLOCK_SIZE * sizeof ( DWORD ) * SIZE );
 	int iBlock = 0;
-	int iPrevKey = -1;
+	Infix_t<SIZE> tPrevKey;
+	bool bHavePrevKey = false;
 	constexpr size_t DWSIZE = sizeof ( DWORD ) * SIZE;
-	ARRAY_FOREACH ( iIndex, dIndex )
+	while ( !qEntries.empty() )
 	{
-		InfixIntvec_c& dData = m_dArena[dIndex[iIndex]].m_tValue;
-		const char* sKey = (const char*)m_dArena[dIndex[iIndex]].m_tKey.m_Data.data();
+		Cursor_t tCursor = qEntries.top();
+		qEntries.pop();
+		InfixHashEntry_t& tEntry = m_dArena.GetBlockEntry ( tCursor.m_iBlock, tCursor.m_iEntry );
+		InfixIntvec_c& dData = tEntry.m_tValue;
+		Infix_t<SIZE> tKey;
+		UnpackKey ( tEntry.m_uKey, tKey );
+		const char* sKey = (const char*)tKey.m_Data.data();
 		int iChars = ( SIZE == 2 )
 					   ? (int)strnlen ( sKey, DWSIZE )
 					   : sphUTF8Len ( sKey, (int)DWSIZE );
@@ -407,9 +593,9 @@ void InfixBuilder_c<SIZE>::SaveEntries ( CSphWriter& wrDict )
 		// compute max common prefix
 		// edit_code = ( num_keep_chars<<4 ) + num_append_chars
 		int iEditCode = iChars;
-		if ( iPrevKey >= 0 )
+		if ( bHavePrevKey )
 		{
-			const char* sPrev = (const char*)m_dArena[dIndex[iPrevKey]].m_tKey.m_Data.data();
+			const char* sPrev = (const char*)tPrevKey.m_Data.data();
 			const char* sCur = sKey;
 			const char* sMax = sCur + iAppendBytes;
 
@@ -479,13 +665,17 @@ void InfixBuilder_c<SIZE>::SaveEntries ( CSphWriter& wrDict )
 			wrDict.ZipInt ( dData[j] - dData[j - 1] );
 
 		// mark block end, restart deltas
-		iPrevKey = iIndex;
+		tPrevKey = tKey;
+		bHavePrevKey = true;
 		if ( ++iBlock == INFIX_BLOCK_SIZE )
 		{
 			iBlock = 0;
-			iPrevKey = -1;
+			bHavePrevKey = false;
 			wrDict.PutByte ( 0 );
 		}
+
+		if ( ++tCursor.m_iEntry < m_dArena.GetBlockLength ( tCursor.m_iBlock ) )
+			qEntries.push ( tCursor );
 	}
 
 	// put end marker
@@ -498,6 +688,9 @@ void InfixBuilder_c<SIZE>::SaveEntries ( CSphWriter& wrDict )
 
 	if ( m_eDictFormat!=DictFormat_e::KEYWORDS_V2 && wrDict.GetPos() > UINT_MAX )
 		sphDie ( "INTERNAL ERROR: dictionary size " INT64_FMT " overflow at infix save", wrDict.GetPos() );
+
+	m_dArena.Reset();
+	m_dLongKeyBlocks.clear();
 }
 
 
@@ -529,15 +722,15 @@ int64_t InfixBuilder_c<SIZE>::SaveEntryBlocks ( CSphWriter& wrDict )
 }
 
 
-std::unique_ptr<ISphInfixBuilder> sphCreateInfixBuilder ( int iCodepointBytes, CSphString* pError, DictFormat_e eDictFormat )
+std::unique_ptr<ISphInfixBuilder> sphCreateInfixBuilder ( int iCodepointBytes, int iMinInfixLen, CSphString* pError, DictFormat_e eDictFormat )
 {
 	assert ( pError );
 	switch ( iCodepointBytes )
 	{
 	case 0: return nullptr;
-	case 1: return std::make_unique<InfixBuilder_c<2>>( eDictFormat ); // upto 6x1 bytes, 2 dwords, sbcs
-	case 2: return std::make_unique<InfixBuilder_c<3>>( eDictFormat ); // upto 6x2 bytes, 3 dwords, utf-8
-	case 3: return std::make_unique<InfixBuilder_c<5>>( eDictFormat ); // upto 6x3 bytes, 5 dwords, utf-8
+	case 1: return std::make_unique<InfixBuilder_c<2>>( iMinInfixLen, eDictFormat ); // upto 6x1 bytes, 2 dwords, sbcs
+	case 2: return std::make_unique<InfixBuilder_c<3>>( iMinInfixLen, eDictFormat ); // upto 6x2 bytes, 3 dwords, utf-8
+	case 3: return std::make_unique<InfixBuilder_c<5>>( iMinInfixLen, eDictFormat ); // upto 6x3 bytes, 5 dwords, utf-8
 	default: pError->SetSprintf ( "unhandled max infix codepoint size %d", iCodepointBytes ); return nullptr;
 	}
 }

--- a/src/dict/infix/infix_builder.h
+++ b/src/dict/infix/infix_builder.h
@@ -45,7 +45,8 @@ public:
 	virtual void SaveEntries ( CSphWriter& wrDict ) = 0;
 	virtual int64_t SaveEntryBlocks ( CSphWriter& wrDict ) = 0;
 	virtual int64_t GetBlocksWordsSize() const = 0;
+	virtual int GetEntriesCount() const = 0;
 };
 
-std::unique_ptr<ISphInfixBuilder> sphCreateInfixBuilder ( int iCodepointBytes, CSphString* pError, DictFormat_e eDictFormat = DictFormat_e::KEYWORDS );
+std::unique_ptr<ISphInfixBuilder> sphCreateInfixBuilder ( int iCodepointBytes, int iMinInfixLen, CSphString* pError, DictFormat_e eDictFormat = DictFormat_e::KEYWORDS );
 bool sphLookupInfixCheckpoints ( const char* sInfix, int iBytes, const BYTE* pInfixes, const CSphVector<InfixBlock_t>& dInfixBlocks, int iInfixCodepointBytes, CSphVector<DWORD>& dCheckpoints, DictFormat_e eDictFormat = DictFormat_e::KEYWORDS );

--- a/src/gtests/CMakeLists.txt
+++ b/src/gtests/CMakeLists.txt
@@ -8,6 +8,7 @@ endif ()
 
 set ( GTESTS_SRC
 		gtests_docidlookup.cpp
+		gtests_infix.cpp
 		gtests_rtstuff.cpp
 		gtests_text.cpp
 		gtests_functions.cpp

--- a/src/gtests/gtests_infix.cpp
+++ b/src/gtests/gtests_infix.cpp
@@ -1,0 +1,37 @@
+#include "gtest/gtest.h"
+
+#include "dict/infix/infix_builder.h"
+#include "sphinxstd.h"
+
+#include <cstring>
+
+namespace
+{
+
+int CountInfixes ( const char* szWord, int iCodepointBytes, int iMinInfixLen )
+{
+	CSphString sError;
+	auto pBuilder = sphCreateInfixBuilder ( iCodepointBytes, iMinInfixLen, &sError );
+	EXPECT_TRUE ( sError.IsEmpty() );
+	pBuilder->AddWord ( (const BYTE*)szWord, (int)strlen(szWord), 1, false );
+	return pBuilder->GetEntriesCount();
+}
+
+}
+
+
+TEST ( InfixBuilder, HonorsMinInfixLengthSingleByte )
+{
+	EXPECT_EQ ( CountInfixes ( "abcdef", 1, 2 ), 15 );
+	EXPECT_EQ ( CountInfixes ( "abcdef", 1, 3 ), 10 );
+	EXPECT_EQ ( CountInfixes ( "abcdef", 1, 4 ), 6 );
+	EXPECT_EQ ( CountInfixes ( "abcdef", 1, 6 ), 1 );
+}
+
+
+TEST ( InfixBuilder, HonorsMinInfixLengthUtf8 )
+{
+	EXPECT_EQ ( CountInfixes ( "äöüß", 2, 2 ), 6 );
+	EXPECT_EQ ( CountInfixes ( "äöüß", 2, 3 ), 3 );
+	EXPECT_EQ ( CountInfixes ( "äöüß", 2, 4 ), 1 );
+}

--- a/src/index_converter.cpp
+++ b/src/index_converter.cpp
@@ -1598,7 +1598,7 @@ bool ConverterPlain_t::Init ( Index_t & tIndex, CSphString & sError )
 	CopyAndUpdateSchema ( tIndex, m_tSchema );
 
 	if ( tIndex.m_tSettings.m_iMinInfixLen && tIndex.m_pDict->GetSettings().IsWordDict() )
-		m_pInfixer = sphCreateInfixBuilder ( tIndex.m_pTokenizer->GetMaxCodepointLength(), &sError );
+		m_pInfixer = sphCreateInfixBuilder ( tIndex.m_pTokenizer->GetMaxCodepointLength(), tIndex.m_tSettings.m_iMinInfixLen, &sError );
 
 	return ( sError.IsEmpty() );
 }

--- a/src/sphinx.cpp
+++ b/src/sphinx.cpp
@@ -4426,7 +4426,7 @@ bool CSphHitBuilder::cidxDone ( int iMemLimit, int & iMinInfixLen, int iMaxCodep
 		}
 	}
 
-	if ( !m_pDict->DictEnd ( pDictHeader, iMemLimit, *m_pLastError ) )
+	if ( !m_pDict->DictEnd ( pDictHeader, iMemLimit, iMinInfixLen, *m_pLastError ) )
 		return false;
 
 	// close all data files
@@ -7459,7 +7459,7 @@ bool CSphIndex_VLN::DoMerge ( const CSphIndex_VLN * pDstIndex, const CSphIndex_V
 		iInfixCodepointBytes = pSettings->m_pTokenizer->GetMaxCodepointLength();
 
 	// FIXME? is this magic dict block constant any good?..
-	pDict->SortedDictBegin ( tDict, g_tMergeSettings.m_iBufferDict, iInfixCodepointBytes );
+	pDict->SortedDictBegin ( tDict, g_tMergeSettings.m_iBufferDict, iInfixCodepointBytes, pSettings->m_tSettings.m_iMinInfixLen );
 
 	BEGIN_CORO ( "sph", "merge dicts, doclists and hitlists" );
 	// merge dictionaries, doclists and hitlists
@@ -7633,7 +7633,7 @@ bool CSphIndex_VLN::DoMergeN ( VecTraits_T<const CSphIndex_VLN *> dIndexes, CSph
 	if ( pSettings->m_tSettings.m_iMinInfixLen > 0 && pDict->GetSettings().IsWordDict() )
 		iInfixCodepointBytes = pSettings->m_pTokenizer->GetMaxCodepointLength();
 
-	pDict->SortedDictBegin ( tDict, g_tMergeSettings.m_iBufferDict, iInfixCodepointBytes );
+	pDict->SortedDictBegin ( tDict, g_tMergeSettings.m_iBufferDict, iInfixCodepointBytes, pSettings->m_tSettings.m_iMinInfixLen );
 
 	BEGIN_CORO ( "sph", "merge dicts, doclists and hitlists (N-way)" );
 	int64_t tmWordsStart = sphMicroTimer();
@@ -7825,7 +7825,7 @@ bool CSphIndex_VLN::DeleteFieldFromDict ( int iFieldId, BuildHeader_t & tBuildHe
 	if ( m_tSettings.m_iMinInfixLen > 0 && pDict->GetSettings().IsWordDict() )
 		iInfixCodepointBytes = m_pTokenizer->GetMaxCodepointLength();
 
-	pDict->SortedDictBegin ( tNewDict, iHitBufferSize, iInfixCodepointBytes );
+	pDict->SortedDictBegin ( tNewDict, iHitBufferSize, iInfixCodepointBytes, m_tSettings.m_iMinInfixLen );
 
 	// merge dictionaries, doclists and hitlists
 	if ( pDict->GetSettings().IsWordDict() )

--- a/src/sphinxrt.cpp
+++ b/src/sphinxrt.cpp
@@ -5126,7 +5126,7 @@ bool RtIndex_c::SaveDiskData ( const char * szFilename, const ConstRtSegmentSlic
 
 	SaveDiskDataContext_t tCtx ( szFilename, tSegs ); // only RAM segments here in game.
 	if ( m_tSettings.m_iMinInfixLen && m_pDict->GetSettings().IsWordDict() )
-		tCtx.m_pInfixer = sphCreateInfixBuilder ( m_pTokenizer->GetMaxCodepointLength(), &sError, GetDictFormat() );
+		tCtx.m_pInfixer = sphCreateInfixBuilder ( m_pTokenizer->GetMaxCodepointLength(), m_tSettings.m_iMinInfixLen, &sError, GetDictFormat() );
 	if ( !sError.IsEmpty() )
 		return false;
 


### PR DESCRIPTION
- store the infix arena and long UTF-8 keys in bounded segments
- compact short keys and one/two-checkpoint lists inline
- sort arena blocks and serialize them with a k-way merge
- honor min_infix_len throughout indexing and merge paths
- release builder storage as soon as infix entries are written
- add a local peak-RSS benchmark

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4850