### PR TITLE
fix: harden PID file ownership and cleanup

### DIFF
--- a/src/daemon/daemon_ipc.cpp
+++ b/src/daemon/daemon_ipc.cpp
@@ -15,6 +15,9 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/poll.h>
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif
 #include <errno.h>
 #include <cstdio>
 #else
@@ -22,6 +25,7 @@
 #endif
 
 #include "searchdaemon.h"
+#include "fileutils.h"
 #include "auth/auth.h"
 
 #include "daemon_ipc.h"
@@ -39,7 +43,14 @@ struct PipeTrait_t : public ISphNonCopyMovable
 static void CreatePipe ( const CSphString & sName, int iOpenFlags, PipeTrait_t & tPipe, CSphString & sError );
 static int WaitPipe ( const PipeTrait_t & tPipe, int iWaitTimeout );
 
-int StopDaemonAndWait ( bool bWait, int iPid, int iWaitTimeout )
+#if defined(__linux__)
+bool IsPidfdUnsupportedError ( int iError )
+{
+	return iError==ENOSYS || iError==EINVAL;
+}
+#endif
+
+int StopDaemonAndWait ( bool bWait, int iPid, int iWaitTimeout, int iPidFileFD )
 {
 	CSphString sError;
 	int iExitCode = 0;
@@ -51,8 +62,34 @@ int StopDaemonAndWait ( bool bWait, int iPid, int iWaitTimeout )
 		sphWarning ( "%s", sError.cstr() );
 
 #if !_WIN32
-	if ( kill ( iPid, SIGTERM ) )
-		sphWarning ( "stop: kill() on pid %d failed: %s", iPid, strerrorm(errno) );
+#if defined(__linux__) && defined(SYS_pidfd_open) && defined(SYS_pidfd_send_signal)
+	int iPidFD = (int)syscall ( SYS_pidfd_open, iPid, 0 );
+	if ( iPidFD<0 && !IsPidfdUnsupportedError(errno) )
+	{
+		sphWarning ( "stop: pidfd_open for pid %d failed: %s", iPid, strerrorm(errno) );
+		return 1;
+	}
+#else
+	int iPidFD = -1;
+#endif
+	CSphString sOwnerError;
+	if ( iPidFileFD>=0 && !ValidatePidFileOwner(iPidFileFD,iPid,sOwnerError) )
+	{
+		if ( iPidFD>=0 ) close ( iPidFD );
+		sphWarning ( "stop: refusing to signal pid %d: %s", iPid, sOwnerError.cstr() );
+		return 1;
+	}
+#if defined(__linux__) && defined(SYS_pidfd_open) && defined(SYS_pidfd_send_signal)
+	int iSignalResult = iPidFD>=0 ? (int)syscall ( SYS_pidfd_send_signal, iPidFD, SIGTERM, nullptr, 0 ) : kill ( iPid, SIGTERM );
+#else
+	int iSignalResult = kill ( iPid, SIGTERM );
+#endif
+	if ( iPidFD>=0 ) close ( iPidFD );
+	if ( iSignalResult )
+	{
+		sphWarning ( "stop: signal on pid %d failed: %s", iPid, strerrorm(errno) );
+		return 1;
+	}
 	sphInfo ( "stop: successfully sent SIGTERM to pid %d", iPid );
 #endif
 

--- a/src/daemon/daemon_ipc.h
+++ b/src/daemon/daemon_ipc.h
@@ -14,8 +14,11 @@
 
 #include "sphinxstd.h"
 
-int StopDaemonAndWait ( bool bWait, int iPid, int iWaitTimeout );
+int StopDaemonAndWait ( bool bWait, int iPid, int iWaitTimeout, int iPidFileFD=-1 );
 CSphString GetNamedPipeName ( int iPid );
+#if defined(__linux__)
+bool IsPidfdUnsupportedError ( int iError );
+#endif
 
 // result of the reload auth command \ unifying exit codes.
 enum class ReloadAuthResult_e : int

--- a/src/fileutils.cpp
+++ b/src/fileutils.cpp
@@ -14,7 +14,10 @@
 #include "sphinxint.h"
 #include "std/hash.h"
 #include "std/crc32.h"
+#include <climits>
+#include <string>
 #include <sys/stat.h>
+#include <vector>
 
 #if _WIN32
 	#define getcwd		_getcwd
@@ -170,6 +173,135 @@ void SafeClose ( int& iFD )
 		::close ( iFD );
 	iFD = -1;
 }
+
+#if !_WIN32
+bool OpenPidFile ( const CSphString & sPath, int & iFD, int & iPid, CSphString & sError )
+{
+	iFD = -1;
+	iPid = 0;
+	int iFlags = O_RDONLY | O_NONBLOCK;
+#ifdef O_CLOEXEC
+	iFlags |= O_CLOEXEC;
+#endif
+#ifdef O_NOFOLLOW
+	iFlags |= O_NOFOLLOW;
+#endif
+	iFD = open ( sPath.cstr(), iFlags );
+	if ( iFD<0 )
+	{
+		sError.SetSprintf ( "cannot open PID file '%s': %s", sPath.cstr(), strerrorm(errno) );
+		return false;
+	}
+
+	struct stat tStat {};
+	if ( fstat(iFD,&tStat)<0 )
+	{
+		sError.SetSprintf ( "cannot inspect PID file '%s': %s", sPath.cstr(), strerrorm(errno) );
+		SafeClose ( iFD );
+		return false;
+	}
+	if ( !S_ISREG(tStat.st_mode) )
+	{
+		sError.SetSprintf ( "PID file '%s' is not a regular file", sPath.cstr() );
+		SafeClose ( iFD );
+		return false;
+	}
+
+	char sPid[65] {};
+	ssize_t iLength = read ( iFD, sPid, sizeof(sPid) );
+	if ( iLength<=0 || iLength>=(ssize_t)sizeof(sPid) )
+	{
+		sError.SetSprintf ( "invalid PID file '%s'", sPath.cstr() );
+		SafeClose ( iFD );
+		return false;
+	}
+
+	size_t iDigits = 0;
+	int64_t iValue = 0;
+	while ( iDigits<(size_t)iLength && sPid[iDigits]>='0' && sPid[iDigits]<='9' )
+	{
+		iValue = iValue*10 + sPid[iDigits]-'0';
+		if ( iValue>INT_MAX )
+			break;
+		++iDigits;
+	}
+	size_t iTail = iDigits;
+	if ( iTail<(size_t)iLength && sPid[iTail]=='\r' ) ++iTail;
+	if ( iTail<(size_t)iLength && sPid[iTail]=='\n' ) ++iTail;
+	if ( !iDigits || iValue<=0 || iValue>INT_MAX || iTail!=(size_t)iLength )
+	{
+		sError.SetSprintf ( "invalid PID file '%s'", sPath.cstr() );
+		SafeClose ( iFD );
+		return false;
+	}
+	iPid = (int)iValue;
+	return true;
+}
+
+bool ValidatePidFileOwner ( int iFD, int iPid, CSphString & sError )
+{
+	struct flock tLock {};
+	tLock.l_type = F_RDLCK;
+	tLock.l_whence = SEEK_SET;
+	if ( fcntl(iFD,F_GETLK,&tLock)<0 )
+	{
+		sError.SetSprintf ( "cannot inspect PID-file lock: %s", strerrorm(errno) );
+		return false;
+	}
+	if ( tLock.l_type==F_UNLCK || tLock.l_pid!=iPid )
+	{
+		sError.SetSprintf ( "PID file is not owned by recorded PID %d", iPid );
+		return false;
+	}
+	return true;
+}
+
+bool UnlinkFileIfSameDescriptor ( int iFD, const CSphString & sPath, CSphString & sError )
+{
+	struct stat tOwned {};
+	if ( fstat(iFD,&tOwned)<0 )
+	{
+		sError.SetSprintf ( "cannot inspect owned file '%s': %s", sPath.cstr(), strerrorm(errno) );
+		return false;
+	}
+	std::string sTemplate = std::string(sPath.cstr()) + ".unlink.XXXXXX";
+	std::vector<char> dTemplate ( sTemplate.begin(), sTemplate.end() );
+	dTemplate.push_back ( '\0' );
+	int iPlaceholderFD = mkstemp ( dTemplate.data() );
+	if ( iPlaceholderFD<0 )
+	{
+		sError.SetSprintf ( "cannot reserve PID cleanup path for '%s': %s", sPath.cstr(), strerrorm(errno) );
+		return false;
+	}
+	CSphString sQuarantine = dTemplate.data();
+	close ( iPlaceholderFD );
+	if ( rename(sPath.cstr(),sQuarantine.cstr())<0 )
+	{
+		int iError = errno;
+		unlink ( sQuarantine.cstr() );
+		sError.SetSprintf ( "cannot quarantine PID metadata '%s': %s", sPath.cstr(), strerrorm(iError) );
+		return false;
+	}
+
+	struct stat tQuarantine {};
+	if ( lstat(sQuarantine.cstr(),&tQuarantine)<0 || !S_ISREG(tQuarantine.st_mode) ||
+		tOwned.st_dev!=tQuarantine.st_dev || tOwned.st_ino!=tQuarantine.st_ino )
+	{
+		// A replacement occupied the public pathname. Restore regular metadata
+		// only if no newer replacement has appeared since the atomic rename.
+		if ( S_ISREG(tQuarantine.st_mode) && link(sQuarantine.cstr(),sPath.cstr())==0 )
+			unlink ( sQuarantine.cstr() );
+		sError.SetSprintf ( "file path '%s' no longer identifies the owned file", sPath.cstr() );
+		return false;
+	}
+	if ( unlink(sQuarantine.cstr())<0 )
+	{
+		sError.SetSprintf ( "cannot unlink quarantined PID metadata for '%s': %s", sPath.cstr(), strerrorm(errno) );
+		return false;
+	}
+	return true;
+}
+#endif
 
 //////////////////////////////////////////////////////////////////////////
 

--- a/src/fileutils.h
+++ b/src/fileutils.h
@@ -143,6 +143,19 @@ void			RawFileUnLock ( const CSphString& sFile, int& iLockFD );
 
 void			SafeClose ( int& iFD );
 
+#if !_WIN32
+/// Open a PID file without following links or blocking on special files,
+/// validate its regular-file shape, and parse one strict positive decimal PID.
+/// The validated descriptor remains open in iFD for a subsequent lock check.
+bool			OpenPidFile ( const CSphString & sPath, int & iFD, int & iPid, CSphString & sError );
+
+/// Require an advisory write-lock owner matching the parsed PID.
+bool			ValidatePidFileOwner ( int iFD, int iPid, CSphString & sError );
+
+/// Unlink a regular-file pathname only when it still names the open descriptor.
+bool			UnlinkFileIfSameDescriptor ( int iFD, const CSphString & sPath, CSphString & sError );
+#endif
+
 /// simple write wrapper
 /// simplifies partial write checks, and also supresses "fortified" glibc warnings
 bool			sphWrite ( int iFD, const void * pBuf, size_t iSize );

--- a/src/gtests/CMakeLists.txt
+++ b/src/gtests/CMakeLists.txt
@@ -16,6 +16,7 @@ set ( GTESTS_SRC
 		gtests_searchd.cpp
 		gtests_filter.cpp
 		gtests_searchdaemon.cpp
+		gtests_pidfile.cpp
 		gtests_api_reply_stream.cpp
 		gtests_ssl.cpp
 		gtests_stringbuilder.cpp

--- a/src/gtests/gtests_pidfile.cpp
+++ b/src/gtests/gtests_pidfile.cpp
@@ -1,0 +1,201 @@
+// Copyright (c) 2017-2026, Manticore Software LTD (https://manticoresearch.com)
+
+#include <gtest/gtest.h>
+
+#include "daemon/daemon_ipc.h"
+#include "fileutils.h"
+
+#include <cerrno>
+#include <string>
+
+#if !_WIN32
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace
+{
+class PidFileTest_c : public testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		char szTemplate[] = "/tmp/manticore-pid-test-XXXXXX";
+		char * szDirectory = mkdtemp ( szTemplate );
+		ASSERT_NE ( nullptr, szDirectory );
+		m_sDirectory = szDirectory;
+		m_sPath = m_sDirectory + "/searchd.pid";
+	}
+
+	void TearDown() override
+	{
+		unlink ( m_sPath.c_str() );
+		unlink ( ( m_sPath+".target" ).c_str() );
+		rmdir ( m_sDirectory.c_str() );
+	}
+
+	void Write ( const std::string & sValue )
+	{
+		int iFD = open ( m_sPath.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0600 );
+		ASSERT_GE ( iFD, 0 );
+		ASSERT_EQ ( (ssize_t)sValue.size(), write ( iFD, sValue.data(), sValue.size() ) );
+		ASSERT_EQ ( 0, close(iFD) );
+	}
+
+	bool Open ( int & iFD, int & iPid, CSphString & sError )
+	{
+		return OpenPidFile ( m_sPath.c_str(), iFD, iPid, sError );
+	}
+
+	std::string m_sDirectory;
+	std::string m_sPath;
+};
+}
+
+TEST_F ( PidFileTest_c, parses_only_a_positive_decimal_pid_with_optional_line_ending )
+{
+	for ( const char * szValid : { "1", "42\n", "314\r\n" } )
+	{
+		Write ( szValid );
+		int iFD = -1;
+		int iPid = 0;
+		CSphString sError;
+		ASSERT_TRUE ( Open(iFD,iPid,sError) ) << sError.cstr();
+		EXPECT_EQ ( atoi(szValid), iPid );
+		SafeClose ( iFD );
+	}
+
+	for ( const char * szInvalid : { "", "0", "-1", "+1", " 1", "1 ", "1x", "1\n\n", "2147483648", "99999999999999999999999999999999999999999999999999999999999999999" } )
+	{
+		Write ( szInvalid );
+		int iFD = -1;
+		int iPid = 0;
+		CSphString sError;
+		EXPECT_FALSE ( Open(iFD,iPid,sError) ) << szInvalid;
+		EXPECT_EQ ( -1, iFD ) << szInvalid;
+		EXPECT_EQ ( 0, iPid ) << szInvalid;
+	}
+}
+
+TEST_F ( PidFileTest_c, rejects_symlinks_and_non_regular_files )
+{
+	std::string sTarget = m_sPath + ".target";
+	int iTargetFD = open ( sTarget.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0600 );
+	ASSERT_GE ( iTargetFD, 0 );
+	ASSERT_EQ ( 2, write(iTargetFD,"42",2) );
+	ASSERT_EQ ( 0, close(iTargetFD) );
+	ASSERT_EQ ( 0, symlink(sTarget.c_str(),m_sPath.c_str()) );
+
+	int iFD = -1;
+	int iPid = 0;
+	CSphString sError;
+	EXPECT_FALSE ( Open(iFD,iPid,sError) );
+	EXPECT_EQ ( -1, iFD );
+	ASSERT_EQ ( 0, unlink(m_sPath.c_str()) );
+
+	ASSERT_EQ ( 0, mkfifo(m_sPath.c_str(),0600) );
+	sError = nullptr;
+	EXPECT_FALSE ( Open(iFD,iPid,sError) );
+	EXPECT_EQ ( -1, iFD );
+}
+
+TEST_F ( PidFileTest_c, validates_that_the_recorded_pid_owns_the_write_lock )
+{
+	Write ( "1" );
+	int dReady[2];
+	int dDone[2];
+	ASSERT_EQ ( 0, pipe(dReady) );
+	ASSERT_EQ ( 0, pipe(dDone) );
+	pid_t iChild = fork();
+	ASSERT_GE ( iChild, 0 );
+	if ( iChild==0 )
+	{
+		close ( dReady[0] );
+		close ( dDone[1] );
+		int iFD = open ( m_sPath.c_str(), O_RDWR );
+		struct flock tLock {};
+		tLock.l_type = F_WRLCK;
+		tLock.l_whence = SEEK_SET;
+		char cReady = iFD>=0 && fcntl(iFD,F_SETLK,&tLock)==0 ? '1' : '0';
+		write ( dReady[1], &cReady, 1 );
+		char cDone;
+		read ( dDone[0], &cDone, 1 );
+		if ( iFD>=0 ) close ( iFD );
+		_exit ( cReady=='1' ? 0 : 1 );
+	}
+
+	close ( dReady[1] );
+	close ( dDone[0] );
+	char cReady = '0';
+	ASSERT_EQ ( 1, read(dReady[0],&cReady,1) );
+	ASSERT_EQ ( '1', cReady );
+	close ( dReady[0] );
+
+	Write ( std::to_string(iChild) );
+	int iFD = -1;
+	int iPid = 0;
+	CSphString sError;
+	ASSERT_TRUE ( Open(iFD,iPid,sError) ) << sError.cstr();
+	EXPECT_TRUE ( ValidatePidFileOwner(iFD,iPid,sError) ) << sError.cstr();
+	sError = nullptr;
+	EXPECT_FALSE ( ValidatePidFileOwner(iFD,iPid+1,sError) );
+	SafeClose ( iFD );
+
+	ASSERT_EQ ( 1, write(dDone[1],"x",1) );
+	close ( dDone[1] );
+	int iStatus = 0;
+	ASSERT_EQ ( iChild, waitpid(iChild,&iStatus,0) );
+	ASSERT_TRUE ( WIFEXITED(iStatus) );
+	ASSERT_EQ ( 0, WEXITSTATUS(iStatus) );
+
+	ASSERT_TRUE ( Open(iFD,iPid,sError) ) << sError.cstr();
+	sError = nullptr;
+	EXPECT_FALSE ( ValidatePidFileOwner(iFD,iPid,sError) );
+	SafeClose ( iFD );
+}
+
+TEST_F ( PidFileTest_c, removes_the_owned_path_through_quarantine )
+{
+	Write ( "42" );
+	int iOwnedFD = open ( m_sPath.c_str(), O_RDONLY );
+	ASSERT_GE ( iOwnedFD, 0 );
+	CSphString sError;
+	EXPECT_TRUE ( UnlinkFileIfSameDescriptor(iOwnedFD,m_sPath.c_str(),sError) ) << sError.cstr();
+	EXPECT_EQ ( -1, access(m_sPath.c_str(),F_OK) );
+	EXPECT_EQ ( ENOENT, errno );
+	SafeClose ( iOwnedFD );
+}
+
+TEST_F ( PidFileTest_c, preserves_a_replacement_path_not_owned_by_the_descriptor )
+{
+	Write ( "42" );
+	int iOwnedFD = open ( m_sPath.c_str(), O_RDONLY );
+	ASSERT_GE ( iOwnedFD, 0 );
+	std::string sOwnedPath = m_sPath + ".target";
+	ASSERT_EQ ( 0, rename(m_sPath.c_str(),sOwnedPath.c_str()) );
+	Write ( "314" );
+
+	CSphString sError;
+	EXPECT_FALSE ( UnlinkFileIfSameDescriptor(iOwnedFD,m_sPath.c_str(),sError) );
+	int iReplacementFD = open ( m_sPath.c_str(), O_RDONLY );
+	ASSERT_GE ( iReplacementFD, 0 );
+	char sValue[4] {};
+	EXPECT_EQ ( 3, read(iReplacementFD,sValue,3) );
+	EXPECT_STREQ ( "314", sValue );
+	SafeClose ( iReplacementFD );
+	SafeClose ( iOwnedFD );
+}
+#endif
+
+#if defined(__linux__)
+TEST ( PidFile, pidfd_fallback_is_only_for_unsupported_kernels )
+{
+	EXPECT_TRUE ( IsPidfdUnsupportedError(ENOSYS) );
+	EXPECT_TRUE ( IsPidfdUnsupportedError(EINVAL) );
+	EXPECT_FALSE ( IsPidfdUnsupportedError(EMFILE) );
+	EXPECT_FALSE ( IsPidfdUnsupportedError(ENFILE) );
+	EXPECT_FALSE ( IsPidfdUnsupportedError(ENOMEM) );
+}
+#endif

--- a/src/searchd.cpp
+++ b/src/searchd.cpp
@@ -510,15 +510,27 @@ bool Shutdown () REQUIRES ( MainThread ) NO_THREAD_SAFETY_ANALYSIS
 	SHUTINFO << "Close auth log ...";
 	AuthDone();
 
-	// close pid
-	SHUTINFO << "Release (close) pid file ...";
+	// Remove owned metadata while the ownership lock is still held. Closing
+	// first lets a concurrent replacement daemon acquire the path and then
+	// have its newly published PID file removed by this exiting process.
+	SHUTINFO << "Remove and release pid file ...";
+#if !_WIN32
+	if ( g_bPidIsMine && !g_sPidFile.IsEmpty() && g_iPidFD!=-1 )
+	{
+		CSphString sUnlinkError;
+		if ( !UnlinkFileIfSameDescriptor(g_iPidFD,g_sPidFile,sUnlinkError) )
+			sphWarning ( "refusing to unlink PID metadata: %s", sUnlinkError.cstr() );
+	}
 	if ( g_iPidFD!=-1 )
 		::close ( g_iPidFD );
 	g_iPidFD = -1;
-
-	// remove pid file, if we owned it
+#else
+	if ( g_iPidFD!=-1 )
+		::close ( g_iPidFD );
+	g_iPidFD = -1;
 	if ( g_bPidIsMine && !g_sPidFile.IsEmpty() )
 		::unlink ( g_sPidFile.cstr() );
+#endif
 
 	SHUTINFO << "Shutdown hazard pointers ...";
 	hazard::Shutdown ();
@@ -16074,28 +16086,42 @@ int StopOrStopWaitAnother ( CSphVariant * v, bool bWait ) REQUIRES ( MainThread 
 
 	CSphString sPidFile = v->cstr();
 	FixPathAbsolute ( sPidFile );
+	int iPid = 0;
+#if _WIN32
 	FILE * fp = fopen ( sPidFile.cstr(), "r" );
 	if ( !fp )
 		sphFatal ( "stop: pid file '%s' does not exist or is not readable", sPidFile.cstr() );
 
-	char sBuf[16];
+	char sBuf[32] {};
 	int iLen = (int) fread ( sBuf, 1, sizeof(sBuf)-1, fp );
-	sBuf[iLen] = '\0';
+	bool bComplete = feof(fp) && !ferror(fp);
 	fclose ( fp );
-
-	int iPid = atoi(sBuf);
-	if ( iPid<=0 )
+	errno = 0;
+	char * pEnd = nullptr;
+	long iValue = strtol ( sBuf, &pEnd, 10 );
+	const char * pLimit = sBuf+iLen;
+	if ( pEnd<pLimit && *pEnd=='\r' ) ++pEnd;
+	if ( pEnd<pLimit && *pEnd=='\n' ) ++pEnd;
+	if ( !bComplete || errno==ERANGE || iValue<=0 || iValue>INT_MAX || !pEnd || pEnd!=pLimit )
 		sphFatal ( "stop: failed to read valid pid from '%s'", sPidFile.cstr() );
+	iPid = (int)iValue;
+#else
+	int iPidFD = -1;
+	CSphString sPidError;
+	if ( !OpenPidFile(sPidFile,iPidFD,iPid,sPidError) )
+		sphFatal ( "stop: %s", sPidError.cstr() );
+	AT_SCOPE_EXIT ( [&] { SafeClose(iPidFD); } );
+	if ( !ValidatePidFileOwner(iPidFD,iPid,sPidError) )
+		sphFatal ( "stop: pid file '%s' is not owned by recorded pid %d: %s", sPidFile.cstr(), iPid, sPidError.cstr() );
+#endif
 
 	int iWaitTimeout = g_iShutdownTimeoutUs + 100000;
-
-	int iExitCode = 0;
 #if _WIN32
-	iExitCode = WinStopOrWaitAnother ( iPid, iWaitTimeout );
+	return WinStopOrWaitAnother ( iPid, iWaitTimeout );
 #else
-	iExitCode = StopDaemonAndWait ( bWait, iPid, iWaitTimeout );
+	return StopDaemonAndWait ( bWait, iPid, iWaitTimeout, iPidFD );
 #endif
-	return iExitCode;}
+}
 } // static namespace
 
 


### PR DESCRIPTION
A PID read from disk is not proof that the process still belongs to searchd. After a crash, a stale PID file can outlive its daemon and the kernel can reuse that PID for an unrelated process. Previously --stop and --stopwait parsed the file with atoi() and signalled the resulting positive PID without checking who held the daemon's PID-file lock. Malformed input with a numeric prefix could also be accepted.

Shutdown had a separate restart race: it closed the PID descriptor, releasing the lock, before unlinking the pathname. A replacement daemon could acquire the file and publish its PID in that interval, only for the exiting daemon to remove the replacement's metadata. A pathname replaced while the old daemon was running had the same cleanup risk. Losing that metadata breaks subsequent stop/stopwait operations and removes the pathname used to coordinate daemon ownership.

On POSIX:
- Open PID metadata without following the final symlink or blocking on a FIFO, require a regular file, and parse a bounded positive decimal PID with only an optional line ending.
- Keep the descriptor open and require the recorded PID to own its advisory write lock. Recheck ownership immediately before signalling; refuse stale or mismatched metadata instead of trusting its contents.
- On Linux, open a pidfd before the final ownership check and signal through it so PID reuse after validation cannot redirect SIGTERM. Fall back to kill() only when pidfd_open is unsupported (ENOSYS or EINVAL), not on permission or resource failures. Platforms without pidfd support retain the check-to-kill race; the lock checks narrow that risk but do not provide an atomic process handle.
- Remove PID metadata before releasing the ownership lock. Rename the pathname to a unique quarantine path and compare its device/inode with the open descriptor before unlinking it. Preserve mismatched metadata and restore a regular replacement when the public pathname is still free, without overwriting a newer replacement.
- Return failure when signalling fails rather than reporting success.

On Windows, replace atoi() with bounded, full-input PID validation; retain the existing Windows stop and cleanup mechanisms.

Review: https://github.com/manticoresoftware/manticoresearch/pull/4786#discussion_r3932219146