### PR TITLE
fix: align bulk item error responses

### DIFF
--- a/src/searchdhttp.cpp
+++ b/src/searchdhttp.cpp
@@ -32,6 +32,8 @@
 #include "auth/auth_proto_http.h"
 #include "netfetch.h"
 
+#include <unordered_set>
+
 static bool g_bLogBadHttpReq = env_exists ( "MANTICORE_LOG_HTTP_BAD_REQ" ); // log content of bad http requests, ruled by this env variable
 static int g_iLogHttpData = env_long ( "MANTICORE_LOG_HTTP_DATA" ).value_or(0); // verbose logging of http data, ruled by this env variable
 
@@ -3324,6 +3326,12 @@ static void SetEsBulkNumericDocid ( BulkDoc_t & tDoc, DocID_t tDocid )
 static bool ParseMetaLine ( const char * sLine, BulkDoc_t & tDoc, CSphString & sError )
 {
 	JsonObj_c tLineMeta ( sLine );
+	if ( !tLineMeta.IsObj() || tLineMeta.Size()!=1 )
+	{
+		sError = "action metadata line should contain exactly one action";
+		return false;
+	}
+
 	JsonObj_c tAction = tLineMeta[0];
 	if ( !tAction )
 	{
@@ -3332,6 +3340,11 @@ static bool ParseMetaLine ( const char * sLine, BulkDoc_t & tDoc, CSphString & s
 	}
 
 	tDoc.m_sAction = tAction.Name();
+	if ( tDoc.m_sAction!="create" && tDoc.m_sAction!="delete" && tDoc.m_sAction!="index" && tDoc.m_sAction!="update" )
+	{
+		sError.SetSprintf ( "unknown action: %s", tDoc.m_sAction.cstr() );
+		return false;
+	}
 
 	if ( !tAction.IsObj() )
 	{
@@ -3664,6 +3677,23 @@ bool HttpHandlerEsBulk_c::Process()
 				return false;
 		}
 	}
+
+	if ( dDocs.IsEmpty() )
+	{
+		ReportLogError ( "no requests added", HttpErrorType_e::ActionRequestValidation, EHTTP_STATUS::_400, false );
+		return false;
+	}
+
+	for ( const BulkDoc_t & tDoc : dDocs )
+	{
+		if ( tDoc.m_sAction!="delete" && IsEmpty ( tDoc.m_tDocLine ) )
+		{
+			sError.SetSprintf ( "source is missing for action %s", tDoc.m_sAction.cstr() );
+			ReportLogError ( sError.cstr(), HttpErrorType_e::ActionRequestValidation, EHTTP_STATUS::_400, false );
+			return false;
+		}
+	}
+
 	CSphVector<BulkTnx_t> dTnx;
 	const BulkDoc_t * pLastDoc = dDocs.Begin();
 	for ( const BulkDoc_t * pCurDoc = pLastDoc + 1; pCurDoc<dDocs.End(); pCurDoc++ )
@@ -3691,12 +3721,9 @@ bool HttpHandlerEsBulk_c::Process()
 	tRoot.AddItem ( "items", tItems );
 	tRoot.AddBool ( "errors", !bOk );
 	tRoot.AddInt ( "took", 1 ); // FIXME!!! add delta
-	BuildReply ( tRoot.AsString(), ( bOk ? EHTTP_STATUS::_200 : EHTTP_STATUS::_409 ) );
+	BuildReply ( tRoot.AsString(), EHTTP_STATUS::_200 );
 
-	if ( !bOk )
-		ReportLogError ( "failed to commit", HttpErrorType_e::Unknown, EHTTP_STATUS::_400, true );
-
-	return bOk;
+	return true;
 }
 
 static void AddEsReply ( const BulkDoc_t & tDoc, JsonObj_c & tRoot )
@@ -3728,15 +3755,18 @@ static void AddEsReply ( const BulkDoc_t & tDoc, JsonObj_c & tRoot )
 
 static void AddEsError ( int iReply, const CSphString & sError, const char * sErrorType, const BulkDoc_t & tDoc, JsonObj_c & tRoot )
 {
+	const bool bVersionConflict = tDoc.m_sAction=="create"
+		&& ( sError.Begins ( "duplicate id '" ) || sError.Begins ( "duplicate uuid id '" ) );
+
 	JsonObj_c tErrorObj;
-	tErrorObj.AddStr ( "type", sErrorType );
+	tErrorObj.AddStr ( "type", bVersionConflict ? "version_conflict_engine_exception" : sErrorType );
 	tErrorObj.AddStr ( "reason", sError.cstr() );
 
 	JsonObj_c tRes;
 	tRes.AddStr ( "_index", tDoc.m_sIndex.cstr() );
 	tRes.AddStr ( "_type", "doc" );
 	tRes.AddStr ( "_id", tDoc.m_sDocid.scstr() );
-	tRes.AddInt ( "status", 400 );
+	tRes.AddInt ( "status", bVersionConflict ? 409 : 400 );
 	tRes.AddItem ( "error", tErrorObj );
 
 	JsonObj_c tAction;
@@ -3762,6 +3792,8 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 		ProcessBegin ( sIdx, false );
 
 		bool bUpdate = false;
+		std::unordered_set<std::string> hCreated;
+		hCreated.reserve ( tTnx.m_iCount );
 		bOk &= dErrors.IsEmpty();
 		dErrors.Resize ( 0 );
 		for ( int i = 0; i<tTnx.m_iCount; i++ )
@@ -3787,6 +3819,15 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 				dErrors.Add ( { iDoc, m_sError } );
 				continue;
 			}
+
+			if ( tDoc.m_sAction=="create" && !tDoc.m_sDocid.IsEmpty() && hCreated.count ( tDoc.m_sDocid.cstr() ) )
+			{
+				CSphString sDuplicate;
+				sDuplicate.SetSprintf ( "duplicate id '%s'", tDoc.m_sDocid.cstr() );
+				dErrors.Add ( { iDoc, sDuplicate } );
+				continue;
+			}
+
 			bool bAction = false;
 			JsonObj_c tResult = JsonNull;
 
@@ -3833,6 +3874,9 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 				}
 			} else if ( tStmt.m_eStmt==STMT_INSERT || tStmt.m_eStmt==STMT_REPLACE )
 			{
+				if ( tDoc.m_sAction=="create" && !tDoc.m_sDocid.IsEmpty() )
+					hCreated.emplace ( tDoc.m_sDocid.cstr() );
+
 				auto dLastIdStrings = session::LastIdStrings();
 				if ( tDoc.m_eDocid==BulkDocid_e::NONE && !dLastIdStrings.IsEmpty() )
 				{
@@ -3851,6 +3895,7 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 		{
 			if ( bUpdate && !GetLastUpdated() )
 			{
+				bOk = false;
 				assert ( tTnx.m_iCount==1 );
 				const BulkDoc_t & tUpdDoc = dDocs[tTnx.m_iFrom];
 				CSphString sUpdError;

--- a/src/searchdhttp.cpp
+++ b/src/searchdhttp.cpp
@@ -32,8 +32,6 @@
 #include "auth/auth_proto_http.h"
 #include "netfetch.h"
 
-#include <unordered_set>
-
 static bool g_bLogBadHttpReq = env_exists ( "MANTICORE_LOG_HTTP_BAD_REQ" ); // log content of bad http requests, ruled by this env variable
 static int g_iLogHttpData = env_long ( "MANTICORE_LOG_HTTP_DATA" ).value_or(0); // verbose logging of http data, ruled by this env variable
 
@@ -3792,8 +3790,7 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 		ProcessBegin ( sIdx, false );
 
 		bool bUpdate = false;
-		std::unordered_set<std::string> hCreated;
-		hCreated.reserve ( tTnx.m_iCount );
+		sph::StringSet hCreated;
 		bOk &= dErrors.IsEmpty();
 		dErrors.Resize ( 0 );
 		for ( int i = 0; i<tTnx.m_iCount; i++ )
@@ -3820,7 +3817,7 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 				continue;
 			}
 
-			if ( tDoc.m_sAction=="create" && !tDoc.m_sDocid.IsEmpty() && hCreated.count ( tDoc.m_sDocid.cstr() ) )
+			if ( tDoc.m_sAction=="create" && !tDoc.m_sDocid.IsEmpty() && hCreated[tDoc.m_sDocid] )
 			{
 				CSphString sDuplicate;
 				sDuplicate.SetSprintf ( "duplicate id '%s'", tDoc.m_sDocid.cstr() );
@@ -3875,7 +3872,7 @@ bool HttpHandlerEsBulk_c::ProcessTnx ( const VecTraits_T<BulkTnx_t> & dTnx, VecT
 			} else if ( tStmt.m_eStmt==STMT_INSERT || tStmt.m_eStmt==STMT_REPLACE )
 			{
 				if ( tDoc.m_sAction=="create" && !tDoc.m_sDocid.IsEmpty() )
-					hCreated.emplace ( tDoc.m_sDocid.cstr() );
+					hCreated.Add ( tDoc.m_sDocid );
 
 				auto dLastIdStrings = session::LastIdStrings();
 				if ( tDoc.m_eDocid==BulkDocid_e::NONE && !dLastIdStrings.IsEmpty() )

--- a/test/test_454/model.bin
+++ b/test/test_454/model.bin
@@ -1,8 +1,8 @@
-a:1:{i:0;a:20:{i:0;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:52:"
+a:1:{i:0;a:25:{i:0;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:52:"
 { "index" : { "_index" : "test1", "_id" : "101" } }";s:4:"rows";s:125:"{"error":{"type":"illegal_argument_exception","reason":"The bulk request must be terminated by a newline [\n]"},"status":400}";s:9:"http_code";i:400;s:4:"http";i:1;}i:1;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:54:"
 { "index" : { "_index" : "test1", "_id" : "102" } }
 
-";s:4:"rows";s:183:"{"items":[{"index":{"_index":"test1","_type":"doc","_id":"102","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse, document is empty"}}}],"errors":true}";s:9:"http_code";i:409;s:4:"http";i:1;}i:2;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:365:"
+";s:4:"rows";s:115:"{"error":{"type":"action_request_validation_exception","reason":"source is missing for action index"},"status":400}";s:9:"http_code";i:400;s:4:"http";i:1;}i:2;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:365:"
 { "index" : { "_index" : "test1", "_id" : "101" } }
 { "int_col" : "101" }
 { "delete" : { "_index" : "test1", "_id" : "11" } }
@@ -13,7 +13,7 @@ a:1:{i:0;a:20:{i:0;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:
 { "update" : {"_index" : "test1", "_id" : "101"} }
 { "doc" : {"int_col" : 1101} }
 
-";s:4:"rows";s:894:"{"items":[{"index":{"_index":"test1","_type":"doc","_id":"101","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"delete":{"_index":"test1","_type":"doc","_id":"11","_version":1,"result":"deleted","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"test1","_type":"doc","_id":"103","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"update":{"_index":"test1","_type":"doc","_id":"51","status":400,"error":{"type":"document_missing_exception","reason":"[_doc][51]: document missing"}}},{"update":{"_index":"test1","_type":"doc","_id":"101","_version":1,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:3;a:6:{s:13:"http_endpoint";s:6:"search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:52:"{ "table": "test1", "query": { "match_all": {} } } }";s:4:"rows";s:216:"{"timed_out":false,"hits":{"total":2,"total_relation":"eq","hits":[{"_id":103,"_score":1,"_source":{"title":"","content":"","int_col":103}},{"_id":101,"_score":1,"_source":{"title":"","content":"","int_col":1101}}]}}";s:9:"http_code";i:200;s:4:"http";i:1;}i:4;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:254:"
+";s:4:"rows";s:893:"{"items":[{"index":{"_index":"test1","_type":"doc","_id":"101","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"delete":{"_index":"test1","_type":"doc","_id":"11","_version":1,"result":"deleted","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"test1","_type":"doc","_id":"103","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"update":{"_index":"test1","_type":"doc","_id":"51","status":400,"error":{"type":"document_missing_exception","reason":"[_doc][51]: document missing"}}},{"update":{"_index":"test1","_type":"doc","_id":"101","_version":1,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:3;a:6:{s:13:"http_endpoint";s:6:"search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:52:"{ "table": "test1", "query": { "match_all": {} } } }";s:4:"rows";s:216:"{"timed_out":false,"hits":{"total":2,"total_relation":"eq","hits":[{"_id":103,"_score":1,"_source":{"title":"","content":"","int_col":103}},{"_id":101,"_score":1,"_source":{"title":"","content":"","int_col":1101}}]}}";s:9:"http_code";i:200;s:4:"http";i:1;}i:4;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:254:"
 { "index" : { "_index" : "test1", "_id" : "111" } }
 { "int_col" : "111" }
 { "delete" : { "_index" : "test1", "_id" : "21" } }
@@ -25,7 +25,7 @@ a:1:{i:0;a:20:{i:0;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:
 { "index" : { "_index" : "test1", "_id" : "1002" } }
 { "int_col" : "101", "id":1010 }
 
-";s:4:"rows";s:179:"{"items":[{"index":{"_index":"test1","_type":"doc","_id":"1002","status":400,"error":{"type":"mapper_parsing_exception","reason":"id has already been specified"}}}],"errors":true}";s:9:"http_code";i:409;s:4:"http";i:1;}i:7;a:6:{s:13:"http_endpoint";s:8:"cli_json";s:11:"http_method";s:4:"POST";s:12:"http_request";s:20:"truncate table test1";s:4:"rows";s:37:"[{"total":0,"error":"","warning":""}]";s:9:"http_code";i:200;s:4:"http";i:1;}i:8;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:75:"
+";s:4:"rows";s:179:"{"items":[{"index":{"_index":"test1","_type":"doc","_id":"1002","status":400,"error":{"type":"mapper_parsing_exception","reason":"id has already been specified"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:7;a:6:{s:13:"http_endpoint";s:8:"cli_json";s:11:"http_method";s:4:"POST";s:12:"http_request";s:20:"truncate table test1";s:4:"rows";s:37:"[{"total":0,"error":"","warning":""}]";s:9:"http_code";i:200;s:4:"http";i:1;}i:8;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:75:"
 { "index" : { "_index" : "test1", "_id" : null } }
 { "int_col" : "201" }
 
@@ -63,8 +63,32 @@ a:1:{i:0;a:20:{i:0;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:
 { "index" : { "_index" : "test1_all", "_id" : "105" } }
 { "s_col" : "test", "mva_col" : [10, 20], "int_col" : 20 }
 
-";s:4:"rows";s:754:"{"items":[{"index":{"_index":"test1_all","_type":"doc","_id":"101","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test1_all","_type":"doc","_id":"102","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test1_all","_type":"doc","_id":"103","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test1_all","_type":"doc","_id":"105","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:18;a:6:{s:13:"http_endpoint";s:6:"search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:56:"{ "table": "test1_all", "query": { "match_all": {} } } }";s:4:"rows";s:407:"{"timed_out":false,"hits":{"total":4,"total_relation":"eq","hits":[{"_id":101,"_score":1,"_source":{"title":"","int_col":0,"s_col":"","mva_col":[]}},{"_id":102,"_score":1,"_source":{"title":"","int_col":0,"s_col":"","mva_col":[]}},{"_id":103,"_score":1,"_source":{"title":"","int_col":0,"s_col":"","mva_col":[]}},{"_id":105,"_score":1,"_source":{"title":"","int_col":20,"s_col":"test","mva_col":[10,20]}}]}}";s:9:"http_code";i:200;s:4:"http";i:1;}i:19;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:73:"
+";s:4:"rows";s:754:"{"items":[{"index":{"_index":"test1_all","_type":"doc","_id":"101","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test1_all","_type":"doc","_id":"102","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test1_all","_type":"doc","_id":"103","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"test1_all","_type":"doc","_id":"105","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:18;a:6:{s:13:"http_endpoint";s:6:"search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:56:"{ "table": "test1_all", "query": { "match_all": {} } } }";s:4:"rows";s:407:"{"timed_out":false,"hits":{"total":4,"total_relation":"eq","hits":[{"_id":101,"_score":1,"_source":{"title":"","int_col":0,"s_col":"","mva_col":[]}},{"_id":102,"_score":1,"_source":{"title":"","int_col":0,"s_col":"","mva_col":[]}},{"_id":103,"_score":1,"_source":{"title":"","int_col":0,"s_col":"","mva_col":[]}},{"_id":105,"_score":1,"_source":{"title":"","int_col":20,"s_col":"test","mva_col":[10,20]}}]}}";s:9:"http_code";i:200;s:4:"http";i:1;}i:19;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:75:"
+{ "create" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 301 }
+
+";s:4:"rows";s:205:"{"items":[{"create":{"_index":"test1","_type":"doc","_id":"301","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:20;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:75:"
+{ "create" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 301 }
+
+";s:4:"rows";s:177:"{"items":[{"create":{"_index":"test1","_type":"doc","_id":"301","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '301'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:21;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:148:"
+{ "create" : { "_index" : "test1", "_id" : "302" } }
+{ "int_col" : 302 }
+{ "create" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 301 }
+
+";s:4:"rows";s:356:"{"items":[{"create":{"_index":"test1","_type":"doc","_id":"302","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"test1","_type":"doc","_id":"301","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '301'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:22;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:148:"
+{ "create" : { "_index" : "test1", "_id" : "303" } }
+{ "int_col" : 303 }
+{ "create" : { "_index" : "test1", "_id" : "303" } }
+{ "int_col" : 304 }
+
+";s:4:"rows";s:356:"{"items":[{"create":{"_index":"test1","_type":"doc","_id":"303","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"test1","_type":"doc","_id":"303","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '303'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:23;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:124:"
+{ "index" : { "_index" : "test1", "_id" : "304" }, "delete" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 304 }
+
+";s:4:"rows";s:135:"{"error":{"type":"action_request_validation_exception","reason":"action metadata line should contain exactly one action"},"status":400}";s:9:"http_code";i:400;s:4:"http";i:1;}i:24;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:73:"
 { "table" : { "_index" : "test1", "_id" : "201" } }
 { "title" : null }
 
-";s:4:"rows";s:170:"{"items":[{"table":{"_index":"test1","_type":"doc","_id":"201","status":400,"error":{"type":"mapper_parsing_exception","reason":"unknown action: table"}}}],"errors":true}";s:9:"http_code";i:409;s:4:"http";i:1;}}}
+";s:4:"rows";s:102:"{"error":{"type":"action_request_validation_exception","reason":"unknown action: table"},"status":400}";s:9:"http_code";i:400;s:4:"http";i:1;}}}

--- a/test/test_454/test.xml
+++ b/test/test_454/test.xml
@@ -157,6 +157,43 @@ index test1_all
 </bulk>
 <query endpoint="search">{ "table": "test1_all", "query": { "match_all": {} } } }</query>
 
+<!-- duplicate create is an item-level conflict, not a request-level failure -->
+<bulk endpoint="_bulk" content="application/x-ndjson" method="POST">
+{ "create" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 301 }
+
+</bulk>
+<bulk endpoint="_bulk" content="application/x-ndjson" method="POST">
+{ "create" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 301 }
+
+</bulk>
+
+<!-- a mixed batch preserves successful items and reports conflicts per item -->
+<bulk endpoint="_bulk" content="application/x-ndjson" method="POST">
+{ "create" : { "_index" : "test1", "_id" : "302" } }
+{ "int_col" : 302 }
+{ "create" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 301 }
+
+</bulk>
+
+<!-- duplicate creates within one batch are reported separately -->
+<bulk endpoint="_bulk" content="application/x-ndjson" method="POST">
+{ "create" : { "_index" : "test1", "_id" : "303" } }
+{ "int_col" : 303 }
+{ "create" : { "_index" : "test1", "_id" : "303" } }
+{ "int_col" : 304 }
+
+</bulk>
+
+<!-- action metadata must contain exactly one action -->
+<bulk endpoint="_bulk" content="application/x-ndjson" method="POST">
+{ "index" : { "_index" : "test1", "_id" : "304" }, "delete" : { "_index" : "test1", "_id" : "301" } }
+{ "int_col" : 304 }
+
+</bulk>
+
 <!-- crash on wrong action name -->
 <bulk endpoint="_bulk" content="application/x-ndjson" method="POST">
 { "table" : { "_index" : "test1", "_id" : "201" } }

--- a/test/test_518/model.bin
+++ b/test/test_518/model.bin
@@ -155,7 +155,7 @@ price integer
 { "title" : "es bulk explicit", "tag" : "bulk", "price" : 43 }
 { "index" : { "_index" : "uuid_ids", "_id" : "not-a-uuid" } }
 { "title" : "es bulk bad", "tag" : "bulk-bad", "price" : 45 }
-";s:4:"rows";s:433:"{"items":[{"index":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440004","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"uuid_ids","_type":"doc","_id":"7099867689679777984","status":400,"error":{"type":"mapper_parsing_exception","reason":"row 1, column 4: uuid id must be a non-empty string"}}}],"errors":true}";s:9:"http_code";i:409;s:4:"http";i:1;}i:286;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:71:"{
+";s:4:"rows";s:433:"{"items":[{"index":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440004","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"index":{"_index":"uuid_ids","_type":"doc","_id":"7099867689679777984","status":400,"error":{"type":"mapper_parsing_exception","reason":"row 1, column 4: uuid id must be a non-empty string"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:286;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:71:"{
 	"table": "uuid_ids",
 	"query": { "equals": { "tag": "bulk-bad" } }
 }";s:4:"rows";s:70:"{"timed_out":false,"hits":{"total":0,"total_relation":"eq","hits":[]}}";s:9:"http_code";i:200;s:4:"http";i:1;}i:287;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:116:"
@@ -170,7 +170,7 @@ price integer
 { "title" : "es bulk numeric id", "tag" : "bulk-numeric-id", "price" : 52 }
 { "create" : { "_index" : "uuid_ids", "_id" : 124 } }
 { "title" : "es bulk numeric create", "tag" : "bulk-numeric-create", "price" : 53 }
-";s:4:"rows";s:382:"{"items":[{"index":{"_index":"uuid_ids","_type":"doc","_id":"123","status":400,"error":{"type":"mapper_parsing_exception","reason":"row 1, column 4: uuid id must be a non-empty string"}}},{"create":{"_index":"uuid_ids","_type":"doc","_id":"124","status":400,"error":{"type":"mapper_parsing_exception","reason":"row 1, column 4: uuid id must be a non-empty string"}}}],"errors":true}";s:9:"http_code";i:409;s:4:"http";i:1;}i:290;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:147:"{
+";s:4:"rows";s:382:"{"items":[{"index":{"_index":"uuid_ids","_type":"doc","_id":"123","status":400,"error":{"type":"mapper_parsing_exception","reason":"row 1, column 4: uuid id must be a non-empty string"}}},{"create":{"_index":"uuid_ids","_type":"doc","_id":"124","status":400,"error":{"type":"mapper_parsing_exception","reason":"row 1, column 4: uuid id must be a non-empty string"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:290;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:147:"{
 	"table": "uuid_ids",
 	"query": { "equals": { "tag": "bulk-numeric-id" } },
 	"_source": [ "id", "tag", "price" ],
@@ -233,10 +233,10 @@ price integer
 { "doc" : { "tag" : "bulk-update-before-invalid", "price" : 84 } }
 { "update" : { "_index" : "uuid_ids", "_id" : "not-a-uuid" } }
 { "doc" : { "tag" : "bulk-update-invalid", "price" : 85 } }
-";s:4:"rows";s:432:"{"items":[{"update":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440041","_version":1,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"update":{"_index":"uuid_ids","_type":"doc","_id":"7099867689679777984","status":400,"error":{"type":"document_missing_exception","reason":"[_doc][7099867689679777984]: document missing"}}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:308;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:124:"
+";s:4:"rows";s:431:"{"items":[{"update":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440041","_version":1,"result":"updated","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"update":{"_index":"uuid_ids","_type":"doc","_id":"7099867689679777984","status":400,"error":{"type":"document_missing_exception","reason":"[_doc][7099867689679777984]: document missing"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:308;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:124:"
 { "update" : { "_index" : "uuid_ids", "_id" : 126 } }
 { "doc" : { "tag" : "bulk-update-numeric-internal", "price" : 86 } }
-";s:4:"rows";s:185:"{"items":[{"update":{"_index":"uuid_ids","_type":"doc","_id":"126","status":400,"error":{"type":"document_missing_exception","reason":"[_doc][126]: document missing"}}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:309;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:136:"{
+";s:4:"rows";s:184:"{"items":[{"update":{"_index":"uuid_ids","_type":"doc","_id":"126","status":400,"error":{"type":"document_missing_exception","reason":"[_doc][126]: document missing"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:309;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:136:"{
 	"table": "uuid_ids",
 	"query": { "equals": { "id": "550e8400-e29b-41d4-a716-446655440041" } },
 	"_source": [ "id", "tag", "price" ]
@@ -258,17 +258,17 @@ price integer
 }";s:4:"rows";s:213:"{"timed_out":false,"hits":{"total":1,"total_relation":"eq","hits":[{"_id":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","_score":1,"_source":{"id":"bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb","tag":"upper-bulk","price":82}}]}}";s:9:"http_code";i:200;s:4:"http";i:1;}i:314;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:184:"
 { "create" : { "_index" : "uuid_ids", "_id" : "550e8400-e29b-41d4-a716-446655440000" } }
 { "title" : "es bulk committed duplicate", "tag" : "bulk-committed-duplicate", "price" : 44 }
-";s:4:"rows";s:237:"{"items":[{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440000","status":400,"error":{"type":"mapper_parsing_exception","reason":"duplicate id '550e8400-e29b-41d4-a716-446655440000'"}}}],"errors":true}";s:9:"http_code";i:409;s:4:"http";i:1;}i:315;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:331:"
+";s:4:"rows";s:246:"{"items":[{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440000","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '550e8400-e29b-41d4-a716-446655440000'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:315;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:331:"
 { "create" : { "_index" : "uuid_ids", "_id" : "550e8400-e29b-41d4-a716-446655440005" } }
 { "title" : "es bulk duplicate one", "tag" : "bulk-dup-one", "price" : 46 }
 { "create" : { "_index" : "uuid_ids", "_id" : "550e8400-e29b-41d4-a716-446655440005" } }
 { "title" : "es bulk duplicate two", "tag" : "bulk-dup-two", "price" : 47 }
-";s:4:"rows";s:456:"{"items":[{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440005","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440005","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:316;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:331:"
+";s:4:"rows";s:461:"{"items":[{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440005","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440005","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '550e8400-e29b-41d4-a716-446655440005'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:316;a:6:{s:13:"http_endpoint";s:5:"_bulk";s:11:"http_method";s:4:"POST";s:12:"http_request";s:331:"
 { "create" : { "_index" : "uuid_ids", "_id" : "550e8400-e29b-41d4-a716-446655440006" } }
 { "title" : "es bulk lower", "tag" : "bulk-case-lower", "price" : 48 }
 { "create" : { "_index" : "uuid_ids", "_id" : "550E8400-E29B-41D4-A716-446655440006" } }
 { "title" : "es bulk upper duplicate", "tag" : "bulk-case-upper", "price" : 49 }
-";s:4:"rows";s:456:"{"items":[{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440006","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440006","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:317;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:129:"{
+";s:4:"rows";s:461:"{"items":[{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440006","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"uuid_ids","_type":"doc","_id":"550e8400-e29b-41d4-a716-446655440006","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '550e8400-e29b-41d4-a716-446655440006'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:317;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:129:"{
 	"table": "uuid_ids",
 	"query": { "equals": { "id": "550e8400-e29b-41d4-a716-446655440006" } },
 	"sort": [ { "tag": "asc" } ]
@@ -329,7 +329,7 @@ price integer
 { "title" : "numeric bulk duplicate one", "tag" : "numeric-bulk-one" }
 { "create" : { "_index" : "numeric_ids", "_id" : 10 } }
 { "title" : "numeric bulk duplicate two", "tag" : "numeric-bulk-two" }
-";s:4:"rows";s:394:"{"items":[{"create":{"_index":"numeric_ids","_type":"doc","_id":"10","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"numeric_ids","_type":"doc","_id":"10","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false}";s:9:"http_code";i:200;s:4:"http";i:1;}i:329;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:96:"{
+";s:4:"rows";s:365:"{"items":[{"create":{"_index":"numeric_ids","_type":"doc","_id":"10","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"numeric_ids","_type":"doc","_id":"10","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '10'"}}}],"errors":true}";s:9:"http_code";i:200;s:4:"http";i:1;}i:329;a:6:{s:13:"http_endpoint";s:11:"json/search";s:11:"http_method";s:4:"POST";s:12:"http_request";s:96:"{
 	"table": "numeric_ids",
 	"query": { "equals": { "id": 10 } },
 	"sort": [ { "tag": "asc" } ]


### PR DESCRIPTION
Return HTTP 200 for processed Elasticsearch-compatible bulk requests while preserving per-item errors. Report duplicate create operations as version conflicts, reject malformed metadata, and detect duplicates within the same batch.

Related issue: https://github.com/manticoresoftware/manticoresearch/issues/4884