### PR TITLE
🆕 Update backup version from 1.10.4 to 1.11.0

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -1,4 +1,4 @@
-backup 1.10.4+26083111-f330f780-dev
+backup 1.11.0+26090416-11772a64-dev
 buddy 4.4.3+26083121-976df147-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa

--- a/deps.txt
+++ b/deps.txt
@@ -1,4 +1,4 @@
-backup 1.11.0+26090416-11772a64-dev
+backup 1.11.0+26090711-f5c09c1e-dev
 buddy 4.4.3+26083121-976df147-dev
 executor 1.4.3+26071315-4cac4d66-dev
 tzdata 1.0.1 250714 7eebffa


### PR DESCRIPTION
Update [backup](https://github.com/manticoresoftware/manticoresearch-backup) version from 1.10.4 to 1.11.0 which includes:

[`f5c09c1`](https://github.com/manticoresoftware/manticoresearch-backup/commit/f5c09c1e4523383324552eb4d0745c310301646b) ci(clt): update CLT action and backup size patterns
