### PR TITLE
🆕 Update load version from 1.26.0 to 1.27.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -2,7 +2,7 @@ backup 1.10.4+26083111-f330f780-dev
 buddy 4.4.3+26083121-976df147-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
-load 1.26.0+26081813-fac2ff17-dev
+load 1.27.0+26090317-da6e0ce0-dev
 galera 3.37
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.26.0 to 1.27.0 which includes:

[`da6e0ce`](https://github.com/manticoresoftware/manticore-load/commit/da6e0ce0ca1f0be6aa1bc50b1d70140436b87001) feat: report searchd resource usage
