### PR TITLE
🆕 Update load version from 1.27.0 to 1.28.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -2,7 +2,7 @@ backup 1.10.4+26083111-f330f780-dev
 buddy 4.4.3+26083121-976df147-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa
-load 1.27.0+26090317-da6e0ce0-dev
+load 1.28.0+26090322-7b728206-dev
 galera 3.37
 ---
 ! Do not change the separator that splits this desc from the data


### PR DESCRIPTION
Update [load](https://github.com/manticoresoftware/manticore-load) version from 1.27.0 to 1.28.0 which includes:

[`7b72820`](https://github.com/manticoresoftware/manticore-load/commit/7b728206e0d29de41b929f37957ddba32997f49c) feat: implemented support for http mode (#27)
