### PR TITLE
fix: restore Buddy fallback for bulk item errors

### DIFF
--- a/src/searchdhttp.cpp
+++ b/src/searchdhttp.cpp
@@ -3753,7 +3753,11 @@ bool HttpHandlerEsBulk_c::Process()
 	tRoot.AddInt ( "took", 1 ); // FIXME!!! add delta
 	BuildReply ( tRoot.AsString(), EHTTP_STATUS::_200 );
 
-	return true;
+	// Restore NDJSON separators for Buddy after the in-place parsing, without replacing the HTTP 200 reply.
+	if ( !bOk )
+		ReportLogError ( "failed to commit", HttpErrorType_e::Unknown, EHTTP_STATUS::_400, true );
+
+	return bOk;
 }
 
 static void AddEsReply ( const BulkDoc_t & tDoc, JsonObj_c & tRoot )

--- a/test/clt-tests/buddy/test-es-bulk-autoschema.rec
+++ b/test/clt-tests/buddy/test-es-bulk-autoschema.rec
@@ -1,0 +1,48 @@
+––– block: ../base/start-searchd-with-buddy –––
+––– input –––
+cat > /tmp/es-bulk-autoschema.ndjson <<'EOF'
+{"index":{"_index":"bulk_autoschema_regression"}}
+{"title":"Yellow Bag","price":12}
+{"create":{"_index":"bulk_autoschema_regression"}}
+{"title":"Red Bag","price":12.5,"id":3}
+EOF
+––– output –––
+––– input –––
+curl -sS --max-time 30 -w '\nHTTP %{http_code}\n' http://127.0.0.1:9308/_bulk -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/es-bulk-autoschema.ndjson -H 'User-Agent: Manticore Buddy' | sed -E 's/"_id":"[0-9]{10,}"/"_id":"GENERATED_ID"/g; s/"took":[0-9]+/"took":0/g'
+––– output –––
+{"items":[{"index":{"_index":"bulk_autoschema_regression","_type":"doc","_id":"","status":400,"error":{"type":"mapper_parsing_exception","reason":"table 'bulk_autoschema_regression' absent"}}},{"create":{"_index":"bulk_autoschema_regression","_type":"doc","_id":"3","status":400,"error":{"type":"mapper_parsing_exception","reason":"table 'bulk_autoschema_regression' absent"}}}],"errors":true,"took":0}
+HTTP 200
+––– input –––
+curl -sS --max-time 30 -w '\nHTTP %{http_code}\n' http://127.0.0.1:9308/_bulk -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/es-bulk-autoschema.ndjson | sed -E 's/"_id":"[0-9]{10,}"/"_id":"GENERATED_ID"/g; s/"took":[0-9]+/"took":0/g'
+––– output –––
+{"items":[{"index":{"_index":"bulk_autoschema_regression","_type":"doc","_id":"GENERATED_ID","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}},{"create":{"_index":"bulk_autoschema_regression","_type":"doc","_id":"3","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1,"status":201}}],"errors":false,"took":0}
+HTTP 200
+––– input –––
+curl -sS --max-time 30 -w '\nHTTP %{http_code}\n' http://127.0.0.1:9308/search -H 'Content-Type: application/json' -d '{"table":"bulk_autoschema_regression","_source":["title","price"]}' | sed -E 's/"_id":"[0-9]{10,}"/"_id":"GENERATED_ID"/g; s/"_id":[0-9]{10,}/"_id":"GENERATED_ID"/g; s/"took":[0-9]+/"took":0/g'
+––– output –––
+{"took":0,"timed_out":false,"hits":{"total":2,"total_relation":"eq","hits":[{"_id":3,"_score":1,"_source":{"title":"Red Bag","price":12.500000}},{"_id":"GENERATED_ID","_score":1,"_source":{"title":"Yellow Bag","price":12.000000}}]}}
+HTTP 200
+––– input –––
+cat > /tmp/es-bulk-autoschema.ndjson <<'EOF'
+{"create":{"_index":"bulk_autoschema_regression","_id":3}}
+{"title":"Duplicate","price":99}
+EOF
+––– output –––
+––– input –––
+curl -sS --max-time 30 -w '\nHTTP %{http_code}\n' http://127.0.0.1:9308/_bulk -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/es-bulk-autoschema.ndjson | sed -E 's/"_id":"[0-9]{10,}"/"_id":"GENERATED_ID"/g; s/"took":[0-9]+/"took":0/g'
+––– output –––
+{"items":[{"create":{"_index":"bulk_autoschema_regression","_type":"doc","_id":3,"status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '3'"}}}],"errors":true,"took":0}
+HTTP 200
+––– input –––
+curl -sS --max-time 30 -w '\nHTTP %{http_code}\n' http://127.0.0.1:9308/_bulk -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/es-bulk-autoschema.ndjson -H 'User-Agent: Manticore Buddy' | sed -E 's/"_id":"[0-9]{10,}"/"_id":"GENERATED_ID"/g; s/"took":[0-9]+/"took":0/g'
+––– output –––
+{"items":[{"create":{"_index":"bulk_autoschema_regression","_type":"doc","_id":"3","status":409,"error":{"type":"version_conflict_engine_exception","reason":"duplicate id '3'"}}}],"errors":true,"took":0}
+HTTP 200
+––– input –––
+curl -sS --max-time 30 -w '\nHTTP %{http_code}\n' http://127.0.0.1:9308/search -H 'Content-Type: application/json' -d '{"table":"bulk_autoschema_regression","_source":["title","price"]}' | sed -E 's/"_id":"[0-9]{10,}"/"_id":"GENERATED_ID"/g; s/"_id":[0-9]{10,}/"_id":"GENERATED_ID"/g; s/"took":[0-9]+/"took":0/g'
+––– output –––
+{"took":0,"timed_out":false,"hits":{"total":2,"total_relation":"eq","hits":[{"_id":3,"_score":1,"_source":{"title":"Red Bag","price":12.500000}},{"_id":"GENERATED_ID","_score":1,"_source":{"title":"Yellow Bag","price":12.000000}}]}}
+HTTP 200
+––– input –––
+rm /tmp/es-bulk-autoschema.ndjson
+––– output –––


### PR DESCRIPTION
Keep the HTTP 200 bulk envelope while returning the internal processing result to enable Buddy AutoSchema. Restore NDJSON separators before forwarding the request; ReportLogError in log-only mode does this without replacing the reply.